### PR TITLE
[instruction] Implement `athrow` and unwinding mechanism

### DIFF
--- a/src/jllvm/object/Object.hpp
+++ b/src/jllvm/object/Object.hpp
@@ -178,4 +178,19 @@ public:
 
 static_assert(std::is_standard_layout_v<String>);
 
+/// In memory representation for a Java Throwable.
+struct Throwable : ObjectInterface
+{
+    ObjectHeader header;
+
+    Object* backtrace = nullptr;
+    String* detailMessage = nullptr;
+    Throwable* cause = nullptr;
+    Array<Object*>* stackTrace = nullptr;
+    std::int32_t depth{};
+    Object* suppressedExceptions = nullptr;
+};
+
+static_assert(std::is_standard_layout_v<Throwable>);
+
 } // namespace jllvm

--- a/src/jllvm/vm/GarbageCollector.cpp
+++ b/src/jllvm/vm/GarbageCollector.cpp
@@ -250,7 +250,7 @@ constexpr auto SLAB_SIZE = 4096 / sizeof(void*);
 
 } // namespace
 
-void** jllvm::GarbageCollector::allocateStatic()
+jllvm::GCRef<jllvm::Object> jllvm::GarbageCollector::allocateStatic()
 {
     if (m_staticRefsSlabs.empty() || m_staticRefsSlabs.back().get() + SLAB_SIZE == m_staticRefsBumpPtr)
     {
@@ -259,7 +259,7 @@ void** jllvm::GarbageCollector::allocateStatic()
 
     void** storage = m_staticRefsBumpPtr;
     m_staticRefsBumpPtr++;
-    return storage;
+    return GCRef<Object>(storage);
 }
 
 void jllvm::GarbageCollector::garbageCollect()

--- a/src/jllvm/vm/JIT.hpp
+++ b/src/jllvm/vm/JIT.hpp
@@ -52,11 +52,11 @@ class JIT
 
     JIT(std::unique_ptr<llvm::orc::ExecutionSession>&& session, std::unique_ptr<llvm::orc::EPCIndirectionUtils>&& epciu,
         llvm::orc::JITTargetMachineBuilder&& builder, llvm::DataLayout&& layout, ClassLoader& classLoader,
-        GarbageCollector& gc, StringInterner& stringInterner, void* jniFunctions);
+        GarbageCollector& gc, StringInterner& stringInterner, void* jniFunctions, Throwable** activeException);
 
 public:
     static JIT create(ClassLoader& classLoader, GarbageCollector& gc, StringInterner& stringInterner,
-                      void* jniFunctions);
+                      void* jniFunctions, Throwable** activeException);
 
     ~JIT();
 

--- a/src/jllvm/vm/NativeImplementation.cpp
+++ b/src/jllvm/vm/NativeImplementation.cpp
@@ -7,5 +7,5 @@ jllvm::VirtualMachine& jllvm::detail::virtualMachineFromJNIEnv(JNIEnv* env)
 
 void jllvm::registerJavaClasses(VirtualMachine& virtualMachine)
 {
-    addModels<ObjectModel, ClassModel>(virtualMachine);
+    addModels<ObjectModel, ClassModel, ThrowableModel>(virtualMachine);
 }

--- a/src/jllvm/vm/NativeImplementation.hpp
+++ b/src/jllvm/vm/NativeImplementation.hpp
@@ -147,6 +147,23 @@ public:
                         addMember<&ClassModel::desiredAssertionStatus0>());
 };
 
+/// Model implementation for the native methods of Javas 'Thowable' class.
+class ThrowableModel : public ModelBase<Throwable>
+{
+public:
+    using Base::Base;
+
+    Throwable* fillInStackTrace(int)
+    {
+        // TODO: Set backtrace and depth of 'javaThis'. See
+        // https://github.com/openjdk/jdk/blob/4f096eb7c9066e5127d9ab8c1c893e991a23d316/src/hotspot/share/classfile/javaClasses.cpp#L2491
+        return &javaThis;
+    }
+
+    constexpr static llvm::StringLiteral className = "java/lang/Throwable";
+    constexpr static auto methods = std::make_tuple(addMember<&ThrowableModel::fillInStackTrace>());
+};
+
 /// Register any models for builtin Java classes in the VM.
 void registerJavaClasses(VirtualMachine& virtualMachine);
 

--- a/src/jllvm/vm/VirtualMachine.hpp
+++ b/src/jllvm/vm/VirtualMachine.hpp
@@ -25,7 +25,8 @@ class VirtualMachine
     ClassLoader m_classLoader;
     GarbageCollector m_gc;
     StringInterner m_stringInterner;
-    JIT m_jit = JIT::create(m_classLoader, m_gc, m_stringInterner, m_jniEnv.get());
+    GCRef<Throwable> m_activeException = static_cast<GCRef<Throwable>>(m_gc.allocateStatic());
+    JIT m_jit = JIT::create(m_classLoader, m_gc, m_stringInterner, m_jniEnv.get(), m_activeException.ref());
     std::mt19937 m_pseudoGen;
     std::uniform_int_distribution<std::uint32_t> m_hashIntDistrib;
 

--- a/tests/Execution/athrow.java
+++ b/tests/Execution/athrow.java
@@ -1,0 +1,30 @@
+// RUN: javac %s -d %t
+// RUN: not jllvm -Xenable-test-utils %t/Test.class 2>&1 | FileCheck %s
+
+class Test
+{
+    static native void print(int i);
+
+    public static void main(String[] args)
+    {
+        // CHECK-NOT: {{[0-9]+}}
+
+        // CHECK: RuntimeException
+        // CHECK: A message
+
+        // CHECK-NOT: {{[0-9]+}}
+        unwindThroughVoid();
+        print(5);
+    }
+
+    private static void unwindThroughVoid()
+    {
+        unwindThroughOther();
+        print(5);
+    }
+
+    private static int unwindThroughOther()
+    {
+        throw new RuntimeException("A message");
+    }
+}


### PR DESCRIPTION
This if the first step for exception handling in our JVM. As described in https://github.com/JLLVM/JLLVM/issues/6, due to shortcomings in LLVMs builtin exception handling when using a relocating GC, we are opting to build the mechanism ourselves. This is achieved by manually generating code to check if and exception was thrown and do appropriate dispatch.

This patch is the first patch in this series which implements `athrow` and the unwinding mechanism. Throwing essentially sets a global called `activeException` to the now active exception. Unwinding is done by checking whether this global is set and returning from the function if true. This requires generating code after every instruction might cause unwinding.

Next patches will create code for dispatching into catch handlers.

Fixes https://github.com/JLLVM/JLLVM/issues/54