### PR TITLE
[cmake] fix warnings on macOS about weak symbol visibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,21 @@ add_definitions(${LLVM_DEFINITIONS})
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
+include(CheckCXXCompilerFlag)
+
+# Matching LLVMs visibility option here. Mismatch of visibility can cause linker warnings on macOS.
+if ((NOT (${CMAKE_SYSTEM_NAME} MATCHES "AIX")) AND
+(NOT (WIN32 OR CYGWIN) OR (MINGW AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")))
+    # GCC for MinGW does nothing about -fvisibility-inlines-hidden, but warns
+    # about use of the attributes. As long as we don't use the attributes (to
+    # override the default) we shouldn't set the command line options either.
+    # GCC on AIX warns if -fvisibility-inlines-hidden is used and Clang on AIX doesn't currently support visibility.
+    check_cxx_compiler_flag("-fvisibility-inlines-hidden" SUPPORTS_FVISIBILITY_INLINES_HIDDEN_FLAG)
+    if (SUPPORTS_FVISIBILITY_INLINES_HIDDEN_FLAG)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility-inlines-hidden")
+    endif ()
+endif ()
+
 add_subdirectory(src)
 add_subdirectory(tools)
 


### PR DESCRIPTION
See "Build JLLVM" step in https://github.com/JLLVM/JLLVM/actions/runs/5025014536/jobs/9011439566 

The linker is currently emitting a huge amount of warnings due to differing symbol visibility. The simple reason is that LLVMs cmake files build using `-fvisibility-inlines-hidden` but we don't. This just replicates LLVMs logic for when to use the flag to avoid warnings (https://github.com/llvm/llvm-project/blob/c9e3840c832d4c3fbbf57f0a8c90ae3d80af8913/llvm/cmake/modules/HandleLLVMOptions.cmake#L368).