### PR TITLE
[vm] Add command line option to conveniently enable `LLVM_DEBUG` logging

### DIFF
--- a/src/jllvm/main/Main.cpp
+++ b/src/jllvm/main/Main.cpp
@@ -47,12 +47,17 @@ int jllvm::main(llvm::StringRef executablePath, llvm::ArrayRef<char*> args)
     llvmArgs.push_back("-max-registers-for-gc-values=1000");
 #endif
 
+    CommandLine commandLine(args);
+
 #ifndef NDEBUG
+    llvm::SmallString<64> buffer;
     llvmArgs.push_back("-jllvm-gc-every-alloc=1");
+    if (llvm::StringRef value = commandLine.getArgs().getLastArgValue(OPT_Xdebug_EQ); !value.empty())
+    {
+        llvmArgs.push_back(("-debug-only=" + value).toNullTerminatedStringRef(buffer).data());
+    }
 #endif
     llvm::cl::ParseCommandLineOptions(llvmArgs.size(), llvmArgs.data());
-
-    CommandLine commandLine(args);
 
     auto inputFiles = commandLine.getArgs().getAllArgValues(OPT_INPUT);
     if (inputFiles.empty())

--- a/src/jllvm/main/Opts.td
+++ b/src/jllvm/main/Opts.td
@@ -6,4 +6,11 @@ def classpath : Separate<["-"], "cp">, MetaVarName<"<class search path>">;
 def : Separate<["-"], "classpath">, Alias<classpath>;
 def : Separate<["--"], "class-path">, Alias<classpath>;
 
-def Xenable_test_utils : F<"Xenable-test-utils", "Enables native test functions">;
+def grp_internal : OptionGroup<"Internal"> {
+    let Flags = [HelpHidden];
+}
+
+def Xdebug_EQ : Joined<["-"], "Xdebug=">, HelpText<"Enable debug debug logging">, Group<grp_internal>;
+def Xdebug : F<"Xdebug", "Enable debug JVM debug logging">, Alias<Xdebug_EQ>, AliasArgs<["jvm"]>, Group<grp_internal>;
+
+def Xenable_test_utils : F<"Xenable-test-utils", "Enables native test functions">, Group<grp_internal>;


### PR DESCRIPTION
Output of `LLVM_DEBUG` can often be used for debugging purposes, especially when trying to trace actions. Debugging linking failures with `-Xdebug=jitlink` or finding out which method was last compiled prior to a crash using `-Xdebug` (equivalent to `-Xdebug=jvm`) are very useful to quickly locate an issue. This commit adds these command line arguments and enables them in debug builds.

The reason why only in debug builds is that these debugging facilities are not compiled into release builds.

Example output from `-Xdebug`
![image](https://github.com/JLLVM/JLLVM/assets/6625526/8b0d9b3e-ef16-485c-a0f8-43c5763600bc)

Example output from `-Xdebug=jitlink`
![image](https://github.com/JLLVM/JLLVM/assets/6625526/24649e21-1b1d-4502-a21b-a0c10fc157f3)
