### PR TITLE
[GC] fix stackmap interaction on macOS

### DIFF
--- a/src/jllvm/main/Main.cpp
+++ b/src/jllvm/main/Main.cpp
@@ -20,7 +20,14 @@ auto trivialPrintFunction()
 
 int jllvm::main(llvm::StringRef executablePath, llvm::ArrayRef<char*> args)
 {
-    llvm::SmallVector<const char*> llvmArgs{"jllvm", "-fixup-allow-gcptr-in-csr", "-max-registers-for-gc-values=1000"};
+    llvm::SmallVector<const char*> llvmArgs{"jllvm"};
+#ifndef __APPLE__
+    // libunwind (from LLVM), seemingly does not properly write to caller saved registers. We therefore disable this
+    // optimization.
+    llvmArgs.push_back("-fixup-allow-gcptr-in-csr");
+    llvmArgs.push_back("-max-registers-for-gc-values=1000");
+#endif
+
 #ifndef NDEBUG
     llvmArgs.push_back("-jllvm-gc-every-alloc=1");
 #endif

--- a/src/jllvm/vm/StackMapRegistrationPlugin.cpp
+++ b/src/jllvm/vm/StackMapRegistrationPlugin.cpp
@@ -20,7 +20,12 @@ void jllvm::StackMapRegistrationPlugin::modifyPassConfig(llvm::orc::Materializat
     config.PrePrunePasses.emplace_back(
         [&](llvm::jitlink::LinkGraph& g)
         {
-            llvm::jitlink::Section* section = g.findSectionByName(".llvm_stackmaps");
+            llvm::StringRef stackMapSectionName = ".llvm_stackmaps";
+            if (g.getTargetTriple().isOSBinFormatMachO())
+            {
+                stackMapSectionName = "__LLVM_STACKMAPS,__llvm_stackmaps";
+            }
+            llvm::jitlink::Section* section = g.findSectionByName(stackMapSectionName);
             if (!section)
             {
                 return llvm::Error::success();
@@ -39,7 +44,12 @@ void jllvm::StackMapRegistrationPlugin::modifyPassConfig(llvm::orc::Materializat
     config.PostFixupPasses.emplace_back(
         [&](llvm::jitlink::LinkGraph& g)
         {
-            llvm::jitlink::Section* section = g.findSectionByName(".llvm_stackmaps");
+            llvm::StringRef stackMapSectionName = ".llvm_stackmaps";
+            if (g.getTargetTriple().isOSBinFormatMachO())
+            {
+                stackMapSectionName = "__LLVM_STACKMAPS,__llvm_stackmaps";
+            }
+            llvm::jitlink::Section* section = g.findSectionByName(stackMapSectionName);
             if (!section)
             {
                 return llvm::Error::success();

--- a/tests/Execution/object-array-ops.java
+++ b/tests/Execution/object-array-ops.java
@@ -1,0 +1,35 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+class Test
+{
+    public static native void print(int i);
+
+	public int value;
+
+	public Test(int value)
+	{
+		this.value = value;
+	}
+
+    public static void main(String[] args)
+    {
+        var is = new Test[3];
+		is[0] = new Test(0);
+		is[1] = new Test(1);
+		is[2] = new Test(2);
+
+		// Something random inbetween, maybe GCs.
+		new Object();
+
+		print(is[0].value);
+		print(is[1].value);
+		print(is[2].value);
+		print(is.length);
+    }
+}
+
+// CHECK: 0
+// CHECK: 1
+// CHECK: 2
+// CHECK: 3


### PR DESCRIPTION
The current JITLink plugin that extracts the stackmap out of object files still had hardcoded section names for just Linux, but not macOS. This caused the garbage collector to collect objects that were still referenced by local variables causing nasty bugs.

Additionally, libunwind seems to not be capable of writing to caller saved regsiters within a stackframe (at least it seemingly does not apply the changes). We therefore disable this optimization on macOS for the moment, and let it spill the code instead.

Attached test was originally meant to be a simple regression test for array operations, turned out to also hit the GC issue on macOS.