### PR TITLE
[instruction] Add support for integer casts instructions

### DIFF
--- a/src/jllvm/main/Main.cpp
+++ b/src/jllvm/main/Main.cpp
@@ -73,7 +73,7 @@ int jllvm::main(llvm::StringRef executablePath, llvm::ArrayRef<char*> args)
             {vm.getInterner()("Java_Test_print__I"), trivialPrintFunction<std::int32_t>()},
             {vm.getInterner()("Java_Test_print__J"), trivialPrintFunction<std::int64_t>()},
             {vm.getInterner()("Java_Test_print__S"), trivialPrintFunction<std::int16_t>()},
-            {vm.getInterner()("Java_Test_print__C"), trivialPrintFunction<std::int16_t>()},
+            {vm.getInterner()("Java_Test_print__C"), trivialPrintFunction<std::uint16_t>()},
             {vm.getInterner()("Java_Test_print__Z"), trivialPrintFunction<bool>()},
         }));
     }

--- a/src/jllvm/materialization/ByteCodeCompileLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeCompileLayer.cpp
@@ -900,6 +900,42 @@ void codeGenBody(llvm::Function* function, const Code& code, const ClassFile& cl
 
                 break;
             }
+            case OpCodes::I2B:
+            {
+                llvm::Value* value = operandStack.pop_back(builder.getInt32Ty());
+                operandStack.push_back(builder.CreateIntCast(value, builder.getInt8Ty(), true));
+                break;
+            }
+            case OpCodes::I2C:
+            {
+                llvm::Value* value = operandStack.pop_back(builder.getInt32Ty());
+                operandStack.push_back(builder.CreateIntCast(value, builder.getInt16Ty(), false));
+                break;
+            }
+            case OpCodes::I2D:
+            {
+                llvm::Value* value = operandStack.pop_back(builder.getInt32Ty());
+                operandStack.push_back(builder.CreateCast(llvm::Instruction::CastOps::SIToFP, value, builder.getDoubleTy()));
+                break;
+            }
+            case OpCodes::I2F:
+            {
+                llvm::Value* value = operandStack.pop_back(builder.getInt32Ty());
+                operandStack.push_back(builder.CreateCast(llvm::Instruction::CastOps::SIToFP, value, builder.getFloatTy()));
+                break;
+            }
+            case OpCodes::I2L:
+            {
+                llvm::Value* value = operandStack.pop_back(builder.getInt32Ty());
+                operandStack.push_back(builder.CreateIntCast(value, builder.getInt64Ty(), true));
+                break;
+            }
+            case OpCodes::I2S:
+            {
+                llvm::Value* value = operandStack.pop_back(builder.getInt32Ty());
+                operandStack.push_back(builder.CreateIntCast(value, builder.getInt16Ty(), true));
+                break;
+            }
             case OpCodes::IAdd:
             {
                 llvm::Value* rhs = operandStack.pop_back(builder.getInt32Ty());
@@ -1195,7 +1231,17 @@ void codeGenBody(llvm::Function* function, const Code& code, const ClassFile& cl
                 operandStack.pop_back(referenceType(builder.getContext()));
                 break;
             }
-            case OpCodes::Return: builder.CreateRetVoid(); break;
+            case OpCodes::Return:
+            {
+                builder.CreateRetVoid();
+                break;
+            }
+            case OpCodes::SIPush:
+            {
+                auto value = consume<std::int16_t>(current);
+                operandStack.push_back(builder.getInt16(value));
+                break;
+            }
         }
     }
 }

--- a/tests/Execution/integer-casts.java
+++ b/tests/Execution/integer-casts.java
@@ -1,0 +1,62 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+class Test
+{
+    public static native void print(int i);
+    public static native void print(byte b);
+    public static native void print(char c);
+    public static native void print(short s);
+    public static native void print(float f);
+    public static native void print(double d);
+    public static native void print(long l);
+
+    public static void main(String[] args)
+    {
+        int x = 516;
+        int y = 129;
+        int z = -129;
+
+        //CHECK: 4
+        print((byte) x);
+        //CHECK: -127
+        print((byte) y);
+        //CHECK: 127
+        print((byte) z);
+
+        //CHECK: 516
+        print((char) x);
+        //CHECK: 129
+        print((char) y);
+        //CHECK: 65407
+        print((char) z);
+
+        //CHECK: 516
+        print((short) x);
+        //CHECK: 129
+        print((short) y);
+        //CHECK: -129
+        print((short) z);
+
+        //CHECK: 516
+        print((long) x);
+        //CHECK: 129
+        print((long) y);
+        //CHECK: -129
+        print((long) z);
+
+        //CHECK: 516
+        print((float) x);
+        //CHECK: 129
+        print((float) y);
+        //CHECK: -129
+        print((float) z);
+
+        //CHECK: 516
+        print((double) x);
+        //CHECK: 129
+        print((double) y);
+        //CHECK: -129
+        print((double) z);
+    }
+}


### PR DESCRIPTION
This PR includes code necessary to support casting integers to bytes, shorts, chars, longs, doubles and floats. Additionally, to ease testing, this PR includes support for the sipush instruction.

fixes https://github.com/JLLVM/JLLVM/issues/41
fixes https://github.com/JLLVM/JLLVM/issues/42