### PR TITLE
[instruction] Add support for `ldc_w` and `ldc2_w` instructions

### DIFF
--- a/tests/Execution/ldc2_w.java
+++ b/tests/Execution/ldc2_w.java
@@ -1,0 +1,29 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+class Test
+{
+    public static native void print(double d);
+    public static native void print(long l);
+
+    public static void main(String[] args)
+    {
+
+        // CHECK: 123.456
+        print(123.456);
+        // CHECK: -987.654
+        print(-987.654);
+
+        // larger double than Float.MAX_VALUE
+        // CHECK: 4.40282e+38
+        print(4.4028235E38);
+
+        // CHECK: 123456
+        print(123456l);
+        // CHECK: 987654
+        print(987654l);
+
+        // larger long than Integer.MAX_VALUE
+        // CHECK: 12147483647
+        print(12147483647l);
+    }
+}


### PR DESCRIPTION
This PR includes support for creating appropriate LLVM instructions on processing the `ldc_w` and `ldc2_w` JVM instructions.

Fixes: #17 