### PR TITLE
[instruction] Implement `instanceof`

### DIFF
--- a/src/jllvm/object/ClassObject.hpp
+++ b/src/jllvm/object/ClassObject.hpp
@@ -366,6 +366,17 @@ public:
         return m_componentTypeAndIsPrimitive.getInt();
     }
 
+    /// Returns true if this class object represents a Java class.
+    /// This does not include array types or interfaces.
+    bool isClass() const
+    {
+        return !isArray() && !isPrimitive() && !isInterface();
+    }
+
+    /// Returns true if an instance of this class object would also be an instance of 'other'.
+    /// Not valid for class objects representing interfaces.
+    bool wouldBeInstanceOf(const ClassObject* other) const;
+
     /// Byte offset from the start of the class object to the start of the VTable.
     constexpr static std::size_t getVTableOffset()
     {

--- a/src/jllvm/object/Object.cpp
+++ b/src/jllvm/object/Object.cpp
@@ -1,1 +1,8 @@
 #include "Object.hpp"
+
+#include "ClassObject.hpp"
+
+bool jllvm::ObjectInterface::instanceOf(const ClassObject* classObject) const
+{
+    return getClass()->wouldBeInstanceOf(classObject);
+}

--- a/src/jllvm/object/Object.hpp
+++ b/src/jllvm/object/Object.hpp
@@ -35,6 +35,20 @@ public:
     {
         return *reinterpret_cast<ObjectHeader*>(this);
     }
+
+    const ObjectHeader& getObjectHeader() const
+    {
+        return *reinterpret_cast<const ObjectHeader*>(this);
+    }
+
+    /// Returns true if this object is an instance of 'classObject'.
+    bool instanceOf(const ClassObject* classObject) const;
+
+    /// Returns the class object of this java object.
+    const ClassObject* getClass() const
+    {
+        return getObjectHeader().classObject;
+    }
 };
 
 class Object;

--- a/src/jllvm/vm/JIT.cpp
+++ b/src/jllvm/vm/JIT.cpp
@@ -60,6 +60,11 @@ jllvm::JIT::JIT(std::unique_ptr<llvm::orc::ExecutionSession>&& session,
     llvm::cantFail(m_main.define(createLambdaMaterializationUnit(
         "jllvm_gc_alloc", m_optimizeLayer, [&](std::uint32_t size) { return m_gc.allocate(size); }, m_dataLayout,
         m_interner)));
+    llvm::cantFail(m_main.define(llvm::orc::absoluteSymbols(
+        {{m_interner("jllvm_instance_of"), llvm::JITEvaluatedSymbol::fromPointer(
+                                               +[](const Object* object, const ClassObject* classObject) -> std::int32_t {
+                                                   return object->instanceOf(classObject);
+                                               })}})));
 }
 
 jllvm::JIT jllvm::JIT::create(ClassLoader& classLoader, GarbageCollector& gc, void* jniFunctions)

--- a/tests/Execution/instanceof.java
+++ b/tests/Execution/instanceof.java
@@ -1,0 +1,69 @@
+// RUN: rm -rf %t && split-file %s %t
+// RUN: cd %t && javac %t/Test.java -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+//--- Test.java
+
+class Test
+{
+    public static native void print(int i);
+
+    public static void main(String[] args)
+    {
+        Object o = null;
+
+        // CHECK: 0
+        print(o instanceof Object ? 1 : 0);
+
+        var array = new Test[1];
+
+        // CHECK: 1
+        print(array instanceof Test[] ? 1 : 0);
+
+        // CHECK: 1
+        print(array instanceof Object[] ? 1 : 0);
+
+        // CHECK: 1
+        print(array instanceof Object ? 1 : 0);
+
+        // CHECK: 0
+        print(((Object)array) instanceof Test[][] ? 1 : 0);
+
+        B c = new C();
+
+        // CHECK: 1
+        print(c instanceof A ? 1 : 0);
+
+        // CHECK: 1
+        print(c instanceof B ? 1 : 0);
+
+        // CHECK: 1
+        print(c instanceof C ? 1 : 0);
+
+        // CHECK: 1
+        print(c instanceof Object ? 1 : 0);
+
+        // TODO: test array of primitive types once creating those is implemented.
+    }
+}
+
+//--- A.java
+
+public interface A
+{
+
+}
+
+//--- B.java
+
+public interface B extends A
+{
+
+}
+
+//--- C.java
+
+public class C implements B
+{
+
+}


### PR DESCRIPTION
This is a rather simple implementation of the op specified here https://docs.oracle.com/javase/specs/jvms/se17/html/jvms-6.html#jvms-6.5.instanceof.

I opted to implement it in C++ instead of LLVM IR because a lot of the supporting infrastructure already existed for things like iterating over all interfaces etc.

Fixes https://github.com/JLLVM/JLLVM/issues/55

Depends on https://github.com/JLLVM/JLLVM/pull/56 within the tests