### PR TITLE
[codegen] Fix calls to functions taking integer arguments smaller than `int`

### DIFF
--- a/src/jllvm/main/Main.cpp
+++ b/src/jllvm/main/Main.cpp
@@ -12,7 +12,8 @@ namespace
 template <class T>
 auto trivialPrintFunction()
 {
-    return llvm::JITEvaluatedSymbol::fromPointer(+[](void*, void*, T value) { llvm::outs() << value << '\n'; });
+    return llvm::JITEvaluatedSymbol::fromPointer(+[](void*, void*, T value)
+                                                 { llvm::outs() << static_cast<std::ptrdiff_t>(value) << '\n'; });
 }
 
 } // namespace
@@ -65,6 +66,7 @@ int jllvm::main(llvm::StringRef executablePath, llvm::ArrayRef<char*> args)
             {vm.getInterner()("Java_Test_print__I"), trivialPrintFunction<std::int32_t>()},
             {vm.getInterner()("Java_Test_print__J"), trivialPrintFunction<std::int64_t>()},
             {vm.getInterner()("Java_Test_print__S"), trivialPrintFunction<std::int16_t>()},
+            {vm.getInterner()("Java_Test_print__C"), trivialPrintFunction<std::int16_t>()},
             {vm.getInterner()("Java_Test_print__Z"), trivialPrintFunction<bool>()},
         }));
     }

--- a/src/jllvm/materialization/ByteCodeCompileLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeCompileLayer.cpp
@@ -988,8 +988,10 @@ void codeGenBody(llvm::Function* function, const Code& code, const ClassFile& cl
                 llvm::Value* vtblSlot = builder.CreateGEP(builder.getInt8Ty(), classObject, {totalOffset});
                 llvm::Value* callee = builder.CreateLoad(builder.getPtrTy(), vtblSlot);
 
-                auto* call =
-                    builder.CreateCall(descriptorToType(descriptor, false, builder.getContext()), callee, args);
+                llvm::FunctionType* functionType = descriptorToType(descriptor, false, builder.getContext());
+                prepareArgumentsForCall(builder, args, functionType);
+                auto* call = builder.CreateCall(functionType, callee, args);
+                call->setAttributes(getABIAttributes(functionType));
 
                 if (descriptor.returnType != FieldType(BaseType::Void))
                 {

--- a/src/jllvm/materialization/ByteCodeCompileLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeCompileLayer.cpp
@@ -60,6 +60,23 @@ llvm::FunctionCallee allocationFunction(llvm::Module* module)
     return function;
 }
 
+/// Truncates 'i32' args which is the type used internally on Javas operand stack for everything but 'long'
+/// to integer types of the bit-width of the callee (e.g. 'i8' for a 'byte' arg in Java).
+void prepareArgumentsForCall(llvm::IRBuilder<>& builder, llvm::MutableArrayRef<llvm::Value*> args,
+                             llvm::FunctionType* functionType)
+{
+    for (auto [arg, argType] : llvm::zip(args, functionType->params()))
+    {
+        if (arg->getType() == argType)
+        {
+            continue;
+        }
+        assert(arg->getType()->isIntegerTy() && argType->isIntegerTy()
+               && arg->getType()->getIntegerBitWidth() > argType->getIntegerBitWidth());
+        arg = builder.CreateTrunc(arg, argType);
+    }
+}
+
 /// Helper class to fetch properties about a class while still doing lazy class loading.
 /// This works by taking callbacks which are either called immediately if a class object is already loaded, leading
 /// to better code generation, or otherwise creating stubs that when called load the given class object and return
@@ -906,8 +923,10 @@ void codeGenBody(llvm::Function* function, const Code& code, const ClassFile& cl
                     refInfo->nameAndTypeIndex.resolve(classFile)->descriptorIndex.resolve(classFile)->text;
                 llvm::Value* callee = helper.getNonVirtualCallee(builder, isStatic, className, methodName, methodType);
 
-                auto* call =
-                    builder.CreateCall(descriptorToType(descriptor, isStatic, builder.getContext()), callee, args);
+                llvm::FunctionType* functionType = descriptorToType(descriptor, isStatic, builder.getContext());
+                prepareArgumentsForCall(builder, args, functionType);
+
+                auto* call = builder.CreateCall(functionType, callee, args);
 
                 if (descriptor.returnType != FieldType(BaseType::Void))
                 {

--- a/src/jllvm/materialization/JNIImplementationLayer.cpp
+++ b/src/jllvm/materialization/JNIImplementationLayer.cpp
@@ -115,8 +115,17 @@ void jllvm::JNIImplementationLayer::emit(std::unique_ptr<llvm::orc::Materializat
 
                 llvm::Value* callee =
                     builder.CreateIntToPtr(builder.getInt64(lookup->getAddress()), builder.getPtrTy());
-                llvm::Value* result =
+                llvm::CallInst* result =
                     builder.CreateCall(llvm::FunctionType::get(returnType, argTypes, false), callee, args);
+                for (auto&& [index, type] : llvm::enumerate(argTypes))
+                {
+                    if (!type->isIntegerTy())
+                    {
+                        continue;
+                    }
+                    // Signextend integer args for ABI.
+                    result->addParamAttr(index, llvm::Attribute::SExt);
+                }
 
                 // TODO: Post-setup code here
 

--- a/tests/Execution/jni-primitives.java
+++ b/tests/Execution/jni-primitives.java
@@ -1,0 +1,32 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+class Test
+{
+    public static native void print(byte i);
+    public static native void print(short i);
+    public static native void print(char i);
+    public static native void print(int i);
+    public static native void print(long i);
+
+    public static void main(String[] args)
+    {
+        byte b = -1;
+        print(b);
+        short s = -1;
+        print(s);
+        int i = -1;
+        print(i);
+
+        // TODO: Needs 'ldc2_w' https://github.com/JLLVM/JLLVM/issues/17
+        // long l = -1;
+        // print(l);
+
+        // Java char does not support assignment from negative values
+        char c = 5;
+        print(5);
+    }
+}
+
+// CHECK-COUNT-3: -1
+// CHECK: 5

--- a/tests/Execution/less-than-int-args.java
+++ b/tests/Execution/less-than-int-args.java
@@ -1,0 +1,34 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+class Test
+{
+    public static native void print(byte i);
+    public static native void print(short i);
+    public static native void print(char i);
+
+    public static void printValue(byte value)
+    {
+        print(value);
+    }
+
+    public static void printValue(short value)
+    {
+        print(value);
+    }
+
+    public static void printValue(char value)
+    {
+        print(value);
+    }
+
+    public static void main(String[] args)
+    {
+        // CHECK: 3
+        printValue((byte)3);
+        // CHECK: 4
+        printValue((short)4);
+        // CHECK: 5
+        printValue((char)5);
+    }
+}

--- a/tests/Execution/less-than-int-args.java
+++ b/tests/Execution/less-than-int-args.java
@@ -22,6 +22,21 @@ class Test
         print(value);
     }
 
+    public void printValueI(byte value)
+    {
+        print(value);
+    }
+
+    public void printValueI(short value)
+    {
+        print(value);
+    }
+
+    public void printValueI(char value)
+    {
+        print(value);
+    }
+
     public static void main(String[] args)
     {
         // CHECK: 3
@@ -30,5 +45,13 @@ class Test
         printValue((short)4);
         // CHECK: 5
         printValue((char)5);
+
+        var t = new Test();
+        // CHECK: 6
+        t.printValueI((byte)6);
+        // CHECK: 7
+        t.printValueI((short)7);
+        // CHECK: 8
+        t.printValueI((char)8);
     }
 }


### PR DESCRIPTION
Since Javas operand stack essentially always uses at least `int`, we have to truncate these before making a call to a function taking `byte`, `short` or any other integer type less than `int`.