### PR TITLE
[instruction] Add support for float array instructions (#4)

### DIFF
--- a/src/jllvm/materialization/ByteCodeCompileLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeCompileLayer.cpp
@@ -953,8 +953,29 @@ void codeGenBody(llvm::Function* function, const Code& code, const ClassFile& cl
                 operandStack.push_back(builder.CreateFAdd(lhs, rhs));
                 break;
             }
-            // TODO: FALoad
-            // TODO: FAStore
+            case OpCodes::FALoad:
+            {
+                llvm::Value* index = operandStack.pop_back(builder.getInt32Ty());
+                llvm::Value* array = operandStack.pop_back(referenceType(builder.getContext()));
+
+                auto* gep = builder.CreateGEP(arrayStructType(builder.getFloatTy()), array,
+                                              {builder.getInt32(0), builder.getInt32(2), index});
+
+                operandStack.push_back(builder.CreateLoad(builder.getFloatTy(), gep));
+                break;
+            }
+            case OpCodes::FAStore:
+            {
+                llvm::Value* value = operandStack.pop_back(builder.getFloatTy());
+                llvm::Value* index = operandStack.pop_back(builder.getInt32Ty());
+                llvm::Value* array = operandStack.pop_back(referenceType(builder.getContext()));
+
+                auto* gep = builder.CreateGEP(arrayStructType(builder.getFloatTy()), array,
+                                              {builder.getInt32(0), builder.getInt32(2), index});
+                builder.CreateStore(value, gep);
+
+                break;
+            }
             case OpCodes::FCmpG:
             case OpCodes::FCmpL:
             {

--- a/src/jllvm/materialization/ByteCodeCompileLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeCompileLayer.cpp
@@ -956,8 +956,10 @@ void codeGenBody(llvm::Function* function, const Code& code, const ClassFile& cl
             case OpCodes::FALoad:
             {
                 llvm::Value* index = operandStack.pop_back(builder.getInt32Ty());
+                // TODO: throw NullPointerException if array is null
                 llvm::Value* array = operandStack.pop_back(referenceType(builder.getContext()));
 
+                // TODO: throw ArrayIndexOutOfBoundsException if index is not within the bounds
                 auto* gep = builder.CreateGEP(arrayStructType(builder.getFloatTy()), array,
                                               {builder.getInt32(0), builder.getInt32(2), index});
 
@@ -968,8 +970,10 @@ void codeGenBody(llvm::Function* function, const Code& code, const ClassFile& cl
             {
                 llvm::Value* value = operandStack.pop_back(builder.getFloatTy());
                 llvm::Value* index = operandStack.pop_back(builder.getInt32Ty());
+                // TODO: throw NullPointerException if array is null
                 llvm::Value* array = operandStack.pop_back(referenceType(builder.getContext()));
 
+                // TODO: throw ArrayIndexOutOfBoundsException if index is not within the bounds
                 auto* gep = builder.CreateGEP(arrayStructType(builder.getFloatTy()), array,
                                               {builder.getInt32(0), builder.getInt32(2), index});
                 builder.CreateStore(value, gep);
@@ -1231,8 +1235,10 @@ void codeGenBody(llvm::Function* function, const Code& code, const ClassFile& cl
             case OpCodes::IALoad:
             {
                 llvm::Value* index = operandStack.pop_back(builder.getInt32Ty());
+                // TODO: throw NullPointerException if array is null
                 llvm::Value* array = operandStack.pop_back(referenceType(builder.getContext()));
 
+                // TODO: throw ArrayIndexOutOfBoundsException if index is not within the bounds
                 auto* gep = builder.CreateGEP(arrayStructType(builder.getInt32Ty()), array,
                                               {builder.getInt32(0), builder.getInt32(2), index});
                 operandStack.push_back(builder.CreateLoad(builder.getInt32Ty(), gep));
@@ -1249,8 +1255,10 @@ void codeGenBody(llvm::Function* function, const Code& code, const ClassFile& cl
             {
                 llvm::Value* value = operandStack.pop_back(builder.getInt32Ty());
                 llvm::Value* index = operandStack.pop_back(builder.getInt32Ty());
+                // TODO: throw NullPointerException if array is null
                 llvm::Value* array = operandStack.pop_back(referenceType(builder.getContext()));
 
+                // TODO: throw ArrayIndexOutOfBoundsException if index is not within the bounds
                 auto* gep = builder.CreateGEP(arrayStructType(builder.getInt32Ty()), array,
                                               {builder.getInt32(0), builder.getInt32(2), index});
                 builder.CreateStore(value, gep);

--- a/tests/Execution/faload-fastore.java
+++ b/tests/Execution/faload-fastore.java
@@ -1,0 +1,27 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+class Test
+{
+    public static native void print(float f);
+
+    public static void main(String[] args)
+    {
+        var nan = Float.NaN;
+        var p_inf = Float.POSITIVE_INFINITY;
+        var n_zero = -0.0f;
+        var p_123 = 123.456f;
+
+        float[] arr = {nan, p_inf, n_zero, p_123};
+        // CHECK: nan
+        print(arr[0]);
+        // CHECK: inf
+        print(arr[1]);
+        // CHECK: -0
+        print(arr[2]);
+        // CHECK: 123.456
+        print(arr[3]);
+        // CHECK: 4
+        print(arr.length);
+    }
+}


### PR DESCRIPTION
This PR includes support for creating appropriate LLVM instructions on processing the `faload` and `fastore` JVM instructions.

TODOs:
* Implement throwing `NullPointerException` if arrayref is null
* Implement throwing  `ArrayIndexOutOfBoundsException` if index is not within the bounds