### PR TITLE
[instruction] Add support for float arithmetic instructions (#4)

### DIFF
--- a/src/jllvm/materialization/ByteCodeCompileLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeCompileLayer.cpp
@@ -946,7 +946,13 @@ void codeGenBody(llvm::Function* function, const Code& code, const ClassFile& cl
             // TODO: F2D
             // TODO: F2I
             // TODO: F2L
-            // TODO: FAdd
+            case OpCodes::FAdd:
+            {
+                llvm::Value* rhs = operandStack.pop_back(builder.getFloatTy());
+                llvm::Value* lhs = operandStack.pop_back(builder.getFloatTy());
+                operandStack.push_back(builder.CreateFAdd(lhs, rhs));
+                break;
+            }
             // TODO: FALoad
             // TODO: FAStore
             // TODO: FCmpG
@@ -966,7 +972,13 @@ void codeGenBody(llvm::Function* function, const Code& code, const ClassFile& cl
                 operandStack.push_back(llvm::ConstantFP::get(builder.getFloatTy(), 2.0));
                 break;
             }
-            // TODO: FDiv
+            case OpCodes::FDiv:
+            {
+                llvm::Value* rhs = operandStack.pop_back(builder.getFloatTy());
+                llvm::Value* lhs = operandStack.pop_back(builder.getFloatTy());
+                operandStack.push_back(builder.CreateFDiv(lhs, rhs));
+                break;
+            }
             case OpCodes::FLoad:
             {
                 auto index = consume<std::uint8_t>(current);
@@ -993,9 +1005,26 @@ void codeGenBody(llvm::Function* function, const Code& code, const ClassFile& cl
                 operandStack.push_back(builder.CreateLoad(builder.getFloatTy(), locals[3]));
                 break;
             }
-            // TODO: FMul
-            // TODO: FNeg
-            // TODO: FRem
+            case OpCodes::FMul:
+            {
+                llvm::Value* rhs = operandStack.pop_back(builder.getFloatTy());
+                llvm::Value* lhs = operandStack.pop_back(builder.getFloatTy());
+                operandStack.push_back(builder.CreateFMul(lhs, rhs));
+                break;
+            }
+            case OpCodes::FNeg:
+            {
+                llvm::Value* value = operandStack.pop_back(builder.getFloatTy());
+                operandStack.push_back(builder.CreateFNeg(value));
+                break;
+            }
+            case OpCodes::FRem:
+            {
+                llvm::Value* rhs = operandStack.pop_back(builder.getFloatTy());
+                llvm::Value* lhs = operandStack.pop_back(builder.getFloatTy());
+                operandStack.push_back(builder.CreateFRem(lhs, rhs));
+                break;
+            }
             case OpCodes::FReturn:
             {
                 builder.CreateRet(operandStack.pop_back(builder.getFloatTy()));
@@ -1027,7 +1056,13 @@ void codeGenBody(llvm::Function* function, const Code& code, const ClassFile& cl
                 builder.CreateStore(operandStack.pop_back(builder.getFloatTy()), locals[3]);
                 break;
             }
-            // TODO: FSub
+            case OpCodes::FSub:
+            {
+                llvm::Value* rhs = operandStack.pop_back(builder.getFloatTy());
+                llvm::Value* lhs = operandStack.pop_back(builder.getFloatTy());
+                operandStack.push_back(builder.CreateFSub(lhs, rhs));
+                break;
+            }
             case OpCodes::GetField:
             {
                 const auto* refInfo = consume<PoolIndex<FieldRefInfo>>(current).resolve(classFile);

--- a/src/jllvm/vm/JIT.cpp
+++ b/src/jllvm/vm/JIT.cpp
@@ -67,7 +67,7 @@ jllvm::JIT::JIT(std::unique_ptr<llvm::orc::ExecutionSession>&& session,
                                                +[](const Object* object, const ClassObject* classObject) -> std::int32_t
                                                { return object->instanceOf(classObject); })},
          {m_interner("fmodf"),
-          llvm::JITEvaluatedSymbol::fromPointer(fmodf)}})));
+          llvm::JITEvaluatedSymbol::fromPointer(std::fmodf)}})));
 }
 
 jllvm::JIT jllvm::JIT::create(ClassLoader& classLoader, GarbageCollector& gc, StringInterner& stringInterner,

--- a/src/jllvm/vm/JIT.cpp
+++ b/src/jllvm/vm/JIT.cpp
@@ -65,7 +65,9 @@ jllvm::JIT::JIT(std::unique_ptr<llvm::orc::ExecutionSession>&& session,
     llvm::cantFail(m_main.define(llvm::orc::absoluteSymbols(
         {{m_interner("jllvm_instance_of"), llvm::JITEvaluatedSymbol::fromPointer(
                                                +[](const Object* object, const ClassObject* classObject) -> std::int32_t
-                                               { return object->instanceOf(classObject); })}})));
+                                               { return object->instanceOf(classObject); })},
+         {m_interner("fmodf"),
+          llvm::JITEvaluatedSymbol::fromPointer(fmodf)}})));
 }
 
 jllvm::JIT jllvm::JIT::create(ClassLoader& classLoader, GarbageCollector& gc, StringInterner& stringInterner,

--- a/tests/Execution/fadd.java
+++ b/tests/Execution/fadd.java
@@ -1,0 +1,69 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+class Test
+{
+    public static native void print(float f);
+
+    public static void main(String[] args)
+    {
+        var nan = Float.NaN;
+        var p_inf = Float.POSITIVE_INFINITY;
+        var n_inf = Float.NEGATIVE_INFINITY;
+        var p_zero = 0.0f;
+        var n_zero = -0.0f;
+        var p_123 = 123.456f;
+        var n_123 = -123.456f;
+
+        // CHECK: nan
+        // CHECK: nan
+        print(nan + 1);
+        print(1 + nan);
+
+        // CHECK: nan
+        // CHECK: nan
+        print(p_inf + n_inf);
+        print(n_inf + p_inf);
+
+        // CHECK: inf
+        // CHECK: -inf
+        print(p_inf + p_inf);
+        print(n_inf + n_inf);
+
+        // CHECK: inf
+        // CHECK: -inf
+        print(p_inf + 1);
+        print(n_inf + 1);
+
+        // CHECK: 0
+        // CHECK: 0
+        print(p_zero + n_zero);
+        print(n_zero + p_zero);
+
+        // CHECK: 0
+        // CHECK: -0
+        print(p_zero + p_zero);
+        print(n_zero + n_zero);
+
+        // CHECK: 123.456
+        // CHECK: 123.456
+        print(p_zero + p_123);
+        print(n_zero + p_123);
+
+        // CHECK: 0
+        // CHECK: 0
+        print(p_123 + n_123);
+        print(n_123 + p_123);
+
+        var x = -6.6057786f;
+        var y = 1549700.4f;
+        var z = -2.1339336E8f;
+
+        // CHECK: 1.54969e+06
+        print(x + y);
+        // CHECK: -2.13393e+08
+        print(x + z);
+        // CHECK: -2.11844e+08
+        print(y + z);
+    }
+}

--- a/tests/Execution/fdiv.java
+++ b/tests/Execution/fdiv.java
@@ -1,0 +1,62 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+class Test
+{
+    public static native void print(float f);
+
+    public static void main(String[] args)
+    {
+        var nan = Float.NaN;
+        var p_inf = Float.POSITIVE_INFINITY;
+        var n_inf = Float.NEGATIVE_INFINITY;
+        var p_zero = 0.0f;
+        var n_zero = -0.0f;
+
+        // CHECK: nan
+        // CHECK: nan
+        print(nan / 2);
+        print(2 / nan);
+
+        // CHECK: nan
+        // CHECK: nan
+        print(p_inf / n_inf);
+        print(n_inf / p_inf);
+
+        // CHECK: inf
+        // CHECK: -inf
+        print(p_inf / 2);
+        print(n_inf / 2);
+
+        // CHECK: 0
+        // CHECK: -0
+        print(2 / p_inf);
+        print(2 / n_inf);
+
+        // CHECK: nan
+        // CHECK: nan
+        print(p_zero / n_zero);
+        print(n_zero / p_zero);
+
+        // CHECK: 0
+        // CHECK: -0
+        print(p_zero / 2);
+        print(n_zero / 2);
+
+        // CHECK: inf
+        // CHECK: -inf
+        print(2 / p_zero);
+        print(2 / n_zero);
+
+        var x = -4.4639528E7f;
+        var y = 1.26373286E9f;
+        var z = -238.710592f;
+
+        // CHECK: -0.0353235
+        print(x / y);
+        // CHECK: 187003
+        print(x / z);
+        // CHECK: -5.294e+06
+        print(y / z);
+    }
+}

--- a/tests/Execution/fmul.java
+++ b/tests/Execution/fmul.java
@@ -1,0 +1,54 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+class Test
+{
+    public static native void print(float f);
+
+    public static void main(String[] args)
+    {
+        var nan = Float.NaN;
+        var p_inf = Float.POSITIVE_INFINITY;
+        var n_inf = Float.NEGATIVE_INFINITY;
+        var p_zero = 0.0f;
+        var n_zero = -0.0f;
+        var p_123 = 123.456f;
+        var n_123 = -123.456f;
+
+        // CHECK: nan
+        // CHECK: nan
+        print(nan * p_123);
+        print(p_123 * nan);
+
+        // CHECK: 15241.4
+        // CHECK: 15241.4
+        print(p_123 * p_123);
+        print(n_123 * n_123);
+
+        // CHECK: -15241.4
+        // CHECK: -15241.4
+        print(p_123 * n_123);
+        print(n_123 * p_123);
+
+        // CHECK: nan
+        // CHECK: nan
+        print(p_inf * p_zero);
+        print(n_inf * n_zero);
+
+        // CHECK: inf
+        // CHECK: -inf
+        print(p_inf * p_123);
+        print(n_inf * p_123);
+
+        var x = 6.7671592E7f;
+        var y = -4.09644288E8f;
+        var z = 1374.04144f;
+
+        // CHECK: -2.77213e+16
+        print(x * y);
+        // CHECK: 9.29836e+10
+        print(x * z);
+        // CHECK: -5.62868e+11
+        print(y * z);
+    }
+}

--- a/tests/Execution/fneg.java
+++ b/tests/Execution/fneg.java
@@ -1,0 +1,47 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+class Test
+{
+    public static native void print(float f);
+
+    public static void main(String[] args)
+    {
+        var nan = Float.NaN;
+        var p_inf = Float.POSITIVE_INFINITY;
+        var n_inf = Float.NEGATIVE_INFINITY;
+        var p_zero = 0.0f;
+        var n_zero = -0.0f;
+        var p_123 = 123.456f;
+        var n_123 = -123.456f;
+
+        // CHECK: nan
+        print(-nan);
+
+        // CHECK: -inf
+        // CHECK: inf
+        print(-p_inf);
+        print(-n_inf);
+
+        // CHECK: -0
+        // CHECK: 0
+        print(-p_zero);
+        print(-n_zero);
+
+        // CHECK: -123.456
+        // CHECK: 123.456
+        print(-p_123);
+        print(-n_123);
+
+        var x = 1.06639384E8f;
+        var y = -5.4427053E8f;
+        var z = -4.29113472f;
+
+        // CHECK: -1.06639e+08
+        print(-x);
+        // CHECK: 5.44271e+08
+        print(-y);
+        // CHECK: 4.29113
+        print(-z);
+    }
+}

--- a/tests/Execution/frem.java
+++ b/tests/Execution/frem.java
@@ -1,0 +1,59 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+class Test
+{
+    public static native void print(float f);
+
+    public static void main(String[] args)
+    {
+        var nan = Float.NaN;
+        var p_inf = Float.POSITIVE_INFINITY;
+        var n_inf = Float.NEGATIVE_INFINITY;
+        var p_zero = 0.0f;
+        var n_zero = -0.0f;
+        var p_123 = 123.456f;
+        var n_123 = -123.456f;
+
+        // CHECK: nan
+        // CHECK: nan
+        print(nan % p_123);
+        print(n_123 % nan);
+
+        // CHECK: 0.456001
+        // CHECK: -0.456001
+        print(p_123 % 3);
+        print(n_123 % 3);
+
+        // CHECK: nan
+        // CHECK: nan
+        print(p_inf % 3);
+        print(n_inf % 3);
+
+        // CHECK: nan
+        // CHECK: nan
+        print(p_123 % p_zero);
+        print(p_123 % n_zero);
+
+        // CHECK: 123.456
+        // CHECK: 123.456
+        print(p_123 % p_inf);
+        print(p_123 % n_inf);
+
+        // CHECK: 0
+        // CHECK: -0
+        print(p_zero % p_123);
+        print(n_zero % p_123);
+
+        var x = 3.52095328E9f;
+        var y = -5.9460864E8f;
+        var z = 1425.10118f;
+
+        // CHECK: 5.4791e+08
+        print(x % y);
+        // CHECK: 1421.57
+        print(x % z);
+        // CHECK: -841.962
+        print(y % z);
+    }
+}

--- a/tests/Execution/fsub.java
+++ b/tests/Execution/fsub.java
@@ -1,0 +1,74 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+class Test
+{
+    public static native void print(float f);
+
+    public static void main(String[] args)
+    {
+        var nan = Float.NaN;
+        var p_inf = Float.POSITIVE_INFINITY;
+        var n_inf = Float.NEGATIVE_INFINITY;
+        var p_zero = 0.0f;
+        var n_zero = -0.0f;
+        var p_123 = 123.456f;
+        var n_123 = -123.456f;
+
+        // CHECK: nan
+        // CHECK: nan
+        print(nan - 1);
+        print(1 - nan);
+
+        // CHECK: inf
+        // CHECK: -inf
+        print(p_inf - n_inf);
+        print(n_inf - p_inf);
+
+        // CHECK: nan
+        // CHECK: nan
+        print(p_inf - p_inf);
+        print(n_inf - n_inf);
+
+        // CHECK: inf
+        // CHECK: -inf
+        print(p_inf - 1);
+        print(n_inf - 1);
+
+        // CHECK: -inf
+        // CHECK: inf
+        print(1 - p_inf);
+        print(1 - n_inf);
+
+        // CHECK: 0
+        // CHECK: -0
+        print(p_zero - n_zero);
+        print(n_zero - p_zero);
+
+        // CHECK: 0
+        // CHECK: 0
+        print(p_zero - p_zero);
+        print(n_zero - n_zero);
+
+        // CHECK: -123.456
+        // CHECK: -123.456
+        print(p_zero - p_123);
+        print(n_zero - p_123);
+
+        // CHECK: 246.912
+        // CHECK: -246.912
+        print(p_123 - n_123);
+        print(n_123 - p_123);
+
+        var x = 1.83799936E8f;
+        var y = -1.09827904E9f;
+        var z = 1.1562734E7f;
+
+        // CHECK: 1.28208e+09
+        print(x - y);
+        // CHECK: 1.72237e+08
+        print(x - z);
+        // CHECK: -1.10984e+09
+        print(y - z);
+    }
+}


### PR DESCRIPTION
This PR includes support for creating appropriate LLVM instructions on processing the `fadd`, `fdiv`, `fmul`, `fneg`, `frem` and `fsub` JVM instructions.