### PR TITLE
[codegen] implement dispatch chains to catch handlers

### DIFF
--- a/src/jllvm/class/ClassFile.hpp
+++ b/src/jllvm/class/ClassFile.hpp
@@ -50,11 +50,7 @@ public:
         return m_index != 0;
     }
 
-    /// True if two pool indices refer to the same entry.
-    bool operator==(const PoolIndex& rhs) const
-    {
-        return m_index == rhs.m_index;
-    }
+    auto operator<=>(const PoolIndex& rhs) const = default;
 };
 
 struct Utf8Info;

--- a/src/jllvm/vm/JIT.cpp
+++ b/src/jllvm/vm/JIT.cpp
@@ -63,6 +63,9 @@ jllvm::JIT::JIT(std::unique_ptr<llvm::orc::ExecutionSession>&& session,
     llvm::cantFail(m_main.define(createLambdaMaterializationUnit(
         "jllvm_gc_alloc", m_optimizeLayer, [&](std::uint32_t size) { return m_gc.allocate(size); }, m_dataLayout,
         m_interner)));
+    llvm::cantFail(m_main.define(createLambdaMaterializationUnit(
+        "jllvm_for_name_loaded", m_optimizeLayer, [&](const char* name) { return m_classLoader.forNameLoaded(name); },
+        m_dataLayout, m_interner)));
     llvm::cantFail(m_main.define(llvm::orc::absoluteSymbols(
         {{m_interner("jllvm_instance_of"), llvm::JITEvaluatedSymbol::fromPointer(
                                                +[](const Object* object, const ClassObject* classObject) -> std::int32_t

--- a/tests/Execution/try-catch.java
+++ b/tests/Execution/try-catch.java
@@ -1,20 +1,139 @@
 // RUN: javac %s -d %t
-// RUN: jllvm -Xenable-test-utils %t/Test.class
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck --match-full-lines %s
 
 class Test
 {
-    public static void foo()
-    {}
+    static native void print(int i);
+    static native void print(String i);
+
+    public static void raiseRuntimeException()
+    {
+        throw new RuntimeException("A message");
+    }
 
     public static void main(String[] args)
     {
         try
         {
-            foo();
+            raiseRuntimeException();
         }
         catch (Exception e)
         {
-            e.printStackTrace();
+            // CHECK: 5
+            print(5);
+        }
+
+        try
+        {
+            raiseRuntimeException();
+        }
+        catch (OutOfMemoryError e)
+        {
+            // CHECK-NOT: 5
+            print(5);
+        }
+        catch (RuntimeException e)
+        {
+            // CHECK: 6
+            print(6);
+        }
+        catch (Exception e)
+        {
+            // CHECK-NOT: 5
+            print(5);
+        }
+
+        try
+        {
+            try
+            {
+                try
+                {
+                    raiseRuntimeException();
+                }
+                catch (OutOfMemoryError e)
+                {
+                    // CHECK-NOT: 5
+                    print(5);
+                }
+            }
+            catch (RuntimeException e)
+            {
+                // CHECK: 6
+                print(6);
+            }
+        }
+        catch (Exception e)
+        {
+            // CHECK-NOT: 5
+            print(5);
+        }
+
+        try
+        {
+            try
+            {
+                try
+                {
+                    raiseRuntimeException();
+                }
+                catch (OutOfMemoryError e)
+                {
+                    // CHECK-NOT: 5
+                    print(5);
+                }
+                finally
+                {
+                    // CHECK: 1
+                    print(1);
+                }
+                // CHECK-NOT: 5
+                print(5);
+            }
+            catch (RuntimeException e)
+            {
+                // CHECK: 6
+                print(6);
+            }
+            finally
+            {
+                // CHECK: 2
+                print(2);
+            }
+            // CHECK: 5
+            print(5);
+        }
+        catch (Exception e)
+        {
+            // CHECK-NOT: 5
+            print(5);
+        }
+        finally
+        {
+            // CHECK: 3
+            print(3);
+        }
+
+
+
+        try
+        {
+            throw new RuntimeException("From athrow to catch");
+        }
+        catch (OutOfMemoryError e)
+        {
+            // CHECK-NOT: 5
+            print(5);
+        }
+        catch (RuntimeException e)
+        {
+            // CHECK: From athrow to catch
+            print(e.getMessage());
+        }
+        catch (Exception e)
+        {
+            // CHECK-NOT: 5
+            print(5);
         }
     }
 }


### PR DESCRIPTION
Catching exceptions works by having a range of bytecode offsets "under protection" of a handler. Each handler has an associated handler program counter and a catch type.

This PR generates appropriate code using the handlers to perform dynamic instance of checks on the exception object and then jump to the corresponding handler.

Special care had to be taken in the order of handlers since it determines which handler is checked first.

Depends on https://github.com/JLLVM/JLLVM/pull/103

Fixes https://github.com/JLLVM/JLLVM/issues/6