### PR TITLE
[instruction] Add support for `if_acmp` instructions (#63)

### DIFF
--- a/src/jllvm/vm/StringInterner.cpp
+++ b/src/jllvm/vm/StringInterner.cpp
@@ -54,7 +54,7 @@ jllvm::String* jllvm::StringInterner::createString(llvm::ArrayRef<std::uint8_t> 
     auto* string = new (m_allocator.Allocate(sizeof(String), alignof(String)))
         String(getStringClassObject(), value, static_cast<std::uint8_t>(encoding));
 
-    m_contentToStringMap.insert({{buffer, static_cast<std::uint8_t>(encoding)}, string});
+    m_contentToStringMap.insert({{{value->begin(), value->end()}, static_cast<std::uint8_t>(encoding)}, string});
 
     return string;
 }

--- a/tests/Execution/integer-comparisons.java
+++ b/tests/Execution/integer-comparisons.java
@@ -250,5 +250,45 @@ class Test
         {
             print(0);
         }
+
+        //ifacmpeq
+        //CHECK: 1
+        if ("a" != "b")
+        {
+            print(1);
+        }
+        else
+        {
+            print(0);
+        }
+        //CHECK: 0
+        if ("a" != "a")
+        {
+            print(1);
+        }
+        else
+        {
+            print(0);
+        }
+
+        //ifacmpne
+        //CHECK: 1
+        if ("a" == "a")
+        {
+            print(1);
+        }
+        else
+        {
+            print(0);
+        }
+        //CHECK: 0
+        if ("a" == "b")
+        {
+            print(1);
+        }
+        else
+        {
+            print(0);
+        }
     }
 }

--- a/tests/Execution/string-literals.java
+++ b/tests/Execution/string-literals.java
@@ -16,8 +16,8 @@ class Test
         // CHECK: Java == ♨
         print("Java == ♨");
 
-        // TODO: does not currently work, because if_acmpne is either not implemented or not implemented correctly
-        /* var hello2 = "Hello World";
-        print(hello1 == hello2); */
+        // CHECK: 1
+        var hello2 = "Hello World";
+        print(hello1 == hello2);
     }
 }


### PR DESCRIPTION
This PR includes support for creating appropriate LLVM instructions on processing the `if_acmpeq` and `if_acmpeq`  JVM instructions.
It also fixes a bug, where `buffer` in `createString` could reference arrays which could later be dealocated resulting in invalid data being inserted into `createString`. (rust would have caught this)