### PR TITLE
[codegen] use `zext` instead of `sext` when working with `char`

### DIFF
--- a/src/jllvm/class/Descriptors.hpp
+++ b/src/jllvm/class/Descriptors.hpp
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <llvm/ADT/StringRef.h>
+#include <llvm/Support/ErrorHandling.h>
 
 #include <memory>
 #include <variant>
@@ -12,17 +13,64 @@ namespace jllvm
 
 /// <BaseType> ::= 'B' | 'C' | 'D' | 'F' | 'I' | 'J' | 'S' | 'Z'
 /// Note: We add 'V' for void here as well for convenience.
-enum class BaseType
+class BaseType
 {
-    Byte, /// 'B'
-    Char, /// 'C'
-    Double, /// 'D'
-    Float, /// 'F'
-    Int, /// 'I'
-    Long, /// 'J'
-    Short, /// 'S'
-    Boolean, /// 'Z'
-    Void /// 'V'
+public:
+    enum Values
+    {
+        Boolean, /// 'Z'
+        Byte,    /// 'B'
+        Char,    /// 'C'
+        Short,   /// 'S'
+        Int,     /// 'I'
+        Float,   /// 'F'
+        Double,  /// 'D'
+        Long,    /// 'J'
+        Void     /// 'V'
+    };
+
+private:
+    Values m_value;
+
+public:
+    /*implicit*/ BaseType(Values value) : m_value(value) {}
+
+    /// Returns the enum value for this base type.
+    Values getValue() const
+    {
+        return m_value;
+    }
+
+    /// Returns true if this base type is an integer type.
+    bool isIntegerType() const
+    {
+        switch (m_value)
+        {
+            case Boolean:
+            case Byte:
+            case Char:
+            case Short:
+            case Int:
+            case Long:
+            default: return false;
+        }
+    }
+
+    /// Returns true if this type is unsigned. All other types are signed.
+    bool isUnsigned() const
+    {
+        return m_value == Char || m_value == Boolean;
+    }
+
+    bool operator==(const BaseType& rhs) const
+    {
+        return m_value == rhs.m_value;
+    }
+
+    bool operator!=(const BaseType& rhs) const
+    {
+        return !(rhs == *this);
+    }
 };
 
 /// <ObjectType> ::= 'L' <ClassName> ';'

--- a/src/jllvm/class/Descriptors.hpp
+++ b/src/jllvm/class/Descriptors.hpp
@@ -51,7 +51,7 @@ public:
             case Char:
             case Short:
             case Int:
-            case Long:
+            case Long: return true;
             default: return false;
         }
     }

--- a/src/jllvm/materialization/ByteCodeCompileUtils.cpp
+++ b/src/jllvm/materialization/ByteCodeCompileUtils.cpp
@@ -13,7 +13,7 @@ llvm::Type* jllvm::descriptorToType(const FieldType& type, llvm::LLVMContext& co
         type,
         [&](BaseType baseType) -> llvm::Type*
         {
-            switch (baseType)
+            switch (baseType.getValue())
             {
                 case jllvm::BaseType::Void: return llvm::Type::getVoidTy(context);
                 case BaseType::Boolean:

--- a/src/jllvm/object/ClassLoader.cpp
+++ b/src/jllvm/object/ClassLoader.cpp
@@ -166,7 +166,7 @@ jllvm::ClassObject& jllvm::ClassLoader::add(std::unique_ptr<llvm::MemoryBuffer>&
             desc,
             [](BaseType baseType) -> std::size_t
             {
-                switch (baseType)
+                switch (baseType.getValue())
                 {
                     case BaseType::Byte: return 1;
                     case BaseType::Char: return 2;

--- a/tests/Execution/integer-casts.java
+++ b/tests/Execution/integer-casts.java
@@ -32,6 +32,13 @@ class Test
         print((short) z);
 
         //CHECK: 516
+        print((char) x);
+        //CHECK: 129
+        print((char) y);
+        //CHECK: 65407
+        print((char) z);
+
+        //CHECK: 516
         print((long) x);
         //CHECK: 129
         print((long) y);

--- a/tests/Execution/less-than-int-fields.java
+++ b/tests/Execution/less-than-int-fields.java
@@ -15,6 +15,9 @@ class Test
     public static char sc = 5;
     public char c = 5;
 
+    public char nc = 65407;
+    public static char ncs = 65407;
+
     public static void main(String[] args)
     {
         var t = new Test();
@@ -25,5 +28,9 @@ class Test
         print((int)Test.sc);
         print((int)t.c);
         // CHECK-COUNT-6: 5
+
+        print((int)t.nc);
+        print((int)t.ncs);
+        // CHECK-COUNT-2: 65407
     }
 }


### PR DESCRIPTION
The original code incorrectly assumed that `char` was a signed type. The JVM spec specifies it as (the only!) unsigned type however, so doing a signed extension leads to correct and unexpected results in various places.

This PR fixes this issue in various places by checking the descriptor whether the integer type is signed or unsigned and using proper instructions accordingly.

Fixes https://github.com/JLLVM/JLLVM/issues/44