### PR TITLE
[instruction][fix] Implement `ireturn` for functions returning smaller integer types

### DIFF
--- a/tests/Execution/ireturn.java
+++ b/tests/Execution/ireturn.java
@@ -4,6 +4,9 @@
 class Test
 {
     public static native void print(int i);
+    public static native void print(boolean i);
+    public static native void print(short i);
+    public static native void print(char i);
 
     private static int test1()
     {
@@ -11,9 +14,24 @@ class Test
     }
 
     private static int test2()
-        {
-            return -3;
-        }
+    {
+        return -3;
+    }
+
+    private static boolean test3()
+    {
+        return true;
+    }
+
+    private static short test4()
+    {
+        return 5;
+    }
+
+    private static char test5()
+    {
+        return 'A';
+    }
 
     public static void main(String[] args)
     {
@@ -21,5 +39,11 @@ class Test
         print(test1());
         // CHECK: -3
         print(test2());
+        // CHECK: 1
+        print(test3());
+        // CHECK: 5
+        print(test4());
+        // CHECK: 65
+        print(test5());
     }
 }


### PR DESCRIPTION
When returning integers in functions returning `i16` or smaller we have to truncate the `i32` first to not create an invalid LLVM IR module that does not verify due to `ret` type mismatches. Additionally, booleans have to be treated specially, as the spec states that converting to a boolean return type has to be done via a bitmask with 1.