### PR TITLE
[classloader] Implement circular initialization of classes

### DIFF
--- a/src/jllvm/object/ClassLoader.cpp
+++ b/src/jllvm/object/ClassLoader.cpp
@@ -201,10 +201,10 @@ jllvm::ClassObject& jllvm::ClassLoader::add(std::unique_ptr<llvm::MemoryBuffer>&
     return *result;
 }
 
-jllvm::ClassObject* jllvm::ClassLoader::forNameLoaded(llvm::Twine className)
+jllvm::ClassObject* jllvm::ClassLoader::forNameLoaded(llvm::Twine fieldDescriptor)
 {
     llvm::SmallString<32> str;
-    llvm::StringRef classNameRef = className.toStringRef(str);
+    llvm::StringRef classNameRef = fieldDescriptor.toStringRef(str);
     auto result = m_mapping.find(classNameRef);
     if (result != m_mapping.end())
     {

--- a/src/jllvm/object/ClassLoader.hpp
+++ b/src/jllvm/object/ClassLoader.hpp
@@ -1,14 +1,15 @@
 #pragma once
 
 #include <llvm/ADT/FunctionExtras.h>
+#include <llvm/ADT/SmallPtrSet.h>
 #include <llvm/ADT/StringMap.h>
 #include <llvm/Support/Allocator.h>
 #include <llvm/Support/MemoryBuffer.h>
 #include <llvm/Support/StringSaver.h>
 
-#include <list>
-
 #include <jllvm/class/ClassFile.hpp>
+
+#include <list>
 
 #include "ClassObject.hpp"
 
@@ -21,6 +22,7 @@ class ClassLoader
 {
     llvm::BumpPtrAllocator m_classAllocator;
     llvm::StringMap<ClassObject*> m_mapping;
+    llvm::SmallPtrSet<const ClassObject*, 8> m_uninitialized;
 
     llvm::BumpPtrAllocator m_stringAllocator;
     llvm::StringSaver m_stringSaver{m_stringAllocator};
@@ -28,7 +30,8 @@ class ClassLoader
     std::list<ClassFile> m_classFiles;
 
     std::vector<std::string> m_classPaths;
-    llvm::unique_function<void(const ClassFile*, ClassObject* classObject)> m_classObjectCreated;
+    llvm::unique_function<void(ClassObject* classObject)> m_initializeClassObject;
+    llvm::unique_function<void(const ClassFile*)> m_classFileLoaded;
     llvm::unique_function<void**()> m_allocateStatic;
 
     ClassObject m_byte{sizeof(std::uint8_t), "B"};
@@ -41,26 +44,53 @@ class ClassLoader
     ClassObject m_boolean{sizeof(bool), "Z"};
     ClassObject m_void{0, "V"};
 
+    void initialize(ClassObject& classObject)
+    {
+        if (!m_uninitialized.contains(&classObject))
+        {
+            return;
+        }
+        m_uninitialized.erase(&classObject);
+        m_initializeClassObject(&classObject);
+    }
+
+    ClassObject& add(std::unique_ptr<llvm::MemoryBuffer>&& memoryBuffer);
+
+    enum class State
+    {
+        Prepared,    // Class object should be created, but it doesn't have to be initialized.
+        Initialized, // Class object should also be initialized.
+    };
+
+    // Internal version of 'forName'. Allows specifying whether the class object must be at minimum only prepared or
+    // also initialized.
+    ClassObject& forName(llvm::Twine fieldDescriptor, State state);
+
 public:
-    /// Constructs a class loader with 'classPaths', which are all directories that class files will be searched for,
-    /// 'classFileLoaded' which is a callback called when a class object has successfully been constructed from the
-    /// given class file, and 'allocateStatic' which should allocate and return 'pointer sized' storage for any
-    /// static variables of reference type.
+    /// Constructs a class loader with 'classPaths', which are all directories that class files will be searched for.
+    /// 'initializeClassObject' is called for the initialization step of a class object and should at the very least
+    /// call the class initialization function of the class object.
+    /// 'classFileLoaded' is called when a class file has been loaded and is being used by the class loader.
+    /// 'allocateStatic' should allocate and return 'pointer sized' storage for any static variables of reference type.
     ClassLoader(std::vector<std::string>&& classPaths,
-                llvm::unique_function<void(const ClassFile*, ClassObject* classObject)>&& classFileLoaded,
+                llvm::unique_function<void(ClassObject* classObject)>&& initializeClassObject,
+                llvm::unique_function<void(const ClassFile* classFile)>&& classFileLoaded,
                 llvm::unique_function<void**()> allocateStatic);
 
-    /// Loads the class object for the given class file. This may also load transitive dependencies of the class file.#
-    /// Currently aborts if a class file could not be loaded.
-    const ClassObject& add(std::unique_ptr<llvm::MemoryBuffer>&& memoryBuffer);
+    /// Loads the class object for the given class file and initializes it. This may also load transitive dependencies
+    /// of the class file. Currently aborts if a class file could not be loaded.
+    const ClassObject& addAndInitialize(std::unique_ptr<llvm::MemoryBuffer>&& memoryBuffer);
 
     /// Returns the class object for 'fieldDescriptor', which must be a valid field descriptor, loading it and
     /// transitive dependencies if required. Currently aborts if a class file could not be loaded.
-    const ClassObject& forName(llvm::Twine fieldDescriptor);
+    const ClassObject& forName(llvm::Twine fieldDescriptor)
+    {
+        return forName(fieldDescriptor, State::Initialized);
+    }
 
     /// Returns the class object for 'fieldDescriptor', which must be a valid field descriptor,
     /// if it has been loaded previously. Null otherwise.
-    const ClassObject* forNameLoaded(llvm::Twine fieldDescriptor);
+    ClassObject* forNameLoaded(llvm::Twine fieldDescriptor);
 };
 
 } // namespace jllvm

--- a/tests/Execution/circular-class-loader.java
+++ b/tests/Execution/circular-class-loader.java
@@ -1,0 +1,25 @@
+// RUN: rm -rf %t && split-file %s %t
+// RUN: cd %t && javac %t/Test.java -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+//--- Test.java
+
+public class Test extends Other
+{
+    public static final int i = Other.i;
+
+    public static native void print(int i);
+
+    public static void main(String[] args)
+    {
+        // CHECK: 2
+        print(Other.i);
+    }
+}
+
+//--- Other.java
+
+public class Other
+{
+    public static final int i = Test.i + 2;
+}


### PR DESCRIPTION
The class loader currently incorrectly immediately initializes class objects as they are loaded. This is problematic however in cases such as two static initializers having circular dependencies on each other. This would previously crash due to loading a class object twice and creating linker errors.

This PR fixes that by following the spec more closely: https://docs.oracle.com/javase/specs/jvms/se17/html/jvms-5.html#jvms-5.5

We first create the class object, mark it as uninitialized (or prepared as the spec calls it), then initialize super classes and interfaces. If these do any lookups or similar for the currently-under- initialization class object they will then succeed without issues.

I have added a test demonstrating the behaviour. It uses circular references between static fields making the actual values dependent on the initialization order of the classes. static fields not yet initialized (just prepared) are explicitly zero initialized according to the spec: https://docs.oracle.com/javase/specs/jvms/se17/html/jvms-5.html#jvms-5.4.2