### PR TITLE
[codegen] Implement control flow path dependent operand stack

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -236,7 +236,7 @@ CheckOptions:
   - key: readability-identifier-naming.MethodIgnoredRegexp
     # Ignoring methods from template specializations which obviously have to match, STL style methods, some LLVM style
     # methods etc.
-    value: 'child_begin|child_end|push_back|emplace_back|insert(_.+)?|find(_.+)?|erase(_.+)?|isa(_.+)?|([a-z]+)_cast(_.+)?'
+    value: 'child_begin|child_end|push_back|pop_back|emplace_back|insert(_.+)?|find(_.+)?|erase(_.+)?|isa(_.+)?|([a-z]+)_cast(_.+)?'
   - key: readability-identifier-naming.FunctionCase
     value: camelBack
   - key: readability-identifier-naming.FunctionIgnoredRegexp

--- a/tests/Execution/control-flow-path-dependent-operand-stack.java
+++ b/tests/Execution/control-flow-path-dependent-operand-stack.java
@@ -1,0 +1,19 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+class Test {
+    public static native void print(int i);
+
+    static void square(int num) {
+        print(num < 6 ? 5 : -3);
+    }
+
+    public static void main(String[] args) {
+        //CHECK: 5
+        square(5);
+        //CHECK: 5
+        square(-1);
+        //CHECK: -3
+        square(6);
+    }
+}


### PR DESCRIPTION
This PR creates a new operand stack that also considers the control flow. This is done by getting and setting the top of stack according to basic blocks.

fixes https://github.com/JLLVM/JLLVM/issues/23