### PR TITLE
[fix] gracefully handle abstract class method declaration of interface class

### DIFF
--- a/tests/Execution/abstract-class-interface.java
+++ b/tests/Execution/abstract-class-interface.java
@@ -1,0 +1,46 @@
+// RUN: rm -rf %t && split-file %s %t
+// RUN: cd %t && javac %t/Other.java -d %t
+// RUN: jllvm -Xenable-test-utils %t/Other.class | FileCheck %s
+
+//--- Test.java
+
+public class Test
+{
+    public static native void print(int i);
+}
+
+//--- A.java
+
+public interface A
+{
+    void a();
+}
+
+//--- B.java
+
+public abstract class B implements A
+{
+    public abstract void a();
+}
+
+//--- C.java
+
+public class C extends B
+{
+    public void a()
+    {
+        Test.print(6);
+    }
+}
+
+//--- Other.java
+
+public class Other
+{
+    public static void main(String[] args)
+    {
+        B c = new C();
+        // CHECK: 6
+        c.a();
+    }
+}


### PR DESCRIPTION
An abstract class can declare a method of a super interface and "overwrite" it, which would lead to the method not being found by the JIT. This is fine since any subclasses of the abstract class will override the method. Nevertheless, simply ignore errors during lookup in the JIT instead of crashing