### PR TITLE
[codegen] fix false positives when creating basic blocks

### DIFF
--- a/src/jllvm/class/ByteCodeIterator.cpp
+++ b/src/jllvm/class/ByteCodeIterator.cpp
@@ -1,0 +1,240 @@
+#include "ByteCodeIterator.hpp"
+
+#include <llvm/Support/Alignment.h>
+#include <llvm/Support/Endian.h>
+
+std::size_t jllvm::ByteCodeIterator::currentOpSize() const
+{
+    switch (static_cast<OpCodes>(*m_current))
+    {
+        case OpCodes::AALoad:
+        case OpCodes::AAStore:
+        case OpCodes::AConstNull:
+        case OpCodes::ALoad0:
+        case OpCodes::ALoad1:
+        case OpCodes::ALoad2:
+        case OpCodes::ALoad3:
+        case OpCodes::AReturn:
+        case OpCodes::ArrayLength:
+        case OpCodes::AStore0:
+        case OpCodes::AStore1:
+        case OpCodes::AStore2:
+        case OpCodes::AStore3:
+        case OpCodes::AThrow:
+        case OpCodes::BALoad:
+        case OpCodes::BAStore:
+        case OpCodes::CALoad:
+        case OpCodes::CAStore:
+        case OpCodes::D2F:
+        case OpCodes::D2I:
+        case OpCodes::D2L:
+        case OpCodes::DAdd:
+        case OpCodes::DALoad:
+        case OpCodes::DAStore:
+        case OpCodes::DCmpG:
+        case OpCodes::DCmpL:
+        case OpCodes::DConst0:
+        case OpCodes::DConst1:
+        case OpCodes::DDiv:
+        case OpCodes::DLoad0:
+        case OpCodes::DLoad1:
+        case OpCodes::DLoad2:
+        case OpCodes::DLoad3:
+        case OpCodes::DMul:
+        case OpCodes::DNeg:
+        case OpCodes::DRem:
+        case OpCodes::DReturn:
+        case OpCodes::DStore0:
+        case OpCodes::DStore1:
+        case OpCodes::DStore2:
+        case OpCodes::DStore3:
+        case OpCodes::DSub:
+        case OpCodes::Dup:
+        case OpCodes::DupX1:
+        case OpCodes::DupX2:
+        case OpCodes::Dup2:
+        case OpCodes::Dup2X1:
+        case OpCodes::Dup2X2:
+        case OpCodes::F2D:
+        case OpCodes::F2I:
+        case OpCodes::F2L:
+        case OpCodes::FAdd:
+        case OpCodes::FALoad:
+        case OpCodes::FAStore:
+        case OpCodes::FCmpG:
+        case OpCodes::FCmpL:
+        case OpCodes::FConst0:
+        case OpCodes::FConst1:
+        case OpCodes::FConst2:
+        case OpCodes::FDiv:
+        case OpCodes::FLoad0:
+        case OpCodes::FLoad1:
+        case OpCodes::FLoad2:
+        case OpCodes::FLoad3:
+        case OpCodes::FMul:
+        case OpCodes::FNeg:
+        case OpCodes::FRem:
+        case OpCodes::FReturn:
+        case OpCodes::FStore0:
+        case OpCodes::FStore1:
+        case OpCodes::FStore2:
+        case OpCodes::FStore3:
+        case OpCodes::FSub:
+        case OpCodes::I2B:
+        case OpCodes::I2C:
+        case OpCodes::I2D:
+        case OpCodes::I2F:
+        case OpCodes::I2L:
+        case OpCodes::I2S:
+        case OpCodes::IAdd:
+        case OpCodes::IALoad:
+        case OpCodes::IAnd:
+        case OpCodes::IAStore:
+        case OpCodes::IConstM1:
+        case OpCodes::IConst0:
+        case OpCodes::IConst1:
+        case OpCodes::IConst2:
+        case OpCodes::IConst3:
+        case OpCodes::IConst4:
+        case OpCodes::IConst5:
+        case OpCodes::IDiv:
+        case OpCodes::ILoad0:
+        case OpCodes::ILoad1:
+        case OpCodes::ILoad2:
+        case OpCodes::ILoad3:
+        case OpCodes::IMul:
+        case OpCodes::INeg:
+        case OpCodes::IOr:
+        case OpCodes::IRem:
+        case OpCodes::IReturn:
+        case OpCodes::IShl:
+        case OpCodes::IShr:
+        case OpCodes::IStore0:
+        case OpCodes::IStore1:
+        case OpCodes::IStore2:
+        case OpCodes::IStore3:
+        case OpCodes::ISub:
+        case OpCodes::IUShr:
+        case OpCodes::IXor:
+        case OpCodes::L2D:
+        case OpCodes::L2F:
+        case OpCodes::L2I:
+        case OpCodes::LAdd:
+        case OpCodes::LALoad:
+        case OpCodes::LAnd:
+        case OpCodes::LAStore:
+        case OpCodes::LCmp:
+        case OpCodes::LConst0:
+        case OpCodes::LConst1:
+        case OpCodes::LDiv:
+        case OpCodes::LLoad0:
+        case OpCodes::LLoad1:
+        case OpCodes::LLoad2:
+        case OpCodes::LLoad3:
+        case OpCodes::LMul:
+        case OpCodes::LNeg:
+        case OpCodes::LOr:
+        case OpCodes::LRem:
+        case OpCodes::LReturn:
+        case OpCodes::LShl:
+        case OpCodes::LShr:
+        case OpCodes::LStore0:
+        case OpCodes::LStore1:
+        case OpCodes::LStore2:
+        case OpCodes::LStore3:
+        case OpCodes::LSub:
+        case OpCodes::LUShr:
+        case OpCodes::LXor:
+        case OpCodes::MonitorEnter:
+        case OpCodes::MonitorExit:
+        case OpCodes::Nop:
+        case OpCodes::Pop:
+        case OpCodes::Pop2:
+        case OpCodes::Return:
+        case OpCodes::SALoad:
+        case OpCodes::SAStore:
+        case OpCodes::Swap: return 1;
+        case OpCodes::ALoad:
+        case OpCodes::AStore:
+        case OpCodes::BIPush:
+        case OpCodes::DLoad:
+        case OpCodes::DStore:
+        case OpCodes::FLoad:
+        case OpCodes::FStore:
+        case OpCodes::ILoad:
+        case OpCodes::IStore:
+        case OpCodes::LDC:
+        case OpCodes::LLoad:
+        case OpCodes::LStore:
+        case OpCodes::NewArray:
+        case OpCodes::Ret: return 2;
+
+        case OpCodes::ANewArray:
+        case OpCodes::CheckCast:
+        case OpCodes::GetField:
+        case OpCodes::GetStatic:
+        case OpCodes::Goto:
+        case OpCodes::IfACmpEq:
+        case OpCodes::IfACmpNe:
+        case OpCodes::IfICmpEq:
+        case OpCodes::IfICmpNe:
+        case OpCodes::IfICmpLt:
+        case OpCodes::IfICmpGe:
+        case OpCodes::IfICmpGt:
+        case OpCodes::IfICmpLe:
+        case OpCodes::IfEq:
+        case OpCodes::IfNe:
+        case OpCodes::IfLt:
+        case OpCodes::IfGe:
+        case OpCodes::IfGt:
+        case OpCodes::IfLe:
+        case OpCodes::IfNonNull:
+        case OpCodes::IfNull:
+        case OpCodes::IInc:
+        case OpCodes::InstanceOf:
+        case OpCodes::InvokeSpecial:
+        case OpCodes::InvokeStatic:
+        case OpCodes::InvokeVirtual:
+        case OpCodes::JSR:
+        case OpCodes::LDCW:
+        case OpCodes::LDC2W:
+        case OpCodes::New:
+        case OpCodes::PutField:
+        case OpCodes::PutStatic:
+        case OpCodes::SIPush: return 3;
+
+        case OpCodes::GotoW:
+        case OpCodes::InvokeDynamic:
+        case OpCodes::InvokeInterface:
+        case OpCodes::JSRw: return 5;
+
+        case OpCodes::LookupSwitch:
+        {
+            std::uint64_t padding = llvm::offsetToAlignedAddr(m_current + 1, llvm::Align(4));
+            const char* pairCountPtr = m_current + 5 + padding;
+            std::uint32_t pairCount;
+            std::memcpy(&pairCount, pairCountPtr, sizeof(std::uint32_t));
+            pairCount = llvm::support::endian::byte_swap(pairCount, llvm::support::big);
+            return 1 + padding + 4 + 8 * pairCount;
+        }
+
+        case OpCodes::MultiANewArray: return 4;
+
+        case OpCodes::TableSwitch:
+        {
+            std::uint64_t padding = llvm::offsetToAlignedAddr(m_current + 1, llvm::Align(4));
+            const char* padded = m_current + 5 + padding;
+            std::uint32_t lowByte;
+            std::memcpy(&lowByte, padded, sizeof(std::uint32_t));
+            lowByte = llvm::support::endian::byte_swap(lowByte, llvm::support::big);
+            padded += sizeof(std::uint32_t);
+            std::uint32_t highByte;
+            std::memcpy(&highByte, padded, sizeof(std::uint32_t));
+            highByte = llvm::support::endian::byte_swap(highByte, llvm::support::big);
+
+            return 1 + padding + 4 + 4 + 4 + (highByte - lowByte + 1) * 4;
+        }
+        case OpCodes::Wide: return static_cast<OpCodes>(m_current[1]) == OpCodes::IInc ? 6 : 4;
+    }
+    llvm_unreachable("Unknown opcode");
+}

--- a/src/jllvm/class/ByteCodeIterator.hpp
+++ b/src/jllvm/class/ByteCodeIterator.hpp
@@ -1,0 +1,271 @@
+
+#pragma once
+
+#include <llvm/ADT/ArrayRef.h>
+#include <llvm/ADT/iterator.h>
+
+#include <cstdint>
+
+namespace jllvm
+{
+/// All JVM OpCodes that exist in version 17 with their identifying byte values.
+/// https://docs.oracle.com/javase/specs/jvms/se17/html/jvms-6.html
+enum class OpCodes : std::uint8_t
+{
+    AALoad = 0x32,
+    AAStore = 0x53,
+    AConstNull = 0x1,
+    ALoad = 0x19,
+    ALoad0 = 0x2a,
+    ALoad1 = 0x2b,
+    ALoad2 = 0x2c,
+    ALoad3 = 0x2d,
+    ANewArray = 0xbd,
+    AReturn = 0xb0,
+    ArrayLength = 0xbe,
+    AStore = 0x3a,
+    AStore0 = 0x4b,
+    AStore1 = 0x4c,
+    AStore2 = 0x4d,
+    AStore3 = 0x4e,
+    AThrow = 0xbf,
+    BALoad = 0x33,
+    BAStore = 0x54,
+    BIPush = 0x10,
+    CALoad = 0x34,
+    CAStore = 0x55,
+    CheckCast = 0xc0,
+    D2F = 0x90,
+    D2I = 0x8e,
+    D2L = 0x8f,
+    DAdd = 0x63,
+    DALoad = 0x31,
+    DAStore = 0x52,
+    DCmpG = 0x98,
+    DCmpL = 0x97,
+    DConst0 = 0xe,
+    DConst1 = 0xf,
+    DDiv = 0x6f,
+    DLoad = 0x18,
+    DLoad0 = 0x26,
+    DLoad1 = 0x27,
+    DLoad2 = 0x28,
+    DLoad3 = 0x29,
+    DMul = 0x6b,
+    DNeg = 0x77,
+    DRem = 0x73,
+    DReturn = 0xaf,
+    DStore = 0x39,
+    DStore0 = 0x47,
+    DStore1 = 0x48,
+    DStore2 = 0x49,
+    DStore3 = 0x4a,
+    DSub = 0x67,
+    Dup = 0x59,
+    DupX1 = 0x5a,
+    DupX2 = 0x5b,
+    Dup2 = 0x5c,
+    Dup2X1 = 0x5d,
+    Dup2X2 = 0x5e,
+    F2D = 0x8d,
+    F2I = 0x8b,
+    F2L = 0x8c,
+    FAdd = 0x62,
+    FALoad = 0x30,
+    FAStore = 0x51,
+    FCmpG = 0x96,
+    FCmpL = 0x95,
+    FConst0 = 0xb,
+    FConst1 = 0xc,
+    FConst2 = 0xd,
+    FDiv = 0x6e,
+    FLoad = 0x17,
+    FLoad0 = 0x22,
+    FLoad1 = 0x23,
+    FLoad2 = 0x24,
+    FLoad3 = 0x25,
+    FMul = 0x6a,
+    FNeg = 0x76,
+    FRem = 0x72,
+    FReturn = 0xae,
+    FStore = 0x38,
+    FStore0 = 0x43,
+    FStore1 = 0x44,
+    FStore2 = 0x45,
+    FStore3 = 0x46,
+    FSub = 0x66,
+    GetField = 0xb4,
+    GetStatic = 0xb2,
+    Goto = 0xa7,
+    GotoW = 0xc8,
+    I2B = 0x91,
+    I2C = 0x92,
+    I2D = 0x87,
+    I2F = 0x86,
+    I2L = 0x85,
+    I2S = 0x93,
+    IAdd = 0x60,
+    IALoad = 0x2e,
+    IAnd = 0x7e,
+    IAStore = 0x4f,
+    IConstM1 = 0x2,
+    IConst0 = 0x3,
+    IConst1 = 0x4,
+    IConst2 = 0x5,
+    IConst3 = 0x6,
+    IConst4 = 0x7,
+    IConst5 = 0x8,
+    IDiv = 0x6c,
+    IfACmpEq = 0xa5,
+    IfACmpNe = 0xa6,
+    IfICmpEq = 0x9f,
+    IfICmpNe = 0xa0,
+    IfICmpLt = 0xa1,
+    IfICmpGe = 0xa2,
+    IfICmpGt = 0xa3,
+    IfICmpLe = 0xa4,
+    IfEq = 0x99,
+    IfNe = 0x9a,
+    IfLt = 0x9b,
+    IfGe = 0x9c,
+    IfGt = 0x9d,
+    IfLe = 0x9e,
+    IfNonNull = 0xc7,
+    IfNull = 0xc6,
+    IInc = 0x84,
+    ILoad = 0x15,
+    ILoad0 = 0x1a,
+    ILoad1 = 0x1b,
+    ILoad2 = 0x1c,
+    ILoad3 = 0x1d,
+    IMul = 0x68,
+    INeg = 0x74,
+    InstanceOf = 0xc1,
+    InvokeDynamic = 0xba,
+    InvokeInterface = 0xb9,
+    InvokeSpecial = 0xb7,
+    InvokeStatic = 0xb8,
+    InvokeVirtual = 0xb6,
+    IOr = 0x80,
+    IRem = 0x70,
+    IReturn = 0xac,
+    IShl = 0x78,
+    IShr = 0x7a,
+    IStore = 0x36,
+    IStore0 = 0x3b,
+    IStore1 = 0x3c,
+    IStore2 = 0x3d,
+    IStore3 = 0x3e,
+    ISub = 0x64,
+    IUShr = 0x7c,
+    IXor = 0x82,
+    JSR = 0xa8,
+    JSRw = 0xc9,
+    L2D = 0x8a,
+    L2F = 0x89,
+    L2I = 0x88,
+    LAdd = 0x61,
+    LALoad = 0x2f,
+    LAnd = 0x7f,
+    LAStore = 0x50,
+    LCmp = 0x94,
+    LConst0 = 0x9,
+    LConst1 = 0xa,
+    LDC = 0x12,
+    LDCW = 0x13,
+    LDC2W = 0x14,
+    LDiv = 0x6d,
+    LLoad = 0x16,
+    LLoad0 = 0x1e,
+    LLoad1 = 0x1f,
+    LLoad2 = 0x20,
+    LLoad3 = 0x21,
+    LMul = 0x69,
+    LNeg = 0x75,
+    LookupSwitch = 0xab,
+    LOr = 0x81,
+    LRem = 0x71,
+    LReturn = 0xad,
+    LShl = 0x79,
+    LShr = 0x7b,
+    LStore = 0x37,
+    LStore0 = 0x3f,
+    LStore1 = 0x40,
+    LStore2 = 0x41,
+    LStore3 = 0x42,
+    LSub = 0x65,
+    LUShr = 0x7d,
+    LXor = 0x83,
+    MonitorEnter = 0xc2,
+    MonitorExit = 0xc3,
+    MultiANewArray = 0xc5,
+    New = 0xbb,
+    NewArray = 0xbc,
+    Nop = 0x0,
+    Pop = 0x57,
+    Pop2 = 0x58,
+    PutField = 0xb5,
+    PutStatic = 0xb3,
+    Ret = 0xa9,
+    Return = 0xb1,
+    SALoad = 0x35,
+    SAStore = 0x56,
+    SIPush = 0x11,
+    Swap = 0x5f,
+    TableSwitch = 0xaa,
+    Wide = 0xc4,
+};
+
+/// Helper struct containing for bytecode relevant information that is returned by the iterator.
+struct ByteCodeOp
+{
+    OpCodes opCode{};
+    /// 0-based offset of this operation.
+    std::size_t offset{};
+    /// Reference to any variable-length extra data this operation contains.
+    /// Does not include the identifying byte of the instruction.
+    llvm::ArrayRef<char> data;
+};
+
+class ByteCodeIterator : public llvm::iterator_facade_base<ByteCodeIterator, std::forward_iterator_tag, ByteCodeOp,
+                                                           std::ptrdiff_t, ByteCodeOp, ByteCodeOp>
+{
+    const char* m_current = nullptr;
+    std::size_t m_offset = 0;
+
+    // Returns the size of the operation, including the identifying byte.
+    std::size_t currentOpSize() const;
+
+public:
+    ByteCodeIterator() = default;
+
+    explicit ByteCodeIterator(const char* current) : m_current(current) {}
+
+    bool operator==(ByteCodeIterator rhs) const
+    {
+        return m_current == rhs.m_current;
+    }
+
+    ByteCodeIterator& operator++()
+    {
+        std::size_t size = currentOpSize();
+        m_current += size;
+        m_offset += size;
+        return *this;
+    }
+
+    value_type operator*() const
+    {
+        std::size_t size = currentOpSize();
+        return {static_cast<OpCodes>(*m_current), m_offset, llvm::ArrayRef(m_current + 1, size - 1)};
+    }
+};
+
+/// Returns an iterator range returning a 'ByteCodeOp' for every JVM instruction.
+/// Assumes that 'current' contains valid byte code.
+inline auto byteCodeRange(llvm::ArrayRef<char> current)
+{
+    return llvm::make_range(ByteCodeIterator(current.begin()), ByteCodeIterator(current.end()));
+}
+
+} // namespace jllvm

--- a/src/jllvm/class/CMakeLists.txt
+++ b/src/jllvm/class/CMakeLists.txt
@@ -1,2 +1,4 @@
-add_library(JLLVMClassParser ClassFile.cpp Descriptors.cpp Descriptors.hpp)
+add_library(JLLVMClassParser ClassFile.cpp Descriptors.cpp Descriptors.hpp
+        ByteCodeIterator.cpp
+        ByteCodeIterator.hpp)
 target_link_libraries(JLLVMClassParser PUBLIC JLLVMSupport)

--- a/src/jllvm/materialization/ByteCodeCompileLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeCompileLayer.cpp
@@ -4,6 +4,7 @@
 #include <llvm/IR/Verifier.h>
 #include <llvm/Support/Debug.h>
 
+#include <jllvm/class/ByteCodeIterator.hpp>
 #include <jllvm/class/Descriptors.hpp>
 #include <jllvm/object/Object.hpp>
 #include <jllvm/support/Bytes.hpp>
@@ -421,212 +422,6 @@ public:
     }
 };
 
-enum class OpCodes : std::uint8_t
-{
-    AALoad = 0x32,
-    AAStore = 0x53,
-    AConstNull = 0x1,
-    ALoad = 0x19,
-    ALoad0 = 0x2a,
-    ALoad1 = 0x2b,
-    ALoad2 = 0x2c,
-    ALoad3 = 0x2d,
-    ANewArray = 0xbd,
-    AReturn = 0xb0,
-    ArrayLength = 0xbe,
-    AStore = 0x3a,
-    AStore0 = 0x4b,
-    AStore1 = 0x4c,
-    AStore2 = 0x4d,
-    AStore3 = 0x4e,
-    AThrow = 0xbf,
-    BALoad = 0x33,
-    BAStore = 0x54,
-    BIPush = 0x10,
-    CALoad = 0x34,
-    CAStore = 0x55,
-    CheckCast = 0xc0,
-    D2F = 0x90,
-    D2I = 0x8e,
-    D2L = 0x8f,
-    DAdd = 0x63,
-    DALoad = 0x31,
-    DAStore = 0x52,
-    DCmpG = 0x98,
-    DCmpL = 0x97,
-    DConst0 = 0xe,
-    DConst1 = 0xf,
-    DDiv = 0x6f,
-    DLoad = 0x18,
-    DLoad0 = 0x26,
-    DLoad1 = 0x27,
-    DLoad2 = 0x28,
-    DLoad3 = 0x29,
-    DMul = 0x6b,
-    DNeg = 0x77,
-    DRem = 0x73,
-    DReturn = 0xaf,
-    DStore = 0x39,
-    DStore0 = 0x47,
-    DStore1 = 0x48,
-    DStore2 = 0x49,
-    DStore3 = 0x4a,
-    DSub = 0x67,
-    Dup = 0x59,
-    DupX1 = 0x5a,
-    DupX2 = 0x5b,
-    Dup2 = 0x5c,
-    Dup2X1 = 0x5d,
-    Dup2X2 = 0x5e,
-    F2D = 0x8d,
-    F2I = 0x8b,
-    F2L = 0x8c,
-    FAdd = 0x62,
-    FALoad = 0x30,
-    FAStore = 0x51,
-    FCmpG = 0x96,
-    FCmpL = 0x95,
-    FConst0 = 0xb,
-    FConst1 = 0xc,
-    FConst2 = 0xd,
-    FDiv = 0x6e,
-    FLoad = 0x17,
-    FLoad0 = 0x22,
-    FLoad1 = 0x23,
-    FLoad2 = 0x24,
-    FLoad3 = 0x25,
-    FMul = 0x6a,
-    FNeg = 0x76,
-    FRem = 0x72,
-    FReturn = 0xae,
-    FStore = 0x38,
-    FStore0 = 0x43,
-    FStore1 = 0x44,
-    FStore2 = 0x45,
-    FStore3 = 0x46,
-    FSub = 0x66,
-    GetField = 0xb4,
-    GetStatic = 0xb2,
-    Goto = 0xa7,
-    GotoW = 0xc8,
-    I2B = 0x91,
-    I2C = 0x92,
-    I2D = 0x87,
-    I2F = 0x86,
-    I2L = 0x85,
-    I2S = 0x93,
-    IAdd = 0x60,
-    IALoad = 0x2e,
-    IAnd = 0x7e,
-    IAStore = 0x4f,
-    IConstM1 = 0x2,
-    IConst0 = 0x3,
-    IConst1 = 0x4,
-    IConst2 = 0x5,
-    IConst3 = 0x6,
-    IConst4 = 0x7,
-    IConst5 = 0x8,
-    IDiv = 0x6c,
-    IfACmpEq = 0xa5,
-    IfACmpNe = 0xa6,
-    IfICmpEq = 0x9f,
-    IfICmpNe = 0xa0,
-    IfICmpLt = 0xa1,
-    IfICmpGe = 0xa2,
-    IfICmpGt = 0xa3,
-    IfICmpLe = 0xa4,
-    IfEq = 0x99,
-    IfNe = 0x9a,
-    IfLt = 0x9b,
-    IfGe = 0x9c,
-    IfGt = 0x9d,
-    IfLe = 0x9e,
-    IfNonNull = 0xc7,
-    IfNull = 0xc6,
-    IInc = 0x84,
-    ILoad = 0x15,
-    ILoad0 = 0x1a,
-    ILoad1 = 0x1b,
-    ILoad2 = 0x1c,
-    ILoad3 = 0x1d,
-    IMul = 0x68,
-    INeg = 0x74,
-    InstanceOf = 0xc1,
-    InvokeDynamic = 0xba,
-    InvokeInterface = 0xb9,
-    InvokeSpecial = 0xb7,
-    InvokeStatic = 0xb8,
-    InvokeVirtual = 0xb6,
-    IOr = 0x80,
-    IRem = 0x70,
-    IReturn = 0xac,
-    IShl = 0x78,
-    IShr = 0x7a,
-    IStore = 0x36,
-    IStore0 = 0x3b,
-    IStore1 = 0x3c,
-    IStore2 = 0x3d,
-    IStore3 = 0x3e,
-    ISub = 0x64,
-    IUShr = 0x7c,
-    IXor = 0x82,
-    JSR = 0xa8,
-    JSRw = 0xc9,
-    L2D = 0x8a,
-    L2F = 0x89,
-    L2I = 0x88,
-    LAdd = 0x61,
-    LALoad = 0x2f,
-    LAnd = 0x7f,
-    LAStore = 0x50,
-    LCmp = 0x94,
-    LConst0 = 0x9,
-    LConst1 = 0xa,
-    LDC = 0x12,
-    LDCW = 0x13,
-    LDC2W = 0x14,
-    LDiv = 0x6d,
-    LLoad = 0x16,
-    LLoad0 = 0x1e,
-    LLoad1 = 0x1f,
-    LLoad2 = 0x20,
-    LLoad3 = 0x21,
-    LMul = 0x69,
-    LNeg = 0x75,
-    LookupSwitch = 0xab,
-    LOr = 0x81,
-    LRem = 0x71,
-    LReturn = 0xad,
-    LShl = 0x79,
-    LShr = 0x7b,
-    LStore = 0x37,
-    LStore0 = 0x3f,
-    LStore1 = 0x40,
-    LStore2 = 0x41,
-    LStore3 = 0x42,
-    LSub = 0x65,
-    LUShr = 0x7d,
-    LXor = 0x83,
-    MonitorEnter = 0xc2,
-    MonitorExit = 0xc3,
-    MultiANewArray = 0xc5,
-    New = 0xbb,
-    NewArray = 0xbc,
-    Nop = 0x0,
-    Pop = 0x57,
-    Pop2 = 0x58,
-    PutField = 0xb5,
-    PutStatic = 0xb3,
-    Ret = 0xa9,
-    Return = 0xb1,
-    SALoad = 0x35,
-    SAStore = 0x56,
-    SIPush = 0x11,
-    Swap = 0x5f,
-    TableSwitch = 0xaa,
-    Wide = 0xc4,
-};
-
 llvm::Type* ensureI32(llvm::Type* llvmFieldType, llvm::IRBuilder<>& builder)
 {
     return !llvmFieldType->isIntegerTy() || llvmFieldType->getIntegerBitWidth() >= 32 ? llvmFieldType :
@@ -671,10 +466,8 @@ void codeGenBody(llvm::Function* function, const Code& code, const ClassFile& cl
 
     llvm::DenseMap<std::uint16_t, llvm::BasicBlock*> basicBlocks;
     // Calculate BasicBlocks
-    llvm::ArrayRef<char> current = code.getCode();
-    while (!current.empty())
+    for (auto [opCode, offset, current] : byteCodeRange(code.getCode()))
     {
-        auto offset = current.data() - code.getCode().data();
         auto addBasicBlock = [&](std::uint16_t target)
         {
             auto [result, inserted] = basicBlocks.insert({target, nullptr});
@@ -684,29 +477,18 @@ void codeGenBody(llvm::Function* function, const Code& code, const ClassFile& cl
                 result->second = llvm::BasicBlock::Create(builder.getContext(), "", function);
             }
         };
-        auto opCode = consume<OpCodes>(current);
         switch (opCode)
         {
-            default:
-            {
-                break;
-            }
             case OpCodes::Goto:
             {
-                if (current.size() >= sizeof(std::int16_t))
-                {
-                    auto target = consume<std::int16_t>(current);
-                    addBasicBlock(target + offset);
-                }
+                auto target = consume<std::int16_t>(current);
+                addBasicBlock(target + offset);
                 break;
             }
             case OpCodes::GotoW:
             {
-                if (current.size() >= sizeof(std::int32_t))
-                {
-                    auto target = consume<std::int32_t>(current);
-                    addBasicBlock(target + offset);
-                }
+                auto target = consume<std::int32_t>(current);
+                addBasicBlock(target + offset);
                 break;
             }
             case OpCodes::IfACmpEq:
@@ -726,22 +508,17 @@ void codeGenBody(llvm::Function* function, const Code& code, const ClassFile& cl
             case OpCodes::IfNonNull:
             case OpCodes::IfNull:
             {
-                if (current.size() >= sizeof(std::int16_t))
-                {
-                    auto target = consume<std::int16_t>(current);
-                    addBasicBlock(target + offset);
-                    addBasicBlock(current.data() - code.getCode().data());
-                }
+                auto target = consume<std::int16_t>(current);
+                addBasicBlock(target + offset);
+                addBasicBlock(current.data() - code.getCode().data());
                 break;
             }
+            default: break;
         }
     }
     llvm::DenseMap<llvm::BasicBlock*, llvm::AllocaInst**> basicBlockStackPointers;
-    current = code.getCode();
-    while (!current.empty())
+    for (auto [opCode, offset, current] : byteCodeRange(code.getCode()))
     {
-        auto offset = current.data() - code.getCode().data();
-
         if (auto result = startHandlers.find(offset); result != startHandlers.end())
         {
             activeHandlers.push_back(result->second);
@@ -770,7 +547,6 @@ void codeGenBody(llvm::Function* function, const Code& code, const ClassFile& cl
                 operandStack.setTopOfStack(resultStackPointer->second);
             }
         }
-        auto opCode = consume<OpCodes>(current);
         switch (opCode)
         {
             default: llvm_unreachable("NOT YET IMPLEMENTED");

--- a/tests/Execution/control-flow-false-positive.java
+++ b/tests/Execution/control-flow-false-positive.java
@@ -1,0 +1,16 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class
+
+class Test
+{
+    public static int foo()
+    {
+        // 0xa7FF which looks like a goto to target ...FF.
+        return -22529;
+    }
+
+    public static void main(String[] args)
+    {
+        foo();
+    }
+}


### PR DESCRIPTION
This is achieved by creating a new byte code iterator abstraction which centralizes our logic for iterating over JVM bytecode, allowing reuse of the logic both when creating the basic blocks and generating LLVM IR.

Previously the basic block creation would interpret everything that looks like a branch instruction as a branch instruction. This would create incorrect basic blocks with no terminators which would make the verifier in LLVM fail as well as some optimization passes.

The implementation was intentionally kept very simple and a large focus was made on having to modify as little code as possible, keeping the code for all instructions implemented so far identical. One could definitely build a nicer abstraction with sum types that already contain parsed data for the instruction but this would require larger code changes that I don't think are worth my time right now.