### PR TITLE
[instruction] add the most basic implementation of `monitorenter`, `monitorexit` and `athrow`

### DIFF
--- a/src/jllvm/materialization/ByteCodeCompileLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeCompileLayer.cpp
@@ -609,7 +609,10 @@ void codeGenBody(llvm::Function* function, const Code& code, const ClassFile& cl
             { builder.CreateStore(operandStack.pop_back(referenceType(builder.getContext())), locals[2]); },
             [&](AStore3)
             { builder.CreateStore(operandStack.pop_back(referenceType(builder.getContext())), locals[3]); },
-            // TODO: AThrow
+            [&](AThrow) {
+                // TODO: Properly implement throwing exception. Pure stop gap solution for now.
+                operandStack.pop_back(referenceType(builder.getContext()));
+            },
             // TODO: BALoad
             // TODO: BAStore
             [&](BIPush biPush)
@@ -1316,8 +1319,13 @@ void codeGenBody(llvm::Function* function, const Code& code, const ClassFile& cl
             // TODO: LSub
             // TODO: LUShr
             // TODO: LXor
-            // TODO: MonitorEnter
-            // TODO: MonitorExit
+            [&](OneOf<MonitorEnter, MonitorExit>)
+            {
+                // Pop object as is required by the instruction.
+                // TODO: If we ever care about multi threading, this would require lazily creating a mutex and
+                //  (un)locking it.
+                operandStack.pop_back(referenceType(builder.getContext()));
+            },
             // TODO: MultiANewArray
             [&](New newOp)
             {

--- a/tests/Execution/monitor-enter-exit.java
+++ b/tests/Execution/monitor-enter-exit.java
@@ -1,0 +1,14 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class
+
+class Test
+{
+    public static void main(String[] args)
+    {
+        var o = new Object();
+        synchronized(o)
+        {
+            new Object();
+        }
+    }
+}

--- a/tests/Execution/try-catch.java
+++ b/tests/Execution/try-catch.java
@@ -1,0 +1,20 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class
+
+class Test
+{
+    public static void foo()
+    {}
+
+    public static void main(String[] args)
+    {
+        try
+        {
+            foo();
+        }
+        catch (Exception e)
+        {
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
Multi threading is currently a non-goal for us, therefore this PR currently implements them as doing nothing but the require operand stack manipulation.
We might still be executing and compiling `synchronized` blocks however, hence their implementations are required.

A `athrow` stub is required due to `synchronized` catching any exception and then rethrowing it. This can currently never be executed, so the stub that does the right stack manipulation should suffice for now

Depends on https://github.com/JLLVM/JLLVM/pull/96