### PR TITLE
[instruction] Add support for `lcd` instruction for constant floats (#7) 

### DIFF
--- a/src/jllvm/main/Main.cpp
+++ b/src/jllvm/main/Main.cpp
@@ -5,6 +5,8 @@
 
 #include <jllvm/vm/VirtualMachine.hpp>
 
+#include <sstream>
+
 #include "CommandLine.hpp"
 
 namespace
@@ -12,8 +14,19 @@ namespace
 template <class T>
 auto trivialPrintFunction()
 {
-    // TODO: change for floating types
-    return [](void*, void*, T value) { llvm::outs() << static_cast<std::ptrdiff_t>(value) << '\n'; };
+    return [](void*, void*, T value)
+    {
+        if constexpr (std::is_floating_point_v<T>)
+        {
+            std::stringstream str;
+            str << std::defaultfloat << value << '\n';
+            llvm::outs() << str.str();
+        }
+        else
+        {
+            llvm::outs() << static_cast<std::ptrdiff_t>(value) << '\n';
+        }
+    };
 }
 
 template <>

--- a/src/jllvm/materialization/ByteCodeCompileLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeCompileLayer.cpp
@@ -1642,6 +1642,8 @@ void codeGenBody(llvm::Function* function, const Code& code, const ClassFile& cl
                     pool.resolve(classFile),
                     [&](const IntegerInfo* integerInfo)
                     { operandStack.push_back(builder.getInt32(integerInfo->value)); },
+                    [&](const FloatInfo* floatInfo)
+                    { operandStack.push_back(llvm::ConstantFP::get(builder.getFloatTy(), floatInfo->value)); },
                     [&](const StringInfo* stringInfo)
                     {
                         llvm::StringRef text = stringInfo->stringValue.resolve(classFile)->text;

--- a/src/jllvm/materialization/ByteCodeCompileLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeCompileLayer.cpp
@@ -378,7 +378,7 @@ public:
                 // set, method lookup succeeds.
 
                 // Otherwise, if the maximally-specific superinterface methods (§5.4.3.3) of C for the name and
-                // descriptor specified by the method reference include exactly one method that does not have its
+                // descriptor specified by the method reference to include exactly one method that does not have its
                 // ACC_ABSTRACT flag set, then this method is chosen and method lookup succeeds.
                 for (const jllvm::ClassObject* interface : classObject->maximallySpecificInterfaces())
                 {

--- a/src/jllvm/materialization/ByteCodeCompileLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeCompileLayer.cpp
@@ -378,7 +378,7 @@ public:
                 // set, method lookup succeeds.
 
                 // Otherwise, if the maximally-specific superinterface methods (§5.4.3.3) of C for the name and
-                // descriptor specified by the method reference to include exactly one method that does not have its
+                // descriptor specified by the method reference include exactly one method that does not have its
                 // ACC_ABSTRACT flag set, then this method is chosen and method lookup succeeds.
                 for (const jllvm::ClassObject* interface : classObject->maximallySpecificInterfaces())
                 {

--- a/src/jllvm/support/Bytes.hpp
+++ b/src/jllvm/support/Bytes.hpp
@@ -1,4 +1,3 @@
-
 #pragma once
 
 #include <llvm/ADT/ArrayRef.h>
@@ -21,11 +20,14 @@ T consume(llvm::ArrayRef<char>& bytes)
     assert(bytes.size() >= sizeof(T));
     std::conditional_t<sizeof(T) <= 2, std::conditional_t<sizeof(T) <= 1, std::uint8_t, std::uint16_t>,
                        std::conditional_t<(sizeof(T) > 4), std::uint64_t, std::uint32_t>>
-        result;
-    std::memcpy(&result, bytes.data(), sizeof(T));
+        asBytes;
+    std::memcpy(&asBytes, bytes.data(), sizeof(T));
     bytes = bytes.drop_front(sizeof(T));
-    result = llvm::support::endian::byte_swap(result, llvm::support::big);
-    return T(result);
+    asBytes = llvm::support::endian::byte_swap(asBytes, llvm::support::big);
+
+    T result;
+    std::memcpy(&result, &asBytes, sizeof(T));
+    return result;
 }
 
 /// Reads in 'length' amount of bytes from 'bytes', returns it as a 'StringRef' and advanced 'bytes' by the amount of

--- a/tests/Execution/fload-fstore.java
+++ b/tests/Execution/fload-fstore.java
@@ -14,8 +14,8 @@ class Test
         var f0 = 0.0f;
         var f1 = 1.0f;
         var f2 = 2.0f;
-        var f3 = 3.0f;
-        var f4 = 4.0f;
+        var f3 = 123.456f;
+        var f4 = -987.654f;
 
         // CHECK: 0
         print(f0);
@@ -23,9 +23,9 @@ class Test
         print(f1);
         // CHECK: 2
         print(f2);
-        // CHECK: 3
+        // CHECK: 123.456
         print(f3);
-        // CHECK: 4
+        // CHECK: -987.654
         print(f4);
     }
 }

--- a/tests/Execution/fload-fstore.java
+++ b/tests/Execution/fload-fstore.java
@@ -14,8 +14,8 @@ class Test
         var f0 = 0.0f;
         var f1 = 1.0f;
         var f2 = 2.0f;
-        var f3 = 0.0f;
-        var f4 = 1.0f;
+        var f3 = 3.0f;
+        var f4 = 4.0f;
 
         // CHECK: 0
         print(f0);
@@ -23,9 +23,9 @@ class Test
         print(f1);
         // CHECK: 2
         print(f2);
-        // CHECK: 0
+        // CHECK: 3
         print(f3);
-        // CHECK: 1
+        // CHECK: 4
         print(f4);
     }
 }


### PR DESCRIPTION
This PR includes support for creating appropriate LLVM instructions for the `lcd` instruction for constant floats of the JVM.
It also fixes a bug, where consume constructed the required type with the given bytes instead of creating it.
Additionally it adds correct formatting for floating point types to `trivialPrintFunction`.