### PR TITLE
[instruction] Add support for `freturn` instruction

### DIFF
--- a/src/jllvm/materialization/ByteCodeCompileLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeCompileLayer.cpp
@@ -996,7 +996,11 @@ void codeGenBody(llvm::Function* function, const Code& code, const ClassFile& cl
             // TODO: FMul
             // TODO: FNeg
             // TODO: FRem
-            // TODO: FReturn
+            case OpCodes::FReturn:
+            {
+                builder.CreateRet(operandStack.pop_back(builder.getFloatTy()));
+                break;
+            }
             case OpCodes::FStore:
             {
                 auto index = consume<std::uint8_t>(current);

--- a/tests/Execution/fload-fstore.java
+++ b/tests/Execution/fload-fstore.java
@@ -14,8 +14,8 @@ class Test
         var f0 = 0.0f;
         var f1 = 1.0f;
         var f2 = 2.0f;
-        var f3 = 123.456f;
-        var f4 = -987.654f;
+        var f3 = f123();
+        var f4 = fm987();
 
         // CHECK: 0
         print(f0);
@@ -27,5 +27,15 @@ class Test
         print(f3);
         // CHECK: -987.654
         print(f4);
+    }
+
+    public static float f123()
+    {
+        return 123.456f;
+    }
+
+    public static float fm987()
+    {
+        return -987.654f;
     }
 }


### PR DESCRIPTION
This PR includes support for creating appropriate LLVM instructions on processing the `freturn` JVM instruction.