### PR TITLE
[codegen] implement basic compilation of catch sections

### DIFF
--- a/tests/Execution/try-catch.java
+++ b/tests/Execution/try-catch.java
@@ -1,0 +1,20 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class
+
+class Test
+{
+    public static void foo()
+    {}
+
+    public static void main(String[] args)
+    {
+        try
+        {
+            foo();
+        }
+        catch (Exception e)
+        {
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
While these are currently not reachable (since we do not yet have an exception mechanism), catch handlers are part of the bytecode stream and therefore have to be compiled by our VM.

Catch handlers have the special semantic of their operand stack having only the exception on the very top which we have to register within our code. Otherwise compilation would lead to crashes and out of bound reads.