### PR TITLE
[codegen] Implement field lookup into super classes

### DIFF
--- a/src/jllvm/object/ClassObject.cpp
+++ b/src/jllvm/object/ClassObject.cpp
@@ -60,3 +60,21 @@ jllvm::ClassObject::ClassObject(std::uint32_t instanceSize, llvm::StringRef name
 {
     m_componentTypeAndIsPrimitive.setInt(true);
 }
+
+const jllvm::Field* jllvm::ClassObject::getField(llvm::StringRef fieldName, llvm::StringRef fieldType,
+                                                 bool isStatic) const
+{
+    for (const ClassObject* curr = this; curr; curr = curr->getSuperClass())
+    {
+        const Field* iter = llvm::find_if(curr->getFields(),
+                                          [&](const Field& field) {
+                                              return field.isStatic() == isStatic && field.getName() == fieldName
+                                                     && field.getType() == fieldType;
+                                          });
+        if (iter != curr->getFields().end())
+        {
+            return iter;
+        }
+    }
+    return nullptr;
+}

--- a/src/jllvm/object/ClassObject.hpp
+++ b/src/jllvm/object/ClassObject.hpp
@@ -259,6 +259,12 @@ public:
         return m_fields;
     }
 
+    /// Returns the field with the given 'fieldName' and 'fieldType', only considering static or instance fields
+    /// depending on 'isStatic'.
+    /// This field lookup unlike 'getFields' also considers fields in the base classes of this class.
+    /// Returns nullptr if no field was found.
+    const Field* getField(llvm::StringRef fieldName, llvm::StringRef fieldType, bool isStatic) const;
+
     /// Returns the direct interfaces implemented by this class.
     llvm::ArrayRef<const ClassObject*> getInterfaces() const
     {

--- a/tests/Execution/superclass-fields.java
+++ b/tests/Execution/superclass-fields.java
@@ -1,0 +1,26 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Other.class | FileCheck %s
+
+class Test
+{
+    public int i = 5;
+    public static int si = 7;
+
+    public static native void print(int i);
+}
+
+class Other extends Test
+{
+    public static void main(String[] args)
+    {
+        var t = new Other();
+        // CHECK: 5
+        Test.print(t.i);
+        t.i = 3;
+        // CHECK: 3
+        Test.print(t.i);
+
+        // CHECK: 7
+        Test.print(Other.si);
+    }
+}


### PR DESCRIPTION
The current implementation only ever considered fields in the immediate class, but not any of its super classes. Implementing this was trivial by just traversing the superclasses right afterwards, bottom up. Since Java only allows single inheritance there is no complicated traversal algorithm.