### PR TITLE
[instruction] Implement iand, ior, ineg and ixor instructions

### DIFF
--- a/src/jllvm/materialization/ByteCodeCompileLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeCompileLayer.cpp
@@ -946,6 +946,13 @@ void codeGenBody(llvm::Function* function, const Code& code, const ClassFile& cl
                 operandStack.push_back(builder.CreateAdd(lhs, rhs));
                 break;
             }
+            case OpCodes::IAnd:
+            {
+                llvm::Value* rhs = operandStack.pop_back(builder.getInt32Ty());
+                llvm::Value* lhs = operandStack.pop_back(builder.getInt32Ty());
+                operandStack.push_back(builder.CreateAnd(lhs, rhs));
+                break;
+            }
             case OpCodes::IConstM1:
             {
                 operandStack.push_back(builder.getInt32(-1));
@@ -1047,6 +1054,12 @@ void codeGenBody(llvm::Function* function, const Code& code, const ClassFile& cl
                 operandStack.push_back(builder.CreateMul(lhs, rhs));
                 break;
             }
+            case OpCodes::INeg:
+            {
+                llvm::Value* value = operandStack.pop_back(builder.getInt32Ty());
+                operandStack.push_back(builder.CreateNeg(value));
+                break;
+            }
             case OpCodes::InvokeStatic:
             case OpCodes::InvokeSpecial:
             {
@@ -1123,6 +1136,13 @@ void codeGenBody(llvm::Function* function, const Code& code, const ClassFile& cl
                 }
                 break;
             }
+            case OpCodes::IOr:
+            {
+                llvm::Value* rhs = operandStack.pop_back(builder.getInt32Ty());
+                llvm::Value* lhs = operandStack.pop_back(builder.getInt32Ty());
+                operandStack.push_back(builder.CreateOr(lhs, rhs));
+                break;
+            }
             case OpCodes::IReturn:
             {
                 builder.CreateRet(operandStack.pop_back(builder.getInt32Ty()));
@@ -1159,6 +1179,13 @@ void codeGenBody(llvm::Function* function, const Code& code, const ClassFile& cl
                 llvm::Value* rhs = operandStack.pop_back(builder.getInt32Ty());
                 llvm::Value* lhs = operandStack.pop_back(builder.getInt32Ty());
                 operandStack.push_back(builder.CreateSub(lhs, rhs));
+                break;
+            }
+            case OpCodes::IXor:
+            {
+                llvm::Value* rhs = operandStack.pop_back(builder.getInt32Ty());
+                llvm::Value* lhs = operandStack.pop_back(builder.getInt32Ty());
+                operandStack.push_back(builder.CreateXor(lhs, rhs));
                 break;
             }
             case OpCodes::LDC:

--- a/tests/Execution/iand-ior-ineg-ixor.java
+++ b/tests/Execution/iand-ior-ineg-ixor.java
@@ -1,0 +1,53 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+class Test
+{
+    public static native void print(int i);
+
+    public static void main(String[] args)
+    {
+        int x = 0;
+        int y = Integer.MIN_VALUE;
+        int z = 5;
+        int a = 3;
+        int b = 1;
+        // CHECK: 0
+        print(x & y);
+        // CHECK: 0
+        print(b & y);
+        // CHECK: -2147483648
+        print(y & y);
+        // CHECK: 1
+        print(z & a);
+
+        // CHECK: -2147483648
+        print(x | y);
+        // CHECK: -2147483647
+        print(b | y);
+        // CHECK: -2147483648
+        print(y | y);
+        // CHECK: 7
+        print(z | a);
+
+        // CHECK: -2147483648
+        print(x ^ y);
+        // CHECK: -2147483647
+        print(b ^ y);
+        // CHECK: 0
+        print(y ^ y);
+        // CHECK: 6
+        print(z ^ a);
+
+        // CHECK: 0
+        print(-x);
+        // CHECK: -2147483648
+        print(-y);
+        // CHECK: -5
+        print(-z);
+        // CHECK: -3
+        print(-a);
+        // CHECK: -1
+        print(-b);
+    }
+}


### PR DESCRIPTION
This PR includes support for creating appropriate LLVM instructions on processing the iand, ior, ineg and ixor JVM instructions.

fixes https://github.com/JLLVM/JLLVM/issues/47