### PR TITLE
[object][NFC] Add convenient iterator over superclasses

### DIFF
--- a/src/jllvm/materialization/ByteCodeCompileLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeCompileLayer.cpp
@@ -329,23 +329,21 @@ public:
         return returnConstantForClassObject(builder, fieldDescriptor, methodName + ";" + typeDescriptor,
                                             [=](const ClassObject* classObject)
                                             {
-                                                const Method* iter;
-                                                do
+                                                for (const ClassObject* curr : classObject->getSuperClasses())
                                                 {
-                                                    llvm::ArrayRef<Method> methods = classObject->getMethods();
-                                                   iter =
+                                                    llvm::ArrayRef<Method> methods = curr->getMethods();
+                                                    const Method* iter =
                                                         llvm::find_if(methods,
                                                                       [&](const Method& method) {
                                                                           return !method.isStatic()
                                                                                  && method.getName() == methodName
                                                                                  && method.getType() == typeDescriptor;
                                                                       });
-                                                   if (iter != methods.end())
-                                                   {
-                                                       return *iter->getVTableSlot();
-                                                   }
-                                                    classObject = classObject->getSuperClass();
-                                                } while (classObject != nullptr);
+                                                    if (iter != methods.end())
+                                                    {
+                                                        return *iter->getVTableSlot();
+                                                    }
+                                                }
                                                 llvm_unreachable("method not found");
                                             });
     }

--- a/src/jllvm/object/ClassLoader.cpp
+++ b/src/jllvm/object/ClassLoader.cpp
@@ -25,16 +25,18 @@ VTableAssignment assignVTableSlots(const jllvm::ClassFile& classFile, const jllv
     using namespace jllvm;
 
     llvm::DenseMap<std::pair<llvm::StringRef, llvm::StringRef>, std::pair<std::uint16_t, const Method*>> map;
-    while (superClass)
+    if (superClass)
     {
-        for (const Method& iter : superClass->getMethods())
+        for (const jllvm::ClassObject* curr : superClass->getSuperClasses())
         {
-            if (auto slot = iter.getVTableSlot())
+            for (const Method& iter : curr->getMethods())
             {
-                map.insert({{iter.getName(), iter.getType()}, {*slot, &iter}});
+                if (auto slot = iter.getVTableSlot())
+                {
+                    map.insert({{iter.getName(), iter.getType()}, {*slot, &iter}});
+                }
             }
         }
-        superClass = superClass->getSuperClass();
     }
     std::uint16_t vTableCount = 0;
     if (!map.empty())

--- a/src/jllvm/object/ClassObject.cpp
+++ b/src/jllvm/object/ClassObject.cpp
@@ -83,13 +83,11 @@ jllvm::ClassObject::ClassObject(std::uint32_t instanceSize, llvm::StringRef name
 const jllvm::Field* jllvm::ClassObject::getField(llvm::StringRef fieldName, llvm::StringRef fieldType,
                                                  bool isStatic) const
 {
-    for (const ClassObject* curr = this; curr; curr = curr->getSuperClass())
+    for (const ClassObject* curr : getSuperClasses())
     {
-        const Field* iter = llvm::find_if(curr->getFields(),
-                                          [&](const Field& field) {
-                                              return field.isStatic() == isStatic && field.getName() == fieldName
-                                                     && field.getType() == fieldType;
-                                          });
+        const Field* iter = llvm::find_if(
+            curr->getFields(), [&](const Field& field)
+            { return field.isStatic() == isStatic && field.getName() == fieldName && field.getType() == fieldType; });
         if (iter != curr->getFields().end())
         {
             return iter;

--- a/src/jllvm/object/ClassObject.cpp
+++ b/src/jllvm/object/ClassObject.cpp
@@ -167,13 +167,5 @@ bool jllvm::ClassObject::wouldBeInstanceOf(const ClassObject* other) const
     {
         return llvm::is_contained(getAllInterfaces(), other);
     }
-
-    for (const ClassObject* curr = getSuperClass(); curr; curr = curr->getSuperClass())
-    {
-        if (other == curr)
-        {
-            return true;
-        }
-    }
-    return false;
+    return llvm::is_contained(getSuperClasses(), other);
 }

--- a/src/jllvm/vm/VirtualMachine.cpp
+++ b/src/jllvm/vm/VirtualMachine.cpp
@@ -36,17 +36,12 @@ llvm::StringRef classOfMethodResolution(const jllvm::ClassObject* classObject, c
     // https://docs.oracle.com/javase/specs/jvms/se17/html/jvms-5.html#jvms-5.4.6 Step 2.
 
     // If C contains a declaration of an instance method m that can override mR (§5.4.5), then m is the selected method.
-    if (llvm::any_of(classObject->getMethods(), [&](const jllvm::Method& method)
-                     { return !method.isStatic() && canOverride(method, interfaceMethod); }))
-    {
-        return classObject->getClassName();
-    }
 
     // Otherwise, if C has a superclass, a search for a declaration of an instance method that can override mR is
     // performed, starting with the direct superclass of C and continuing with the direct superclass of that class, and
     // so forth, until a method is found or no further superclasses exist. If a method is found, it is the selected
     // method.
-    for (const jllvm::ClassObject* curr = classObject->getSuperClass(); curr; curr = curr->getSuperClass())
+    for (const jllvm::ClassObject* curr : classObject->getSuperClasses())
     {
         if (llvm::any_of(curr->getMethods(), [&](const jllvm::Method& method)
                          { return !method.isStatic() && canOverride(method, interfaceMethod); }))
@@ -110,7 +105,7 @@ jllvm::VirtualMachine::VirtualMachine(std::vector<std::string>&& classPath)
                 return;
             }
 
-            for (const ClassObject* curr = classObject; curr; curr = curr->getSuperClass())
+            for (const ClassObject* curr : classObject->getSuperClasses())
             {
                 for (const Method& iter : curr->getMethods())
                 {


### PR DESCRIPTION
The codebase has a lot of loops traversing through the superclasses of a class object. By adding this iterator and the convenient `getSuperClasses` method we can use very nice ranged `for` loops and the various algorithms in C++s `<algorithm>` header (and similar functions in LLVM).