### PR TITLE
[instruction] Add support for `fconst` instructions (#4)

### DIFF
--- a/src/jllvm/main/Main.cpp
+++ b/src/jllvm/main/Main.cpp
@@ -12,6 +12,7 @@ namespace
 template <class T>
 auto trivialPrintFunction()
 {
+    // TODO: change for floating types
     return [](void*, void*, T value) { llvm::outs() << static_cast<std::ptrdiff_t>(value) << '\n'; };
 }
 

--- a/src/jllvm/materialization/ByteCodeCompileLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeCompileLayer.cpp
@@ -943,9 +943,21 @@ void codeGenBody(llvm::Function* function, const Code& code, const ClassFile& cl
             // TODO: FAStore
             // TODO: FCmpG
             // TODO: FCmpL
-            // TODO: FConst0
-            // TODO: FConst1
-            // TODO: FConst2
+            case OpCodes::FConst0:
+            {
+                operandStack.push_back(llvm::ConstantFP::get(builder.getFloatTy(), 0.0));
+                break;
+            }
+            case OpCodes::FConst1:
+            {
+                operandStack.push_back(llvm::ConstantFP::get(builder.getFloatTy(), 1.0));
+                break;
+            }
+            case OpCodes::FConst2:
+            {
+                operandStack.push_back(llvm::ConstantFP::get(builder.getFloatTy(), 2.0));
+                break;
+            }
             // TODO: FDiv
             // TODO: FLoad
             // TODO: FLoad0

--- a/tests/Execution/jni-primitives.java
+++ b/tests/Execution/jni-primitives.java
@@ -4,10 +4,13 @@
 class Test
 {
     public static native void print(byte i);
-    public static native void print(short i);
     public static native void print(char i);
+    public static native void print(double i);
+    public static native void print(float i);
     public static native void print(int i);
     public static native void print(long i);
+    public static native void print(short i);
+    public static native void print(boolean i);
 
     public static void main(String[] args)
     {
@@ -25,8 +28,18 @@ class Test
         // Java char does not support assignment from negative values
         char c = 5;
         print(5);
+
+        print(true);
+
+        print(0.0f);
+        print(1.0f);
+        print(2.0f);
     }
 }
 
 // CHECK-COUNT-3: -1
 // CHECK: 5
+// CHECK: 1
+// CHECK: 0
+// CHECK: 1
+// CHECK: 2


### PR DESCRIPTION
This PR includes support for creating appropriate LLVM instructions on processing the `fconst` JVM instructions.

TODO:
* Change the native jni-methods do print floats correctly. Currently not implemented because `llvm::raw_ostream` does not work  `std ` stream manipulators and the default formatting in always in scientific notation.