### PR TITLE
[instruction] Implement int shifting instructions

### DIFF
--- a/src/jllvm/materialization/ByteCodeCompileLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeCompileLayer.cpp
@@ -1303,6 +1303,22 @@ void codeGenBody(llvm::Function* function, const Code& code, const ClassFile& cl
                 builder.CreateRet(operandStack.pop_back(builder.getInt32Ty()));
                 break;
             }
+            case OpCodes::IShl:
+            {
+                llvm::Value* rhs = operandStack.pop_back(builder.getInt32Ty());
+                llvm::Value* maskedRhs = builder.CreateAnd(rhs, builder.getInt32(0x1F)); // According to JVM only the lower 5 bits shall be considered
+                llvm::Value* lhs = operandStack.pop_back(builder.getInt32Ty());
+                operandStack.push_back(builder.CreateShl(lhs, maskedRhs));
+                break;
+            }
+            case OpCodes::IShr:
+            {
+                llvm::Value* rhs = operandStack.pop_back(builder.getInt32Ty());
+                llvm::Value* maskedRhs = builder.CreateAnd(rhs, builder.getInt32(0x1F)); // According to JVM only the lower 5 bits shall be considered
+                llvm::Value* lhs = operandStack.pop_back(builder.getInt32Ty());
+                operandStack.push_back(builder.CreateAShr(lhs, maskedRhs));
+                break;
+            }
             case OpCodes::IStore:
             {
                 auto index = consume<std::uint8_t>(current);
@@ -1334,6 +1350,14 @@ void codeGenBody(llvm::Function* function, const Code& code, const ClassFile& cl
                 llvm::Value* rhs = operandStack.pop_back(builder.getInt32Ty());
                 llvm::Value* lhs = operandStack.pop_back(builder.getInt32Ty());
                 operandStack.push_back(builder.CreateSub(lhs, rhs));
+                break;
+            }
+            case OpCodes::IUShr:
+            {
+                llvm::Value* rhs = operandStack.pop_back(builder.getInt32Ty());
+                llvm::Value* maskedRhs = builder.CreateAnd(rhs, builder.getInt32(0x1F)); // According to JVM only the lower 5 bits shall be considered
+                llvm::Value* lhs = operandStack.pop_back(builder.getInt32Ty());
+                operandStack.push_back(builder.CreateLShr(lhs, maskedRhs));
                 break;
             }
             case OpCodes::IXor:

--- a/tests/Execution/int-shifts.java
+++ b/tests/Execution/int-shifts.java
@@ -1,0 +1,35 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+class Test
+{
+    public static native void print(int i);
+
+    public static void main(String[] args)
+    {
+        int x = 5;
+        int y = 2;
+        int z = -1;
+
+        //CHECK: 20
+        print(x << y);
+        //CHECK: 64
+        print(y << x);
+        //CHECK: -4
+        print(z << y);
+
+        //CHECK: 1
+        print(x >> y);
+        //CHECK: 0
+        print(y >> x);
+        //CHECK: -1
+        print(z >> y);
+
+        //CHECK: 1
+        print(x >>> y);
+        //CHECK: 0
+        print(y >>> x);
+        //CHECK: 1073741823
+        print(z >>> y);
+    }
+}


### PR DESCRIPTION
This PR includes support for creating appropriate LLVM instructions on processing the ishl, ishr and iushr JVM instructions.

fixes https://github.com/JLLVM/JLLVM/issues/51