### PR TITLE
[object][instruction] Make `ClassObject` a proper Java object

### DIFF
--- a/src/jllvm/materialization/ByteCodeCompileLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeCompileLayer.cpp
@@ -1696,6 +1696,20 @@ void codeGenBody(llvm::Function* function, const Code& code, const ClassFile& cl
                             builder.CreateIntToPtr(builder.getInt64(reinterpret_cast<std::uint64_t>(string)),
                                                    referenceType(builder.getContext())));
                     },
+                    [&](const ClassInfo* classInfo)
+                    {
+                        llvm::StringRef text = classInfo->nameIndex.resolve(classFile)->text;
+                        llvm::Value* classObject;
+                        if (text.front() == '[')
+                        {
+                            classObject = helper.getClassObject(builder, text);
+                        }
+                        else
+                        {
+                            classObject = helper.getClassObject(builder, "L" + text + ";");
+                        }
+                        operandStack.push_back(classObject);
+                    },
                     [](const auto*) { llvm::report_fatal_error("Not yet implemented"); });
 
                 break;

--- a/src/jllvm/object/ClassLoader.hpp
+++ b/src/jllvm/object/ClassLoader.hpp
@@ -44,6 +44,8 @@ class ClassLoader
     ClassObject m_boolean{sizeof(bool), "Z"};
     ClassObject m_void{0, "V"};
 
+    ClassObject* m_metaClassObject = nullptr;
+
     void initialize(ClassObject& classObject)
     {
         if (!m_uninitialized.contains(&classObject))
@@ -91,6 +93,12 @@ public:
     /// Returns the class object for 'fieldDescriptor', which must be a valid field descriptor,
     /// if it has been loaded previously. Null otherwise.
     ClassObject* forNameLoaded(llvm::Twine fieldDescriptor);
+
+    /// Loads java classes required to boot up the VM. This a separate method and not executed as part of the
+    /// constructor as it requires the VM to already be ready to execute JVM Bytecode (one that does not depend on the
+    /// bootstrap classes) and to have at the very least initialized the builtin native methods of the bootstrap
+    /// classes.
+    void loadBootstrapClasses();
 };
 
 } // namespace jllvm

--- a/src/jllvm/object/ClassObject.cpp
+++ b/src/jllvm/object/ClassObject.cpp
@@ -13,9 +13,9 @@ auto arrayRefAlloc(llvm::BumpPtrAllocator& allocator, const Range& ref)
 }
 } // namespace
 
-jllvm::ClassObject* jllvm::ClassObject::create(llvm::BumpPtrAllocator& allocator, std::size_t vTableSlots,
-                                               std::uint32_t fieldAreaSize, llvm::ArrayRef<Method> methods,
-                                               llvm::ArrayRef<Field> fields,
+jllvm::ClassObject* jllvm::ClassObject::create(llvm::BumpPtrAllocator& allocator, const ClassObject* metaClass,
+                                               std::size_t vTableSlots, std::uint32_t fieldAreaSize,
+                                               llvm::ArrayRef<Method> methods, llvm::ArrayRef<Field> fields,
                                                llvm::ArrayRef<const ClassObject*> interfaces, llvm::StringRef className,
                                                const jllvm::ClassObject* superClass)
 {
@@ -34,18 +34,19 @@ jllvm::ClassObject* jllvm::ClassObject::create(llvm::BumpPtrAllocator& allocator
 
     auto* result =
         new (allocator.Allocate(ClassObject::totalSizeToAlloc<VTableSlot>(vTableSlots), alignof(ClassObject)))
-            ClassObject(fieldAreaSize, arrayRefAlloc(allocator, methods), arrayRefAlloc(allocator, fields),
+            ClassObject(metaClass, fieldAreaSize, arrayRefAlloc(allocator, methods), arrayRefAlloc(allocator, fields),
                         arrayRefAlloc(allocator, interfaces), arrayRefAlloc(allocator, iTables), className, superClass);
     // Zero out vTable.
     std::memset(result->getVTable(), 0, vTableSlots * sizeof(VTableSlot));
     return result;
 }
 
-jllvm::ClassObject::ClassObject(std::int32_t fieldAreaSize, llvm::ArrayRef<Method> methods,
-                                llvm::ArrayRef<Field> fields, llvm::ArrayRef<const ClassObject*> interfaces,
-                                llvm::ArrayRef<ITable*> iTables, llvm::StringRef className,
-                                const jllvm::ClassObject* superClass)
-    : m_fieldAreaSize(fieldAreaSize),
+jllvm::ClassObject::ClassObject(const ClassObject* metaClass, std::int32_t fieldAreaSize,
+                                llvm::ArrayRef<Method> methods, llvm::ArrayRef<Field> fields,
+                                llvm::ArrayRef<const ClassObject*> interfaces, llvm::ArrayRef<ITable*> iTables,
+                                llvm::StringRef className, const jllvm::ClassObject* superClass)
+    : m_objectHeader(metaClass),
+      m_fieldAreaSize(fieldAreaSize),
       m_methods(methods),
       m_fields(fields),
       m_interfaces(interfaces),
@@ -55,8 +56,8 @@ jllvm::ClassObject::ClassObject(std::int32_t fieldAreaSize, llvm::ArrayRef<Metho
 {
 }
 
-jllvm::ClassObject* jllvm::ClassObject::createArray(llvm::BumpPtrAllocator& allocator, const ClassObject* componentType,
-                                                    llvm::StringSaver& stringSaver)
+jllvm::ClassObject* jllvm::ClassObject::createArray(llvm::BumpPtrAllocator& allocator, const ClassObject* metaClass,
+                                                    const ClassObject* componentType, llvm::StringSaver& stringSaver)
 {
     std::uint32_t arrayFieldAreaSize = sizeof(std::uint32_t);
     // Account for padding inbetween 'length' and the elements after.
@@ -69,16 +70,16 @@ jllvm::ClassObject* jllvm::ClassObject::createArray(llvm::BumpPtrAllocator& allo
         arrayFieldAreaSize = llvm::alignTo(arrayFieldAreaSize, sizeof(void*));
     }
 
-    auto* result = create(allocator, 0, arrayFieldAreaSize, {}, {}, {},
+    auto* result = create(allocator, metaClass, 0, arrayFieldAreaSize, {}, {}, {},
                           stringSaver.save("[L" + componentType->getClassName() + ";"), nullptr);
-    result->m_componentTypeAndIsPrimitive.setPointer(componentType);
+    result->m_componentType = componentType;
     return result;
 }
 
 jllvm::ClassObject::ClassObject(std::uint32_t instanceSize, llvm::StringRef name)
-    : ClassObject(instanceSize - sizeof(void*), {}, {}, {}, {}, name, nullptr)
+    : ClassObject(nullptr, instanceSize - sizeof(void*), {}, {}, {}, {}, name, nullptr)
 {
-    m_componentTypeAndIsPrimitive.setInt(true);
+    m_isPrimitive = true;
 }
 
 const jllvm::Field* jllvm::ClassObject::getField(llvm::StringRef fieldName, llvm::StringRef fieldType,
@@ -97,9 +98,11 @@ const jllvm::Field* jllvm::ClassObject::getField(llvm::StringRef fieldName, llvm
     return nullptr;
 }
 
-jllvm::ClassObject::ClassObject(std::size_t interfaceId, llvm::ArrayRef<Method> methods, llvm::ArrayRef<Field> fields,
-                                llvm::ArrayRef<const ClassObject*> interfaces, llvm::StringRef className)
-    : m_fieldAreaSize(0),
+jllvm::ClassObject::ClassObject(const ClassObject* metaClass, std::size_t interfaceId, llvm::ArrayRef<Method> methods,
+                                llvm::ArrayRef<Field> fields, llvm::ArrayRef<const ClassObject*> interfaces,
+                                llvm::StringRef className)
+    : m_objectHeader(metaClass),
+      m_fieldAreaSize(0),
       m_methods(methods),
       m_fields(fields),
       m_interfaces(interfaces),
@@ -108,13 +111,14 @@ jllvm::ClassObject::ClassObject(std::size_t interfaceId, llvm::ArrayRef<Method> 
 {
 }
 
-jllvm::ClassObject* jllvm::ClassObject::createInterface(llvm::BumpPtrAllocator& allocator, std::size_t interfaceId,
-                                                        llvm::ArrayRef<Method> methods, llvm::ArrayRef<Field> fields,
+jllvm::ClassObject* jllvm::ClassObject::createInterface(llvm::BumpPtrAllocator& allocator, const ClassObject* metaClass,
+                                                        std::size_t interfaceId, llvm::ArrayRef<Method> methods,
+                                                        llvm::ArrayRef<Field> fields,
                                                         llvm::ArrayRef<const ClassObject*> interfaces,
                                                         llvm::StringRef className)
 {
     return new (allocator.Allocate<ClassObject>())
-        ClassObject(interfaceId, arrayRefAlloc(allocator, methods), arrayRefAlloc(allocator, fields),
+        ClassObject(metaClass, interfaceId, arrayRefAlloc(allocator, methods), arrayRefAlloc(allocator, fields),
                     arrayRefAlloc(allocator, interfaces), className);
 }
 

--- a/src/jllvm/object/ClassObject.cpp
+++ b/src/jllvm/object/ClassObject.cpp
@@ -79,7 +79,7 @@ jllvm::ClassObject* jllvm::ClassObject::createArray(llvm::BumpPtrAllocator& allo
 jllvm::ClassObject::ClassObject(std::uint32_t instanceSize, llvm::StringRef name)
     : ClassObject(nullptr, instanceSize - sizeof(void*), {}, {}, {}, {}, name, nullptr)
 {
-    m_isPrimitive = true;
+    m_isPrimitive = true; // NOLINT(*-prefer-member-initializer): https://github.com/llvm/llvm-project/issues/52818
 }
 
 const jllvm::Field* jllvm::ClassObject::getField(llvm::StringRef fieldName, llvm::StringRef fieldType,

--- a/src/jllvm/vm/NativeImplementation.cpp
+++ b/src/jllvm/vm/NativeImplementation.cpp
@@ -7,5 +7,5 @@ jllvm::VirtualMachine& jllvm::detail::virtualMachineFromJNIEnv(JNIEnv* env)
 
 void jllvm::registerJavaClasses(VirtualMachine& virtualMachine)
 {
-    addModel<ObjectModel>(virtualMachine);
+    addModels<ObjectModel, ClassModel>(virtualMachine);
 }

--- a/src/jllvm/vm/VirtualMachine.cpp
+++ b/src/jllvm/vm/VirtualMachine.cpp
@@ -161,6 +161,8 @@ jllvm::VirtualMachine::VirtualMachine(std::vector<std::string>&& classPath)
       m_hashIntDistrib(1, std::numeric_limits<std::uint32_t>::max())
 {
     registerJavaClasses(*this);
+
+    m_classLoader.loadBootstrapClasses();
 }
 
 int jllvm::VirtualMachine::executeMain(llvm::StringRef path, llvm::ArrayRef<llvm::StringRef> args)

--- a/tests/Execution/class-object-as-java-object.java
+++ b/tests/Execution/class-object-as-java-object.java
@@ -1,0 +1,24 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+class Test
+{
+    public static native void print(int i);
+
+    public static void main(String[] args)
+    {
+        var clazz = Object.class.getClass();
+        // CHECK: 1
+        print(clazz == clazz.getClass() ? 1 : 0);
+
+        var array = Object[].class;
+        // CHECK: 1
+        print(array.isArray() ? 1 : 0);
+        // CHECK: 1
+        print(array.getComponentType() == Object.class ? 1 : 0);
+
+        var o = new Object();
+        // CHECK: 1
+        print(o.getClass() == Object.class ? 1 : 0);
+    }
+}

--- a/tests/Execution/class-object-as-java-object.java
+++ b/tests/Execution/class-object-as-java-object.java
@@ -3,22 +3,22 @@
 
 class Test
 {
-    public static native void print(int i);
+    public static native void print(boolean i);
 
     public static void main(String[] args)
     {
         var clazz = Object.class.getClass();
         // CHECK: 1
-        print(clazz == clazz.getClass() ? 1 : 0);
+        print(clazz == clazz.getClass());
 
         var array = Object[].class;
         // CHECK: 1
-        print(array.isArray() ? 1 : 0);
+        print(array.isArray());
         // CHECK: 1
-        print(array.getComponentType() == Object.class ? 1 : 0);
+        print(array.getComponentType() == Object.class);
 
         var o = new Object();
         // CHECK: 1
-        print(o.getClass() == Object.class ? 1 : 0);
+        print(o.getClass() == Object.class);
     }
 }


### PR DESCRIPTION
`Class` is Java's most fundamental mechanism for reflection and very important to its execution model. We additionally utilize it as RTTI object and owner of V and ITables. These have so far been in an internal format however which was incompatible with the `Class` shipped with OpenJDK.

This patch fixes that by making it a proper java object and synchronizing its field layout with OpenJDK. The largest complexity in the patch is actually a change to the class loader. Since `Class` is also its own class object, a special "bootstrap load sequence" has to be done in the class loader on startup. Some of the fields from OpenJDK are likely to require special initialization by the VM that is currently not yet done and left as future exercise once required.

Additionally, because testing would be difficult without it, `ldc` for class objects was implemented and a few of the `native` methods of `Class` and `Object` for very basic testing.

It is expected that more tests with finer grained testing of various methods and aspects in `Class` will be added in the future on a per need basis.

Fixes https://github.com/JLLVM/JLLVM/issues/7 and https://github.com/JLLVM/JLLVM/issues/8