### PR TITLE
[instruction] Add support for float cast instructions

### DIFF
--- a/src/jllvm/materialization/ByteCodeCompileLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeCompileLayer.cpp
@@ -722,10 +722,21 @@ void codeGenBody(llvm::Function* function, const Code& code, const ClassFile& cl
             // TODO: Dup2
             // TODO: Dup2X1
             // TODO: Dup2X2
+            case OpCodes::F2D:
+            {
+                llvm::Value* value = operandStack.pop_back(builder.getFloatTy());
+                operandStack.push_back(builder.CreateFPExt(value, builder.getDoubleTy()));
+                break;
+            }
+            case OpCodes::F2I:
+            case OpCodes::F2L:
+            {
+                llvm::Value* value = operandStack.pop_back(builder.getFloatTy());
+                llvm::Type* type = opCode == OpCodes::F2I ? builder.getInt32Ty() : builder.getInt64Ty();
 
-            // TODO: F2D
-            // TODO: F2I
-            // TODO: F2L
+                operandStack.push_back(builder.CreateIntrinsic(type, llvm::Intrinsic::fptosi_sat, {value}));
+                break;
+            }
             case OpCodes::FAdd:
             {
                 llvm::Value* rhs = operandStack.pop_back(builder.getFloatTy());

--- a/tests/Execution/float-casts.java
+++ b/tests/Execution/float-casts.java
@@ -1,0 +1,75 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+class Test
+{
+    public static native void print(int i);
+    public static native void print(double d);
+    public static native void print(long l);
+
+    public static void main(String[] args)
+    {
+        var nan = Float.NaN;
+        var p_inf = Float.POSITIVE_INFINITY;
+        var n_inf = Float.NEGATIVE_INFINITY;
+        var p_zero = 0.0f;
+        var n_zero = -0.0f;
+        var p_19 = 1.9f;
+        var n_19 = -1.9f;
+        var p_long_max_plus = 9323372036854775807.0f;
+        var n_long_max_plus = -9323372036854775807.0f;
+
+        //CHECK: nan
+        print((double) nan);
+        //CHECK: inf
+        print((double) p_inf);
+        //CHECK: -inf
+        print((double) n_inf);
+        //CHECK: 0
+        print((double) p_zero);
+        //CHECK: -0
+        print((double) n_zero);
+        //CHECK: 9.32337e+18
+        print((double) p_long_max_plus);
+        //CHECK: -9.32337e+18
+        print((double) n_long_max_plus);
+
+        //CHECK: 0
+        print((int) nan);
+        //CHECK: 2147483647
+        print((int) p_inf);
+        //CHECK: -2147483648
+        print((int) n_inf);
+        //CHECK: 0
+        print((int) p_zero);
+        //CHECK: 0
+        print((int) n_zero);
+        //CHECK: 1
+        print((int) p_19);
+        //CHECK: -1
+        print((int) n_19);
+        //CHECK: 2147483647
+        print((int) p_long_max_plus);
+        //CHECK: -2147483648
+        print((int) n_long_max_plus);
+
+        //CHECK: 0
+        print((long) nan);
+        //CHECK: 9223372036854775807
+        print((long) p_inf);
+        //CHECK: -9223372036854775808
+        print((long) n_inf);
+        //CHECK: 0
+        print((long) p_zero);
+        //CHECK: 0
+        print((long) n_zero);
+        //CHECK: 1
+        print((long) p_19);
+        //CHECK: -1
+        print((long) n_19);
+        //CHECK: 9223372036854775807
+        print((long) p_long_max_plus);
+        //CHECK: -9223372036854775808
+        print((long) n_long_max_plus);
+    }
+}


### PR DESCRIPTION
This PR includes support for creating appropriate LLVM instructions on processing the `f2d`, `f2i`  and `f2l` JVM instructions.