### PR TITLE
[instruction] Add support for ireturn instruction

### DIFF
--- a/src/jllvm/materialization/ByteCodeCompileLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeCompileLayer.cpp
@@ -1084,6 +1084,11 @@ void codeGenBody(llvm::Function* function, const Code& code, const ClassFile& cl
                 }
                 break;
             }
+            case OpCodes::IReturn:
+            {
+                builder.CreateRet(operandStack.pop_back(builder.getInt32Ty()));
+                break;
+            }
             case OpCodes::IStore:
             {
                 auto index = consume<std::uint8_t>(current);

--- a/tests/Execution/ireturn.java
+++ b/tests/Execution/ireturn.java
@@ -1,0 +1,25 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+class Test
+{
+    public static native void print(int i);
+
+    private static int test1()
+    {
+        return 5;
+    }
+
+    private static int test2()
+        {
+            return -3;
+        }
+
+    public static void main(String[] args)
+    {
+        // CHECK: 5
+        print(test1());
+        // CHECK: -3
+        print(test2());
+    }
+}


### PR DESCRIPTION
This PR includes support for creating appropriate LLVM instructions on processing the ireturn JVM instruction. 

fixes https://github.com/JLLVM/JLLVM/issues/39