### PR TITLE
[llvm] Fix crash due to a wrong function attribute on our allocation function

### DIFF
--- a/src/jllvm/materialization/ByteCodeCompileLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeCompileLayer.cpp
@@ -56,7 +56,9 @@ llvm::FunctionCallee allocationFunction(llvm::Module* module)
     function = llvm::Function::Create(llvm::FunctionType::get(referenceType(module->getContext()),
                                                               {llvm::Type::getInt32Ty(module->getContext())}, false),
                                       llvm::GlobalValue::ExternalLinkage, "jllvm_gc_alloc", module);
-    function->addRetAttr(llvm::Attribute::NoAlias);
+    function->addFnAttrs(llvm::AttrBuilder(module->getContext())
+                             .addAllocSizeAttr(0, std::nullopt)
+                             .addAllocKindAttr(llvm::AllocFnKind::Alloc | llvm::AllocFnKind::Zeroed));
     return function;
 }
 

--- a/tests/Execution/llvm-miscompile.java
+++ b/tests/Execution/llvm-miscompile.java
@@ -1,0 +1,17 @@
+// RUN: javac %s -d %t
+// RUN: jllvm %t/Test.class
+
+class Test
+{
+    public int i = 3;
+    public static Test sink = null;
+
+    public static void main(String[] args)
+    {
+        var t = new Test[0];
+        // Causes garbage collection inbetween 't' and storing it. The dead store elimination
+        // would previously falsely delete storing 'Test[].class' into 't'.
+        new Object();
+        sink = t[0];
+    }
+}


### PR DESCRIPTION
The `noalias` attribute on return types of functions has additional special semantics in LLVM. According to the LangRef, it makes LLVM assume that the pointer returned by the function is unique AND that it comes from the system allocator directly.

The latter has bad consequences in our case however. It makes LLVM assume that stores to the objects memory that are not read are dead and can be removed. This is incorrect in our case however as the GC relies on code setting the class object and attempts reading it. LLVM deleting the store of the class object however leads to it remaining null, and the GC crashing when trying to parse the heap during garbage collection.

This PR fixes that issue by removing the inaccurate `noalias` attribute and replacing it with the `allockind` attribute (https://llvm.org/docs/LangRef.html#function-attributes) this makes LLVM assume that any stores to the object might be read by the allocation function while still assuming that any pointers returned by the function may not alias any other objects.