### PR TITLE
[CI] Switch clang-tidy and clang-format installations to Ubuntu repositories

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,6 +20,7 @@ jobs:
 
       - name: Install clang-tidy
         run: |
+          sudo apt-get remove libclang-common-15-dev
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh $LLVM_VERSION all

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,6 +20,7 @@ jobs:
 
       - name: Install clang-tidy
         run: |
+          sudo apt-get update
           sudo apt-get install clang-tidy-$LLVM_VERSION
 
       - name: Checkout JLLVM
@@ -96,6 +97,7 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install clang-format-$LLVM_VERSION
 
       - name: Set up Python

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,10 +20,7 @@ jobs:
 
       - name: Install clang-tidy
         run: |
-          sudo apt-get remove libclang-common-15-dev
-          wget https://apt.llvm.org/llvm.sh
-          chmod +x llvm.sh
-          sudo ./llvm.sh $LLVM_VERSION all
+          sudo apt-get install clang-tidy-$LLVM_VERSION
 
       - name: Checkout JLLVM
         uses: actions/checkout@v3
@@ -99,9 +96,7 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
-          wget https://apt.llvm.org/llvm.sh
-          chmod +x llvm.sh
-          sudo ./llvm.sh $LLVM_VERSION all
+          sudo apt-get install clang-format-$LLVM_VERSION
 
       - name: Set up Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
Recent updates to the `jammy-updates` repository seem to now provide clang 15. 
This has had the negative side effect of seemingly breaking our lint builder since it was now in conflict with the LLVM APT repository with which packages provide which files.

Fix this by just using the ubuntu packages from now on. This has the nice side effect of them being more granular and a lot faster to install