### PR TITLE
[vm] implement basic implementation for 'assert' class initializers

### DIFF
--- a/src/jllvm/materialization/ByteCodeCompileLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeCompileLayer.cpp
@@ -609,7 +609,10 @@ void codeGenBody(llvm::Function* function, const Code& code, const ClassFile& cl
             { builder.CreateStore(operandStack.pop_back(referenceType(builder.getContext())), locals[2]); },
             [&](AStore3)
             { builder.CreateStore(operandStack.pop_back(referenceType(builder.getContext())), locals[3]); },
-            // TODO: AThrow
+            [&](AThrow) {
+                // TODO: Properly implement throwing exception. Pure stop gap solution for now.
+                operandStack.pop_back(referenceType(builder.getContext()));
+            },
             // TODO: BALoad
             // TODO: BAStore
             [&](BIPush biPush)
@@ -1316,8 +1319,13 @@ void codeGenBody(llvm::Function* function, const Code& code, const ClassFile& cl
             // TODO: LSub
             // TODO: LUShr
             // TODO: LXor
-            // TODO: MonitorEnter
-            // TODO: MonitorExit
+            [&](OneOf<MonitorEnter, MonitorExit>)
+            {
+                // Pop object as is required by the instruction.
+                // TODO: If we ever care about multi threading, this would require lazily creating a mutex and
+                //  (un)locking it.
+                operandStack.pop_back(referenceType(builder.getContext()));
+            },
             // TODO: MultiANewArray
             [&](New newOp)
             {

--- a/src/jllvm/vm/NativeImplementation.hpp
+++ b/src/jllvm/vm/NativeImplementation.hpp
@@ -132,9 +132,19 @@ public:
         return javaThis.isArray();
     }
 
+    static bool desiredAssertionStatus0(VirtualMachine&, ClassObject*)
+    {
+#ifndef NDEBUG
+        return true;
+#else
+        return false;
+#endif
+    }
+
     constexpr static llvm::StringLiteral className = "java/lang/Class";
     constexpr static auto methods =
-        std::make_tuple(addMember<&ClassModel::registerNatives>(), addMember<&ClassModel::isArray>());
+        std::make_tuple(addMember<&ClassModel::registerNatives>(), addMember<&ClassModel::isArray>(),
+                        addMember<&ClassModel::desiredAssertionStatus0>());
 };
 
 /// Register any models for builtin Java classes in the VM.

--- a/tests/Execution/assert.java
+++ b/tests/Execution/assert.java
@@ -1,0 +1,17 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class
+
+class Test
+{
+    public static int x;
+
+    private void dummy()
+    {
+        assert x == 5;
+    }
+
+    public static void main(String[] args)
+    {
+        // Nothing for now, just making sure the implicit '<clinit>' works
+    }
+}

--- a/tests/Execution/monitor-enter-exit.java
+++ b/tests/Execution/monitor-enter-exit.java
@@ -1,0 +1,14 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class
+
+class Test
+{
+    public static void main(String[] args)
+    {
+        var o = new Object();
+        synchronized(o)
+        {
+            new Object();
+        }
+    }
+}

--- a/tests/Execution/try-catch.java
+++ b/tests/Execution/try-catch.java
@@ -1,0 +1,20 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class
+
+class Test
+{
+    public static void foo()
+    {}
+
+    public static void main(String[] args)
+    {
+        try
+        {
+            foo();
+        }
+        catch (Exception e)
+        {
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
Any uses of `assert` within a class leads to the creation of a class initializer which queries the assertion status from the class loader and VM: https://godbolt.org/z/9a6q675bx

This PR implements the 'native' method called from `Class.desiredAssertionStatus` to allow our VM to load class files that contain `assert` (even if they're never executed). `assert`s themselves do not yet work (nor can be compiled) since it contains `athrow` of `AssertionError`.

I currently made it simply match whether the VM is compiled in debug or release but this isn't really proper. Rather, a command line option should be added in the future to make this user configurable, but this is beyond the scope of this PR

Depends on https://github.com/JLLVM/JLLVM/pull/95