### PR TITLE
[vm] Add a high level API to easily implement 'native' methods of Java in C++

### DIFF
--- a/src/jllvm/main/Main.cpp
+++ b/src/jllvm/main/Main.cpp
@@ -12,8 +12,7 @@ namespace
 template <class T>
 auto trivialPrintFunction()
 {
-    return llvm::JITEvaluatedSymbol::fromPointer(+[](void*, void*, T value)
-                                                 { llvm::outs() << static_cast<std::ptrdiff_t>(value) << '\n'; });
+    return [](void*, void*, T value) { llvm::outs() << static_cast<std::ptrdiff_t>(value) << '\n'; };
 }
 
 } // namespace
@@ -66,16 +65,15 @@ int jllvm::main(llvm::StringRef executablePath, llvm::ArrayRef<char*> args)
 
     if (commandLine.getArgs().hasArg(OPT_Xenable_test_utils))
     {
-        vm.addJNISymbols(llvm::orc::absoluteSymbols({
-            {vm.getInterner()("Java_Test_print__B"), trivialPrintFunction<std::int8_t>()},
-            {vm.getInterner()("Java_Test_print__D"), trivialPrintFunction<double>()},
-            {vm.getInterner()("Java_Test_print__F"), trivialPrintFunction<float>()},
-            {vm.getInterner()("Java_Test_print__I"), trivialPrintFunction<std::int32_t>()},
-            {vm.getInterner()("Java_Test_print__J"), trivialPrintFunction<std::int64_t>()},
-            {vm.getInterner()("Java_Test_print__S"), trivialPrintFunction<std::int16_t>()},
-            {vm.getInterner()("Java_Test_print__C"), trivialPrintFunction<std::uint16_t>()},
-            {vm.getInterner()("Java_Test_print__Z"), trivialPrintFunction<bool>()},
-        }));
+        JIT& jit = vm.getJIT();
+        jit.addJNISymbol("Java_Test_print__B", trivialPrintFunction<std::int8_t>());
+        jit.addJNISymbol("Java_Test_print__D", trivialPrintFunction<double>());
+        jit.addJNISymbol("Java_Test_print__F", trivialPrintFunction<float>());
+        jit.addJNISymbol("Java_Test_print__I", trivialPrintFunction<std::int32_t>());
+        jit.addJNISymbol("Java_Test_print__J", trivialPrintFunction<std::int64_t>());
+        jit.addJNISymbol("Java_Test_print__S", trivialPrintFunction<std::int16_t>());
+        jit.addJNISymbol("Java_Test_print__C", trivialPrintFunction<std::uint16_t>());
+        jit.addJNISymbol("Java_Test_print__Z", trivialPrintFunction<bool>());
     }
 
     return vm.executeMain(inputFiles.front(), llvm::to_vector_of<llvm::StringRef>(llvm::drop_begin(inputFiles)));

--- a/src/jllvm/materialization/ByteCodeCompileLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeCompileLayer.cpp
@@ -39,9 +39,14 @@ struct jllvm::CppToLLVMType<jllvm::ClassObject*> : CppToLLVMType<const jllvm::Cl
 namespace
 {
 
+auto objectHeaderType(llvm::LLVMContext& context)
+{
+    return llvm::StructType::get(/*classObject*/ referenceType(context), /*hashCode*/ llvm::Type::getInt32Ty(context));
+}
+
 auto arrayStructType(llvm::Type* elementType)
 {
-    return llvm::StructType::get(elementType->getContext(), {referenceType(elementType->getContext()),
+    return llvm::StructType::get(elementType->getContext(), {objectHeaderType(elementType->getContext()),
                                                              llvm::Type::getInt32Ty(elementType->getContext()),
                                                              llvm::ArrayType::get(elementType, 0)});
 }

--- a/src/jllvm/materialization/JNIImplementationLayer.hpp
+++ b/src/jllvm/materialization/JNIImplementationLayer.hpp
@@ -10,6 +10,12 @@
 namespace jllvm
 {
 
+/// Applies the JNI name mangling to create the corresponding C symbol name for the given 'methodName' inside of
+/// 'className'. If 'methodDescriptor' is non empty, it must be a valid method descriptor whose parameter types are
+/// then also encoded in the symbol name (to allow overloading).
+std::string formJNIMethodName(llvm::StringRef className, llvm::StringRef methodName,
+                              llvm::StringRef methodDescriptor = {});
+
 /// Layer implementing all JIT functionality related to the Java Native Interface. It is also where any JNI symbols
 /// must be registered to be called at runtime. Its implementation roughly boils down to creating compile stubs for any
 /// native methods registered and then looking up and generating bridge code once the native method has actually

--- a/src/jllvm/materialization/LambdaMaterialization.hpp
+++ b/src/jllvm/materialization/LambdaMaterialization.hpp
@@ -26,6 +26,36 @@ struct CppToLLVMType<T, std::enable_if_t<std::is_integral_v<T>>>
     }
 };
 
+/// Specialization for float.
+template <>
+struct CppToLLVMType<float>
+{
+    static llvm::Type* get(llvm::LLVMContext* context)
+    {
+        return llvm::Type::getFloatTy(*context);
+    }
+
+    static llvm::Value* getConstant(float value, llvm::IRBuilder<>& builder)
+    {
+        return llvm::ConstantFP::get(builder.getFloatTy(), value);
+    }
+};
+
+/// Specialization for double.
+template <>
+struct CppToLLVMType<double>
+{
+    static llvm::Type* get(llvm::LLVMContext* context)
+    {
+        return llvm::Type::getDoubleTy(*context);
+    }
+
+    static llvm::Value* getConstant(double value, llvm::IRBuilder<>& builder)
+    {
+        return llvm::ConstantFP::get(builder.getDoubleTy(), value);
+    }
+};
+
 /// Specialization for void.
 template <>
 struct CppToLLVMType<void>

--- a/src/jllvm/object/Object.hpp
+++ b/src/jllvm/object/Object.hpp
@@ -15,7 +15,26 @@ class ClassObject;
 /// Purpose of this being its own type is mostly size calculations.
 struct ObjectHeader
 {
+    /// Type of the object.
     const ClassObject* classObject;
+    /// Cached hash of the object. This has to be stored and lazily calculated on first use. We cannot use an objects
+    /// address as we have a relocating garbage collector. It is therefore unstable.
+    /// A value of 0 indicates the hashCode of an object has not yet been calculated.
+    std::int32_t hashCode;
+};
+
+/// Pure interface class used to implement methods one would commonly associate with 'Object'.
+/// We cannot use C++ inheritance to do this as that does not have a defined memory layout. We instead use
+/// composition and require all Java objects to simply always start with an 'ObjectHeader' instance.
+/// Inheriting from this class when that is not the case is undefined behaviour.
+class ObjectInterface
+{
+public:
+    /// Returns the object header of the class.
+    ObjectHeader& getObjectHeader()
+    {
+        return *reinterpret_cast<ObjectHeader*>(this);
+    }
 };
 
 class Object;
@@ -23,7 +42,7 @@ class Object;
 /// In memory representation of Java array with component type 'T'.
 /// 'T' is always either a primitive or a pointer to Java objects.
 template <class T = Object*>
-class Array
+class Array : public ObjectInterface
 {
     ObjectHeader m_header;
     std::uint32_t m_length;
@@ -94,7 +113,7 @@ public:
 static_assert(std::is_standard_layout_v<Array<>>);
 
 /// In memory representation for a general Java object.
-class Object
+class Object : public ObjectInterface
 {
     ObjectHeader m_header;
 };

--- a/src/jllvm/vm/CMakeLists.txt
+++ b/src/jllvm/vm/CMakeLists.txt
@@ -2,7 +2,7 @@
 llvm_map_components_to_libnames(llvm_native_libs ${LLVM_NATIVE_ARCH})
 
 add_library(JLLVMVirtualMachine VirtualMachine.cpp JIT.cpp GarbageCollector.cpp StackMapRegistrationPlugin.cpp
-        JNIImplementation.cpp)
+        JNIImplementation.cpp NativeImplementation.cpp)
 target_link_libraries(JLLVMVirtualMachine
         PRIVATE ${llvm_native_libs}
         PUBLIC JLLVMClassParser JLLVMObject LLVMExecutionEngine LLVMOrcJIT LLVMJITLink JLLVMMaterialization
@@ -23,4 +23,4 @@ find_path(JNI_INCLUDE_PATH2 NAMES jni_md.h jniport.h REQUIRED
         ${JAVA_INCLUDE_PATH}/aix
         )
 
-set_source_files_properties(JNIImplementation.cpp PROPERTIES INCLUDE_DIRECTORIES "${JNI_INCLUDE_PATH1};${JNI_INCLUDE_PATH2}")
+target_include_directories(JLLVMVirtualMachine PRIVATE ${JNI_INCLUDE_PATH1} ${JNI_INCLUDE_PATH2})

--- a/src/jllvm/vm/JNIImplementation.cpp
+++ b/src/jllvm/vm/JNIImplementation.cpp
@@ -6,6 +6,7 @@
 jllvm::VirtualMachine::JNINativeInterfaceUPtr jllvm::VirtualMachine::createJNIEnvironment()
 {
     auto* result = new JNINativeInterface_{};
+    result->reserved0 = reinterpret_cast<void*>(this);
 
     return JNINativeInterfaceUPtr(
         result, +[](void* ptr) { delete reinterpret_cast<JNINativeInterface_*>(ptr); });

--- a/src/jllvm/vm/NativeImplementation.cpp
+++ b/src/jllvm/vm/NativeImplementation.cpp
@@ -1,0 +1,11 @@
+#include "NativeImplementation.hpp"
+
+jllvm::VirtualMachine& jllvm::detail::virtualMachineFromJNIEnv(JNIEnv* env)
+{
+    return *reinterpret_cast<jllvm::VirtualMachine*>(env->functions->reserved0);
+}
+
+void jllvm::registerJavaClasses(VirtualMachine& virtualMachine)
+{
+    addModel<ObjectModel>(virtualMachine);
+}

--- a/src/jllvm/vm/NativeImplementation.hpp
+++ b/src/jllvm/vm/NativeImplementation.hpp
@@ -1,0 +1,165 @@
+#pragma once
+
+#include <llvm/ADT/STLExtras.h>
+#include <llvm/ADT/StringRef.h>
+
+#include <memory>
+#include <utility>
+
+#include <jni.h>
+
+#include "VirtualMachine.hpp"
+
+namespace jllvm
+{
+
+/// Method used to add a (possibly static) member function to the 'method' tuple of a 'ModelBase' instance.
+/// This uses an implementation defined trick to get the name of the member function and returns it together with the
+/// function pointer.
+template <auto fnPtr>
+constexpr auto addMember()
+{
+    // GCC and Clang encode the typename here by appending at the back something similar to [fnPtr = Class::name]
+    std::string_view demangledName = __PRETTY_FUNCTION__;
+    std::size_t rstart = demangledName.rfind(']');
+    assert(rstart != std::string_view::npos);
+    // Skip over possible whitespace.
+    while (rstart > 0 && demangledName[rstart - 1] == ' ')
+    {
+        rstart--;
+    }
+
+    // Last namespace qualifier from the back.
+    constexpr std::string_view namespaceQual = "::";
+    std::size_t lastNamespaceQual = demangledName.rfind(namespaceQual, rstart);
+    assert(lastNamespaceQual != std::string_view::npos);
+
+    demangledName = demangledName.substr(lastNamespaceQual + namespaceQual.size(),
+                                         rstart - (lastNamespaceQual + namespaceQual.size()));
+    return std::pair{fnPtr, demangledName};
+}
+
+/// Base class for any Models used as our high level API for implementing native methods of Java.
+/// This high level API builds on top of the JNI and translates the JNIs general and JVM agnostic C interface to
+/// a more high level C++ API specific to our JVM implementation.
+///
+/// To implement a new implementation of native methods for a Java class, simply create a new model class inheriting
+/// from 'ModelBase'. The one optional template parameter describes the type that should be used as object
+/// representation for any 'this' object coming from Java. By default it is simply 'Object'.
+///
+/// The model subclass may then simply implement member functions with the EXACT same name as the 'native' method in
+/// Java. Function parameters from Java can easily be translated to C++ types: For integer types simply use signed
+/// integer types with the same width as the corresponding Java type. For Java Objects, use 'Object*' or any other
+/// subclass of 'ObjectInterface' (such as e.g. 'Array<int>*') that corresponds to, or is at least a super class, of
+/// the object used in the Java API.
+///
+/// Non-static method members do NOT need an explicit 'this' pointer parameter. You can use 'javaThis' from within
+/// member functions to get the 'this' pointer from Java.
+///
+/// Static methods must always have 'VirtualMachine&' and 'ClassObject*' as their first two parameters. The parameters
+/// from the static method from Java follow right afterwards. The 'ClassObject*' is the class object of the class the
+/// static method is defined in.
+///
+/// As a final step, 'ModelBase' subclasses must add the following 'constexpr static' fields:
+/// * 'llvm::StringLiteral className' which should contain the fully qualified name (i.e. with slashes) of the class
+///    being modelled
+/// *  'auto methods = std::make_tuple(addMember<&ModelClass::aNativeMethod>(), ...)' which is a tuple using
+///    'addMember' that should list ALL implementations of 'native' methods that should be registered in the VM.
+template <class JavaObject = Object>
+class ModelBase
+{
+    static_assert(
+        std::is_base_of_v<ObjectInterface, JavaObject>,
+        "JavaObject must be a valid Java object representation with an object header and inherits from ObjectInterface");
+
+protected:
+    /// 'this' object from Java to be used in member functions.
+    JavaObject& javaThis;
+    /// Instance of the virtual machine this model is registered in.
+    VirtualMachine& virtualMachine;
+
+    using Base = ModelBase<JavaObject>;
+
+public:
+    /// Constructor required to be implemented by any subclasses. Simply adding 'using Base::Base' to subclasses will
+    /// make them inherit this constructor.
+    ModelBase(JavaObject& javaThis, VirtualMachine& virtualMachine) : javaThis(javaThis), virtualMachine(virtualMachine)
+    {
+    }
+
+    /// Object representation type of Javas 'this'.
+    using ThisType = JavaObject;
+};
+
+/// Model implementation for the native methods of Javas 'Object' class.
+class ObjectModel : public ModelBase<>
+{
+public:
+    using Base::Base;
+
+    std::int32_t hashCode()
+    {
+        std::int32_t& hashCode = javaThis.getObjectHeader().hashCode;
+        if (!hashCode)
+        {
+            hashCode = virtualMachine.createNewHashCode();
+        }
+        return hashCode;
+    }
+
+    constexpr static llvm::StringLiteral className = "java/lang/Object";
+    constexpr static auto methods = std::make_tuple(addMember<&ObjectModel::hashCode>());
+};
+
+/// Register any models for builtin Java classes in the VM.
+void registerJavaClasses(VirtualMachine& virtualMachine);
+
+namespace detail
+{
+
+jllvm::VirtualMachine& virtualMachineFromJNIEnv(JNIEnv* env);
+
+template <class, class Ret, class... Args>
+auto createMethodBridge(Ret (*ptr)(jllvm::VirtualMachine&, jllvm::ClassObject*, Args...))
+{
+    return [ptr](JNIEnv* env, jllvm::ClassObject* classObject, Args... args)
+    { return ptr(virtualMachineFromJNIEnv(env), classObject, args...); };
+}
+
+template <class Model, class Ret, class... Args>
+auto createMethodBridge(Ret (Model::*ptr)(Args...))
+{
+    return [ptr](JNIEnv* env, typename Model::ThisType* javaThis, Args... args)
+    { return (Model(*javaThis, virtualMachineFromJNIEnv(env)).*ptr)(args...); };
+}
+
+template <class Model>
+using hasClassName = decltype(Model::className);
+
+template <class Model>
+using hasMethods = decltype(Model::methods);
+
+} // namespace detail
+
+/// Registers all methods of a model 'Model' within 'virtualMachine'.
+template <class Model>
+void addModel(jllvm::VirtualMachine& virtualMachine)
+{
+    static_assert(
+        llvm::is_detected<detail::hasClassName, Model>{},
+        "'Model' must have a 'constexpr static llvm::StringLiteral className' field with fully qualified name of the class it is modelling");
+    static_assert(
+        llvm::is_detected<detail::hasMethods, Model>{},
+        "'Model' must have a 'constexpr static' tuple called 'methods' listing all 'native' methods implemented");
+
+    std::apply(
+        [&](const auto& subTuple)
+        {
+            auto [ptr, methodName] = subTuple;
+            virtualMachine.getJIT().addJNISymbol(jllvm::formJNIMethodName(Model::className, methodName),
+                                                 detail::createMethodBridge<Model>(ptr));
+        },
+        Model::methods);
+}
+
+} // namespace jllvm

--- a/src/jllvm/vm/VirtualMachine.cpp
+++ b/src/jllvm/vm/VirtualMachine.cpp
@@ -2,6 +2,8 @@
 
 #include <llvm/Support/Debug.h>
 
+#include "NativeImplementation.hpp"
+
 #define DEBUG_TYPE "jvm"
 
 jllvm::VirtualMachine::VirtualMachine(std::vector<std::string>&& classPath)
@@ -46,8 +48,13 @@ jllvm::VirtualMachine::VirtualMachine(std::vector<std::string>&& classPath)
             }
         },
         [this](const ClassFile* classFile) { m_jit.add(classFile); }, [&] { return m_gc.allocateStatic(); }),
-      m_gc(/*small random value for now*/ 4096)
+      m_gc(/*small random value for now*/ 4096),
+      // Seed from the C++ implementations entropy source.
+      m_pseudoGen(std::random_device{}()),
+      // Exclude 0 from the output as that is our sentinel value for "not yet calculated".
+      m_hashIntDistrib(1, std::numeric_limits<std::uint32_t>::max())
 {
+    registerJavaClasses(*this);
 }
 
 int jllvm::VirtualMachine::executeMain(llvm::StringRef path, llvm::ArrayRef<llvm::StringRef> args)
@@ -66,4 +73,9 @@ int jllvm::VirtualMachine::executeMain(llvm::StringRef path, llvm::ArrayRef<llvm
     }
     reinterpret_cast<void (*)(void*)>(lookup->getAddress())(nullptr);
     return 0;
+}
+
+std::int32_t jllvm::VirtualMachine::createNewHashCode()
+{
+    return m_hashIntDistrib(m_pseudoGen);
 }

--- a/tests/Execution/ObjectHashCode.java
+++ b/tests/Execution/ObjectHashCode.java
@@ -1,0 +1,20 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+class Test
+{
+    public static native void print(int i);
+
+    public static void main(String[] args)
+    {
+        var t = new Test();
+        print(t.hashCode());
+        // Cause garbage collection (at least in debug builds).
+        new Object();
+        // Hashcode should remain the same despite object relocation.
+        print(t.hashCode());
+    }
+}
+
+// CHECK: [[HASHCODE:.*]]
+// CHECK-NEXT: [[HASHCODE]]


### PR DESCRIPTION
The high level API builds on top of the JNI interface, simply doing casts to go from the JVM agnostic to classes specific to our JVM implementation. The API essentially works by creating 'Model' classes in C++ which should mirror the class from Java. 

Within the 'Model' class, one defines (possibly static) methods with the exact same name and signatures (translated to C++ types) as are used in Java. One then only has to list the name of the Java class and the list of methods implemented in static members of the model class and register in a 'VirtualMachine' instance.

As a simple demonstration of how to use the API, a model class for Javas 'Object' was implemented with an implementation of `hashCode`. It lazily computes a unique id for a Java object and then stores it within the object header to remain stable throughout the objects lifetime. This is similar to how Chromium's V8 JS engine does it as well. Using the objects address is not viable due to being unstable within our relocating Garbage Collector.