### PR TITLE
[fix] Fix wrong assignment in codegen for narrowing integer casts

### DIFF
--- a/src/jllvm/materialization/ByteCodeCompileLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeCompileLayer.cpp
@@ -824,13 +824,13 @@ void codeGenBody(llvm::Function* function, const Code& code, const ClassFile& cl
             {
                 llvm::Value* value = operandStack.pop_back(builder.getInt32Ty());
                 llvm::Value* truncated = builder.CreateTrunc(value, builder.getInt8Ty());
-                operandStack.push_back(builder.CreateSExt(value, builder.getInt32Ty()));
+                operandStack.push_back(builder.CreateSExt(truncated, builder.getInt32Ty()));
             },
             [&](I2C)
             {
                 llvm::Value* value = operandStack.pop_back(builder.getInt32Ty());
                 llvm::Value* truncated = builder.CreateTrunc(value, builder.getInt16Ty());
-                operandStack.push_back(builder.CreateZExt(value, builder.getInt32Ty()));
+                operandStack.push_back(builder.CreateZExt(truncated, builder.getInt32Ty()));
             },
             [&](I2D)
             {
@@ -851,7 +851,7 @@ void codeGenBody(llvm::Function* function, const Code& code, const ClassFile& cl
             {
                 llvm::Value* value = operandStack.pop_back(builder.getInt32Ty());
                 llvm::Value* truncated = builder.CreateTrunc(value, builder.getInt16Ty());
-                operandStack.push_back(builder.CreateSExt(value, builder.getInt32Ty()));
+                operandStack.push_back(builder.CreateSExt(truncated, builder.getInt32Ty()));
             },
             [&](IAdd)
             {

--- a/tests/Execution/integer-casts.java
+++ b/tests/Execution/integer-casts.java
@@ -58,5 +58,18 @@ class Test
         print((double) y);
         //CHECK: -129
         print((double) z);
+
+        // Testing narrowing conversions
+        int b = 2 * Byte.MAX_VALUE;
+        //CHECK: -2
+        print((int)(byte) b);
+
+        int c = 2 * Character.MAX_VALUE;
+        //CHECK: 65534
+        print((int)(char) c);
+
+        int s = 2 * Short.MAX_VALUE;
+        //CHECK: -2
+        print((int)(short) s);
     }
 }


### PR DESCRIPTION
This PR fixes the bug, where the argument to `CreateSExt` or `CreateZExt` in `codeGenBody` was the original integer value not the truncated one. 

Fixes #90