### PR TITLE
[instruction] Add support for idiv instruction

### DIFF
--- a/src/jllvm/materialization/ByteCodeCompileLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeCompileLayer.cpp
@@ -847,9 +847,9 @@ void codeGenBody(llvm::Function* function, const Code& code, const ClassFile& cl
             }
             case OpCodes::IAdd:
             {
-                llvm::Value* lhs = operandStack.back();
-                operandStack.pop_back();
                 llvm::Value* rhs = operandStack.back();
+                operandStack.pop_back();
+                llvm::Value* lhs = operandStack.back();
                 operandStack.pop_back();
                 operandStack.push_back(builder.CreateAdd(lhs, rhs));
                 break;
@@ -887,6 +887,15 @@ void codeGenBody(llvm::Function* function, const Code& code, const ClassFile& cl
             case OpCodes::IConst5:
             {
                 operandStack.push_back(builder.getInt32(5));
+                break;
+            }
+            case OpCodes::IDiv:
+            {
+                llvm::Value* rhs = operandStack.back();
+                operandStack.pop_back();
+                llvm::Value* lhs = operandStack.back();
+                operandStack.pop_back();
+                operandStack.push_back(builder.CreateSDiv(lhs, rhs));
                 break;
             }
             case OpCodes::ILoad:

--- a/tests/Execution/idiv.java
+++ b/tests/Execution/idiv.java
@@ -10,14 +10,26 @@ class Test
         int x = 3;
         int y = 2;
         // CHECK: 1
+        // CHECK-NOT:-
         print(x/y);
         // CHECK: 3
+        // CHECK-NOT:-
         print(x/1);
         // CHECK: 9
+        // CHECK-NOT:-
         print(27/x);
         // CHECK: 9
+        // CHECK-NOT:-
         print(28/x);
         // CHECK: 0
+        // CHECK-NOT:-
         print(Integer.MAX_VALUE/Integer.MIN_VALUE);
+        // CHECK: -3
+        print(x/-1);
+        // CHECK: 0
+        // CHECK-NOT:-
+        print(-1/x);
+        // CHECK: -5
+        print(-15/3);
     }
 }

--- a/tests/Execution/idiv.java
+++ b/tests/Execution/idiv.java
@@ -1,0 +1,23 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+class Test
+{
+    public static native void print(int i);
+
+    public static void main(String[] args)
+    {
+        int x = 3;
+        int y = 2;
+        // CHECK: 1
+        print(x/y);
+        // CHECK: 3
+        print(x/1);
+        // CHECK: 9
+        print(27/x);
+        // CHECK: 9
+        print(28/x);
+        // CHECK: 0
+        print(Integer.MAX_VALUE/Integer.MIN_VALUE);
+    }
+}


### PR DESCRIPTION
This PR includes support for creating appropriate LLVM instructions on processing the idiv JVM instruction. Furthermore, the processing of the iadd instruction is modified s.t. LHS and RHS match the order defined by the JVM specification. 

Fixes https://github.com/JLLVM/JLLVM/issues/31