### PR TITLE
[fix] properly take superinterfaces of superclasses into account as well

### DIFF
--- a/src/jllvm/object/ClassLoader.cpp
+++ b/src/jllvm/object/ClassLoader.cpp
@@ -215,16 +215,16 @@ jllvm::ClassObject& jllvm::ClassLoader::add(std::unique_ptr<llvm::MemoryBuffer>&
     }
     else
     {
+        if (superClass)
+        {
+            interfaces.insert(interfaces.begin(), superClass);
+        }
         result = ClassObject::create(m_classAllocator, m_metaClassObject, vTableAssignment.vTableCount, instanceSize,
-                                     methods, fields, interfaces, className, superClass);
+                                     methods, fields, interfaces, className);
     }
     m_mapping.insert({("L" + className + ";").str(), result});
 
     // 5.5 Initialization, step 7: Initialize super class and interfaces recursively.
-    if (superClass)
-    {
-        initialize(*superClass);
-    }
     llvm::for_each(interfaces, [this](ClassObject* interface) { initialize(*interface); });
 
     return *result;

--- a/tests/Execution/super-class-super-interface.java
+++ b/tests/Execution/super-class-super-interface.java
@@ -1,0 +1,49 @@
+// RUN: rm -rf %t && split-file %s %t
+// RUN: cd %t && javac %t/Other.java -d %t
+// RUN: jllvm -Xenable-test-utils %t/Other.class | FileCheck %s
+
+//--- Test.java
+
+public class Test
+{
+    public static native void print(int i);
+}
+
+//--- A.java
+
+public interface A
+{
+    void a();
+}
+
+//--- B.java
+
+public class B implements A
+{
+    public void a()
+    {
+        Test.print(9);
+    }
+}
+
+//--- C.java
+
+public class C extends B
+{
+    public void a()
+    {
+        Test.print(6);
+    }
+}
+
+//--- Other.java
+
+public class Other
+{
+    public static void main(String[] args)
+    {
+        A a = new C();
+        // CHECK: 6
+        a.a();
+    }
+}


### PR DESCRIPTION
The iterators used to enumerate all interfaces (either in any order or topological) previously only took into account direct superinterfaces and their transitive superinterfaces but not the (direct and indirect) superinterfaces of superclasses. This would lead to failures to allocate and populate ITables for specific classes followed by runtime crashes when `invokeinterface` did not find an ITable entry.

This patch fixes that by changing the GraphTraits to create a whole classgraph out of all class objects and simply use a filter to only output interfaces. This makes the superinterfaces of superclasses reachable as well.

The implementation of ClassObject was also adjusted to ease the implementation.