### PR TITLE
[CI] Add initial CI

### DIFF
--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -1,0 +1,58 @@
+name: "Install build dependencies"
+description: "Installs all dependencies on all platforms that are generally required to compile JLLVM"
+
+inputs:
+  cxx-compiler:
+    description: "C++ compiler that will be used for compilation"
+    required: true
+  ccache-key:
+    description: "Key to cache the ccache cache"
+    required: true
+
+outputs:
+  key:
+    value: ${{steps.compiler-hash.outputs.key}}
+    description: "ccache-key concatenated with a hash specific to the cxx-compilers version"
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.9
+
+    - name: Set up Java
+      uses: actions/setup-java@v3
+      with:
+        java-version: 17
+        distribution: 'oracle'
+
+    - name: Install minimum required cmake and ninja
+      uses: lukka/get-cmake@latest
+      with:
+        cmakeVersion: 3.20.6
+
+    - name: Install Ubuntu dependencies
+      if: ${{ runner.os == 'Linux' }}
+      shell: bash
+      run: |
+        sudo apt update
+        sudo apt install lld clang g++-10
+
+    - name: Generate compiler hash
+      id: compiler-hash
+      shell: pwsh
+      run: |
+        $compiler_version = ${{inputs.cxx-compiler}} -v 2>&1 | Out-String
+        $stream = [IO.MemoryStream]::new([byte[]][char[]]$compiler_version)
+        $hash = (Get-FileHash -InputStream $stream -Algorithm SHA256).Hash
+        "key=${{inputs.ccache-key}}-$hash" >> $Env:GITHUB_OUTPUT
+
+    - name: Install CCache
+      uses: Chocobo1/setup-ccache-action@v1
+      with:
+        ccache_options: |
+          max_size=50M
+          compiler_check=none
+        override_cache_key: ${{steps.compiler-hash.outputs.key}}

--- a/.github/actions/llvm-build/action.yml
+++ b/.github/actions/llvm-build/action.yml
@@ -1,0 +1,132 @@
+name: "Build LLVM"
+description: "Builds LLVM at the currently required/tested revision used to build JLLVM"
+
+inputs:
+  c-compiler:
+    description: 'C compiler to use'
+    required: true
+  cpp-compiler:
+    description: 'C++ compiler to use'
+    required: true
+  sanitizers:
+    description: 'Sanitizers to use, comma separated'
+    required: false
+    default: ''
+  cache-key:
+    description: 'Key to use to cache LLVM compilation. Should encode build config details'
+    required: true
+
+outputs:
+  install-dir:
+    value: ${{steps.output-build-dir.outputs.build-dir}}
+    description: "Location of the compiled LLVM installation"
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout LLVM
+      uses: actions/checkout@v3
+      with:
+        repository: llvm/llvm-project
+        ref: release/16.x
+        path: llvm-project
+
+    - name: Cache LLVM Build
+      id: cache-llvm-build
+      uses: actions/cache@v3
+      with:
+        path: |
+          llvm-build 
+          llvm-optimized-tblgen
+        key: ${{inputs.cache-key}}
+
+    - name: Configure Optimized TableGen
+      if: steps.cache-llvm-build.outputs.cache-hit != 'true'
+      shell: pwsh
+      run: |
+        $use_lld = ''
+        if (!$IsMacOs) {
+          $use_lld = '-DLLVM_ENABLE_LLD=ON'
+        }
+        cmake -GNinja -Bllvm-optimized-tblgen `
+          -DCMAKE_BUILD_TYPE=Release `
+          -DCMAKE_CXX_COMPILER=${{inputs.cpp-compiler}} `
+          -DCMAKE_C_COMPILER=${{inputs.c-compiler}} `
+          -DLLVM_BUILD_TOOLS=OFF `
+          -DLLVM_BUILD_UTILS=ON `
+          -DLLVM_INCLUDE_TESTS=OFF `
+          -DLLVM_INSTALL_UTILS=ON `
+          -DLLVM_TARGETS_TO_BUILD="" `
+          $use_lld `
+          -DPython3_ROOT_DIR="$Env:pythonLocation" -DPython3_FIND_STRATEGY=LOCATION `
+          -S ${{github.workspace}}/llvm-project/llvm
+
+    - name: Build Optimized TableGen
+      if: steps.cache-llvm-build.outputs.cache-hit != 'true'
+      shell: pwsh
+      run: |
+        cmake --build llvm-optimized-tblgen --target llvm-tblgen
+
+    - name: Configure LLVM
+      if: steps.cache-llvm-build.outputs.cache-hit != 'true'
+      shell: pwsh
+      run: |
+        $work_space = "${{github.workspace}}".replace('\', '/') 
+        $assertions = '-DLLVM_ENABLE_ASSERTIONS=ON'
+        $san_flag = ''
+        if ('${{inputs.sanitizers}}') {
+          $sanitizer = (Get-Culture).TextInfo.ToTitleCase('${{inputs.sanitizers}}'.replace(',', ';'))
+          $san_flag = "-DLLVM_USE_SANITIZER=""$sanitizer"""
+        
+          # Assertions within LLVM also enables assertions in libstdc++ and libc++, which have the negative side effect
+          # of causing thread sanitizer errors due to extra reads performed in the assertions (that would otherwise
+          # not be present).
+          if ('${{inputs.sanitizers}}'.contains('thread')) {
+            $assertions = '-DLLVM_ENABLE_ASSERTIONS=OFF'
+          }
+        }
+        
+        $use_lld = ''
+        if (!$IsMacOs) {
+          $use_lld = '-DLLVM_ENABLE_LLD=ON'
+        }
+        
+        cmake -GNinja -Bllvm-build `
+        -DLLVM_TABLEGEN="$work_space/llvm-optimized-tblgen/bin/llvm-tblgen" `
+        -DCMAKE_BUILD_TYPE=Release `
+        -DCMAKE_CXX_COMPILER=${{inputs.cpp-compiler}} `
+        -DCMAKE_C_COMPILER=${{inputs.c-compiler}} `
+        $assertions `
+        -DLLVM_BUILD_TOOLS=OFF `
+        -DLLVM_BUILD_UTILS=ON `
+        -DLLVM_INCLUDE_TESTS=OFF `
+        -DLLVM_INSTALL_UTILS=ON `
+        -DLLVM_TARGETS_TO_BUILD="host" `
+        $use_lld `
+        -DLLVM_BUILD_LLVM_C_DYLIB=OFF `
+        -DLLVM_INCLUDE_BENCHMARKS=OFF `
+        -DLLVM_APPEND_VC_REV=OFF `
+        -DLLD_BUILD_TOOLS=OFF `
+        -DPython3_ROOT_DIR="$Env:pythonLocation" -DPython3_FIND_STRATEGY=LOCATION `
+        $san_flag `
+        -S ${{github.workspace}}/llvm-project/llvm
+
+    - name: Build LLVM
+      if: steps.cache-llvm-build.outputs.cache-hit != 'true'
+      shell: pwsh
+      run: |
+        cmake --build llvm-build
+
+    - name: Remove Object files when not using thing archives
+      shell: pwsh
+      if: steps.cache-llvm-build.outputs.cache-hit != 'true'
+      run: |
+        $ext = 'o'
+        Remove-Item '${{github.workspace}}/llvm-build' -Recurse -Include "*.$ext"
+        Remove-Item '${{github.workspace}}/llvm-optimized-tblgen' -Recurse -Include "*.$ext"
+
+    - name: Output build dir
+      id: output-build-dir
+      shell: pwsh
+      run: |
+        "build-dir=${{github.workspace}}/llvm-build" >> $Env:GITHUB_OUTPUT

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1,0 +1,104 @@
+name: Builds
+
+permissions:
+  contents: read
+  actions: write
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "**" ]
+
+jobs:
+  Builds:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: ubuntu-22.04, cxx_compiler: clang++, c_compiler: clang, sanitizer: "address,undefined" }
+          - { os: ubuntu-22.04, cxx_compiler: g++-10, c_compiler: gcc-10 }
+          - { os: macos-12, cxx_compiler: clang++, c_compiler: clang }
+
+    runs-on: ${{matrix.os}}
+    defaults:
+      run:
+        shell: pwsh
+
+    steps:
+      - name: Checkout JLLVM
+        uses: actions/checkout@v3
+        with:
+          path: JLLVM
+
+      - name: Calculate ccache key
+        id: ccache-key
+        shell: pwsh
+        run: |
+          $key = '${{runner.os}}'
+
+          if ('${{matrix.sanitizer}}') {
+            $key += '-${{matrix.sanitizer}}'.Replace(',', '_and_')
+          }
+
+          "key=$key" >> $Env:GITHUB_OUTPUT
+
+      - name: Install Dependencies
+        id: dep-install
+        uses: ./JLLVM/.github/actions/dependencies
+        with:
+          cxx-compiler: ${{matrix.cxx_compiler}}
+          ccache-key: ${{steps.ccache-key.outputs.key}}
+
+      - name: Install Python depends
+        run: |
+          Invoke-expression "$Env:pythonLocation\python -m pip install -r ${{github.workspace}}/JLLVM/tests/requirements.txt"
+
+      - name: Build LLVM
+        id: llvm-build
+        uses: ./JLLVM/.github/actions/llvm-build
+        with:
+          c-compiler: ${{matrix.c_compiler}}
+          cpp-compiler: ${{matrix.cxx_compiler}}
+          sanitizers: ${{matrix.sanitizer}}
+          cache-key: LLVM-${{steps.dep-install.outputs.key}}
+
+      - name: Configure JLLVM
+        run: |
+          $sanitizer_arg = ''
+          if ('${{matrix.sanitizer}}') {
+            $sanitizer_arg = '-DCMAKE_CXX_FLAGS="-g1 -fsanitize=${{matrix.sanitizer}}"'
+          }
+          
+          $use_lld = ''
+          if (!$IsMacOs) {
+            $use_lld = '-DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld"'
+          }
+          
+          cmake -GNinja -Bjllvm-build `
+            -DCMAKE_BUILD_TYPE=Release `
+            -DCMAKE_CXX_COMPILER=${{matrix.cxx_compiler}} `
+            -DCMAKE_C_COMPILER=${{matrix.c_compiler}} `
+            -DCMAKE_CXX_FLAGS="-g1" `
+            -DJLLVM_ENABLE_ASSERTIONS=ON `
+            $sanitizer_arg `
+            -DPython3_ROOT_DIR="$Env:pythonLocation" -DPython3_FIND_STRATEGY=LOCATION `
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache `
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache `
+            $use_lld `
+            -DLLVM_DIR="${{steps.llvm-build.outputs.install-dir}}/lib/cmake/llvm/" `
+            -S ${{github.workspace}}/JLLVM
+
+      - name: Build JLLVM
+        run: |
+          cmake --build jllvm-build
+
+      - name: Test
+        working-directory: ${{github.workspace}}/jllvm-build
+        run: ctest --extra-verbose
+
+      - name: Cleanup disk space
+        if: always()
+        run: |
+          Remove-Item -Recurse -Force jllvm-build -ErrorAction Ignore
+

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,130 @@
+name: Lint
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "**" ]
+
+permissions:
+  contents: read
+  actions: write
+
+env:
+  LLVM_VERSION: 15
+
+jobs:
+  lint-run:
+    runs-on: ubuntu-22.04
+    steps:
+
+      - name: Install clang-tidy
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh $LLVM_VERSION all
+
+      - name: Checkout JLLVM
+        uses: actions/checkout@v3
+        with:
+          path: JLLVM
+          # Depth 2 because we use git diff HEAD^ later.
+          fetch-depth: 2
+
+      - name: Install Dependencies
+        uses: ./JLLVM/.github/actions/dependencies
+        with:
+          cxx-compiler: clang++
+          ccache-key: clang-tidy
+
+      # Required by clang-tidy-diff.py.
+      - name: Install Python depends
+        run: |
+          python -m pip install pyyaml
+
+      - name: Build LLVM
+        id: llvm-build
+        uses: ./JLLVM/.github/actions/llvm-build
+        with:
+          c-compiler: clang
+          cpp-compiler: clang++
+          cache-key: clang-tidy
+
+      - name: Configure JLLVM
+        run: |
+          cmake -GNinja -Bjllvm-build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CXX_COMPILER=clang++ \
+            -DCMAKE_C_COMPILER=clang \
+            -DPython3_ROOT_DIR="$pythonLocation" \
+            -DPython3_FIND_STRATEGY=LOCATION \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld" \
+            -DLLVM_DIR="${{steps.llvm-build.outputs.install-dir}}/lib/cmake/llvm/" \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+            -S ${{github.workspace}}/JLLVM
+
+      - name: Build JLLVM
+        run: |
+          cmake --build jllvm-build -- -k0
+
+      # We let clang-tidy output a fixes.yml file. If no warnings have ever been emitted it will be empty, otherwise
+      # we exit with an error code.
+      - name: Run clang-tidy
+        working-directory: ${{github.workspace}}/JLLVM
+        run: |
+          git diff -U0 HEAD^ '***.c' '***.h' '***.hpp' '***.cpp' \
+           | clang-tidy-diff-$LLVM_VERSION.py -p1 -quiet -use-color -path ${{github.workspace}}/jllvm-build \
+             -export-fixes ${{github.workspace}}/fixes.yml -clang-tidy-binary $(which clang-tidy-$LLVM_VERSION) \
+             -j$(nproc)
+          
+          if [ -s ${{github.workspace}}/fixes.yml ] 
+          then
+            exit 1
+          fi
+
+      - name: Upload clang-tidy fixes.yml
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: fixes.yml
+          path: ${{github.workspace}}/fixes.yml
+
+
+  format-run:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Install dependencies
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh $LLVM_VERSION all
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+
+      - name: Checkout JLLVM
+        uses: actions/checkout@v3
+        with:
+          # Depth 2 because we need the diff.
+          fetch-depth: 2
+
+      - name: Run clang-format on changes
+        run: |
+          # Below ensures that the exit code of git-clang-format is properly propagated
+          set -o pipefail
+          git diff -U0 HEAD^ '***.c' '***.h' '***.hpp' '***.cpp' \
+           | clang-format-diff-$LLVM_VERSION -p1 -binary $(which clang-format-$LLVM_VERSION) \
+           | tee ${{github.workspace}}/clang-format.patch
+
+      - name: Upload clang-format patch
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: clang-format.patch
+          path: ${{github.workspace}}/clang-format.patch
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,12 @@ project(JLLVM)
 
 set(CMAKE_CXX_STANDARD 17)
 
+if( NOT uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG" )
+    option(JLLVM_ENABLE_ASSERTIONS "Enable assertions" OFF)
+else()
+    option(JLLVM_ENABLE_ASSERTIONS "Enable assertions" ON)
+endif()
+
 find_package(Threads REQUIRED)
 link_libraries(Threads::Threads)
 find_package(LLVM REQUIRED CONFIG)
@@ -29,6 +35,29 @@ if (NOT LLVM_ENABLE_RTTI)
         string(REGEX REPLACE "-frtti" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
     endif ()
+endif ()
+
+if (JLLVM_ENABLE_ASSERTIONS)
+    # On non-Debug builds cmake automatically defines NDEBUG, so we
+    # explicitly undefine it:
+    if( NOT uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG" )
+        # NOTE: use `add_compile_options` rather than `add_definitions` since
+        # `add_definitions` does not support generator expressions.
+        add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-UNDEBUG>)
+        if (MSVC)
+            # Also remove /D NDEBUG to avoid MSVC warnings about conflicting defines.
+            foreach (flags_var_to_scrub
+                    CMAKE_CXX_FLAGS_RELEASE
+                    CMAKE_CXX_FLAGS_RELWITHDEBINFO
+                    CMAKE_CXX_FLAGS_MINSIZEREL
+                    CMAKE_C_FLAGS_RELEASE
+                    CMAKE_C_FLAGS_RELWITHDEBINFO
+                    CMAKE_C_FLAGS_MINSIZEREL)
+                string (REGEX REPLACE "(^| )[/-]D *NDEBUG($| )" " "
+                        "${flags_var_to_scrub}" "${${flags_var_to_scrub}}")
+            endforeach()
+        endif()
+    endif()
 endif ()
 
 set(JLLVM_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/jllvm/materialization/ByteCodeCompileLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeCompileLayer.cpp
@@ -124,9 +124,9 @@ class LazyClassLoaderHelper
                         llvm::cantFail(m_baseLayer.add(
                             m_implDylib, llvm::orc::ThreadSafeModule(std::move(module), std::move(context))));
 
-                        auto address =
-                            llvm::cantFail(m_implDylib.getExecutionSession().lookup({&m_implDylib}, stubSymbol))
-                                .getAddress();
+                        auto address = llvm::cantFail(m_implDylib.getExecutionSession().lookup({&m_implDylib},
+                                                                                               m_interner(stubSymbol)))
+                                           .getAddress();
 
                         llvm::cantFail(m_stubsManager.updatePointer(stubSymbol, address));
 
@@ -194,8 +194,9 @@ public:
                     [=, *this]
                     {
                         m_classLoader.forName("L" + className + ";");
-                        auto address = llvm::cantFail(m_mainDylib.getExecutionSession().lookup({&m_mainDylib}, method))
-                                           .getAddress();
+                        auto address =
+                            llvm::cantFail(m_mainDylib.getExecutionSession().lookup({&m_mainDylib}, m_interner(method)))
+                                .getAddress();
                         llvm::cantFail(m_stubsManager.updatePointer(stubName, address));
                         return address;
                     })),

--- a/src/jllvm/vm/GarbageCollector.cpp
+++ b/src/jllvm/vm/GarbageCollector.cpp
@@ -173,7 +173,7 @@ void replaceStackRoots(const llvm::DenseMap<std::uintptr_t, std::vector<jllvm::S
                     auto* object = reinterpret_cast<ObjectRepr*>(rp);
                     if (auto* replacement = mapping.lookup(object))
                     {
-                        _Unwind_SetGR(context, iter.registerNumber, reinterpret_cast<_Unwind_Word>(replacement));
+                        _Unwind_SetGR(context, iter.registerNumber, reinterpret_cast<std::uintptr_t>(replacement));
                     }
                     break;
                 }

--- a/src/jllvm/vm/JIT.hpp
+++ b/src/jllvm/vm/JIT.hpp
@@ -43,8 +43,6 @@ class JIT
     ByteCodeCompileLayer m_byteCodeCompileLayer;
     ByteCodeOnDemandLayer m_byteCodeOnDemandLayer;
     JNIImplementationLayer m_jniLayer;
-    llvm::ThreadPool m_threadPool;
-
 
     GarbageCollector& m_gc;
 

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -1,11 +1,14 @@
 
 
 #include <llvm/Support/FileSystem.h>
+#include <llvm/Support/InitLLVM.h>
 
 #include <jllvm/main/Main.hpp>
 
 int main(int argc, char** argv)
 {
+    llvm::InitLLVM initLlvm(argc, argv);
+
     auto executablePath = llvm::sys::fs::getMainExecutable(argv[0], reinterpret_cast<void*>(&main));
     return jllvm::main(executablePath, {argv, static_cast<std::size_t>(argc)});
 }


### PR DESCRIPTION
This PR adds two simple GitHub Actions Workflows:
* builds.yml: Which verifies that our commits and pull requests properly build and run through tests
* lint.yml: Which lints only changed lines of code in a PR or commit for either linting issues or code style/formatting violations

Part of the complexity is installing all the dependencies. The action.yml in dependencies installs basically all readily available dependencies that we need (Python, cmake, JDK, Compilers, ccache).

The action.yml in llvm-build does a build of the LLVM 16 release branch and caches it (as it otherwise takes roughly 2 hours to build). The advantage of building our own LLVM are that we can use better debugging options such as sanitizers and are not reliant on any kind of repository but the source repository.

While doing issues popped up in regards to both sanitizer issues and macOS issues. I have also fixed these as part of this PR. I can separate them in a different PR if you prefer but I feel like without test infrastructure they're somewhat not meaningful. The issues popped up and fixed boil down to:
* Missing uses of the `llvm::orc::MangleAndInterner`. This class is important as it applies the platform mangling. macOS uses a leading `_` for every symbol and without it the linker fails to find the definitions of the symbols
* Get rid of the thread pool and parallel task dispatching in the JIT. This has caused both sanitizer failure and dead locks in my testing