### PR TITLE
[object] make vtable slot assignment correct first, optimized later

### DIFF
--- a/src/jllvm/class/ClassFile.hpp
+++ b/src/jllvm/class/ClassFile.hpp
@@ -384,17 +384,10 @@ public:
         return (m_accessFlags & AccessFlag::Abstract) != AccessFlag::None;
     }
 
-    /// Returns true if this method can overwrite subclass methods.
-    bool canOverwrite(const ClassFile& classFile) const
+    /// Returns true if this method requires a VTable slot.
+    bool needsVTableSlot(const ClassFile& classFile) const
     {
-        return !(isPrivate() || isStatic() || getName(classFile) == "<init>");
-    }
-
-    /// Returns true if this method can be overwritten by subclasses.
-    bool canBeOverwritten(const ClassFile& classFile) const
-    {
-        // TODO: Can this be optimized using 'isFinal()'?
-        return canOverwrite(classFile);
+        return !isStatic() && getName(classFile) != "<init>";
     }
 
     /// Returns the name of this method.

--- a/src/jllvm/materialization/ByteCodeCompileLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeCompileLayer.cpp
@@ -332,6 +332,16 @@ public:
         return returnConstantForClassObject(builder, fieldDescriptor, methodName + ";" + typeDescriptor,
                                             [=](const ClassObject* classObject)
                                             {
+                                                // https://docs.oracle.com/javase/specs/jvms/se17/html/jvms-5.html#jvms-5.4.3.3
+
+                                                // Otherwise, method resolution attempts to locate the referenced method
+                                                // in C and its superclasses:
+
+                                                // Otherwise, if C declares a method with the name and descriptor
+                                                // specified by the method reference, method lookup succeeds.
+
+                                                // Otherwise, if C has a superclass, step 2 of method resolution is
+                                                // recursively invoked on the direct superclass of C.
                                                 for (const ClassObject* curr : classObject->getSuperClasses())
                                                 {
                                                     llvm::ArrayRef<Method> methods = curr->getMethods();
@@ -347,6 +357,18 @@ public:
                                                         return *iter->getVTableSlot();
                                                     }
                                                 }
+
+                                                // TODO: Implement below. Requires a vtable slot per implementing class
+                                                //       For any default interface method.
+
+                                                // Otherwise, method resolution attempts to locate the referenced method
+                                                // in the superinterfaces of the specified class C:
+
+                                                // If the maximally-specific superinterface methods of C for the name
+                                                // and descriptor specified by the method reference include exactly one
+                                                // method that does not have its ACC_ABSTRACT flag set, then this method
+                                                // is chosen and method lookup succeeds.
+
                                                 llvm_unreachable("method not found");
                                             });
     }

--- a/src/jllvm/object/ClassObject.hpp
+++ b/src/jllvm/object/ClassObject.hpp
@@ -385,6 +385,21 @@ public:
         return m_className;
     }
 
+    /// Returns the name of the package this class is defined in.
+    /// Note: This is not properly checked whether that is how the JVM spec actually defines, but we currently define
+    /// it as the part before the last '/'.
+    llvm::StringRef getPackageName() const
+    {
+        auto [package, clazz] = m_className.rsplit('/');
+        if (clazz.empty())
+        {
+            // If there is no /, 'clazz' is empty and 'package' is actually the class name.
+            // We assume the package to be the empty string for now.
+            return clazz;
+        }
+        return package;
+    }
+
     /// Returns the super class of this class or null if the class does not have a super class.
     /// This is notably the case for array types, primitives and java/lang/Object.
     const ClassObject* getSuperClass() const

--- a/tests/Execution/invoke-virtual-interface-method.java
+++ b/tests/Execution/invoke-virtual-interface-method.java
@@ -1,0 +1,29 @@
+// RUN: rm -rf %t && split-file %s %t
+// RUN: cd %t && javac %t/Test.java -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+// XFAIL: *
+
+//--- Test.java
+
+public class Test implements Other
+{
+    public static native void print(int i);
+
+    public static void main(String[] args)
+    {
+        var t = new Test();
+        // CHECK: 5
+        t.a();
+    }
+}
+
+//--- Other.java
+
+public interface Other
+{
+    default void a()
+    {
+        Test.print(5);
+    }
+}

--- a/tests/Execution/private-invoke-virtual.java
+++ b/tests/Execution/private-invoke-virtual.java
@@ -1,0 +1,36 @@
+// RUN: rm -rf %t && split-file %s %t
+// RUN: cd %t && javac %t/Other.java -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+//--- Test.java
+
+public class Test
+{
+    public static native void print(int i);
+
+    public static void main(String[] args)
+    {
+        Other t = new Other();
+        // CHECK: 6
+        t.foo();
+        Test o = t;
+        // CHECK: 5
+        o.foo();
+    }
+
+    private void foo()
+    {
+        print(5);
+    }
+}
+
+
+//--- Other.java
+
+public class Other extends Test
+{
+    public void foo()
+    {
+        Test.print(6);
+    }
+}

--- a/tests/Execution/simple-package-private-override.java
+++ b/tests/Execution/simple-package-private-override.java
@@ -1,0 +1,36 @@
+// RUN: rm -rf %t && split-file %s %t
+// RUN: cd %t && javac %t/Other.java -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+//--- Test.java
+
+public class Test
+{
+    public static native void print(int i);
+
+    public static void main(String[] args)
+    {
+        Other t = new Other();
+        // CHECK: 6
+        t.foo();
+        Test o = t;
+        // CHECK: 6
+        o.foo();
+    }
+
+    void foo()
+    {
+        print(5);
+    }
+}
+
+
+//--- Other.java
+
+public class Other extends Test
+{
+    void foo()
+    {
+        Test.print(6);
+    }
+}


### PR DESCRIPTION
The current vtable slot assignment was prematurely optimized to the point of being incorrect. In particular, calling private methods was not possible as they have been filtered out. In the future, if we were to fully implement the complicated package private overriding scenario described here https://docs.oracle.com/javase/specs/jvms/se17/html/jvms-5.html#jvms-5.4.5 it'd likely stand in our way too.

For now, just simplify the implementation and give a vtable slot to every non-static method. Then properly assign method according to the method selection described in 5.4.6 (this is the same procedure as for interface methods). Additionally, package private calls from the same "package" was implemented (this is required to load `Class`) and tests annotated XFAIL with todos for the future were added