### PR TITLE
[GC][codegen] add extra GC error detection using ASAN

### DIFF
--- a/src/jllvm/materialization/ByteCodeCompileLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeCompileLayer.cpp
@@ -1740,6 +1740,10 @@ void jllvm::ByteCodeCompileLayer::emit(std::unique_ptr<llvm::orc::Materializatio
         llvm::Function::Create(descriptorToType(descriptor, methodInfo->isStatic(), module->getContext()),
                                llvm::GlobalValue::ExternalLinkage, mangleMethod(*methodInfo, *classFile), module.get());
     function->setGC("coreclr");
+#ifdef LLVM_ADDRESS_SANITIZER_BUILD
+    function->addFnAttr(llvm::Attribute::SanitizeAddress);
+#endif
+
     auto code = methodInfo->getAttributes().find<Code>();
     assert(code);
     codeGenBody(function, *code, *classFile,

--- a/src/jllvm/vm/CMakeLists.txt
+++ b/src/jllvm/vm/CMakeLists.txt
@@ -1,7 +1,7 @@
 llvm_map_components_to_libnames(llvm_native_libs ${LLVM_NATIVE_ARCH})
 
 add_library(JLLVMVirtualMachine VirtualMachine.cpp JIT.cpp GarbageCollector.cpp StackMapRegistrationPlugin.cpp
-        JNIImplementation.cpp NativeImplementation.cpp StringInterner.cpp)
+        JNIImplementation.cpp NativeImplementation.cpp StringInterner.cpp MarkSanitizersGCLeafs.cpp)
 target_link_libraries(JLLVMVirtualMachine
         PRIVATE ${llvm_native_libs}
         PUBLIC JLLVMClassParser JLLVMObject LLVMExecutionEngine LLVMOrcJIT LLVMJITLink JLLVMMaterialization

--- a/src/jllvm/vm/JIT.cpp
+++ b/src/jllvm/vm/JIT.cpp
@@ -78,7 +78,7 @@ jllvm::JIT::JIT(std::unique_ptr<llvm::orc::ExecutionSession>&& session,
     llvm::cantFail(m_main.define(llvm::orc::absoluteSymbols(
         {{m_interner("activeException"), llvm::JITEvaluatedSymbol::fromPointer(activeException)}})));
 
-#ifdef LLVM_ADDRESS_SANITIZER_BUILD
+#if LLVM_ADDRESS_SANITIZER_BUILD
     m_main.addGenerator(llvm::cantFail(llvm::orc::DynamicLibrarySearchGenerator::GetForCurrentProcess(
         m_dataLayout.getGlobalPrefix(),
         /*Allow=*/[](const llvm::orc::SymbolStringPtr& symbolStringPtr)
@@ -160,7 +160,7 @@ void jllvm::JIT::optimize(llvm::Module& module)
 
     passBuilder.registerOptimizerLastEPCallback([&](llvm::ModulePassManager& modulePassManager, llvm::OptimizationLevel)
         {
-#ifdef LLVM_ADDRESS_SANITIZER_BUILD
+#if LLVM_ADDRESS_SANITIZER_BUILD
             llvm::AddressSanitizerOptions options;
             modulePassManager.addPass(llvm::AddressSanitizerPass(options));
             modulePassManager.addPass(llvm::RequireAnalysisPass<llvm::GlobalsAA, llvm::Module>{});

--- a/src/jllvm/vm/MarkSanitizersGCLeafs.cpp
+++ b/src/jllvm/vm/MarkSanitizersGCLeafs.cpp
@@ -1,0 +1,18 @@
+
+#include "MarkSanitizersGCLeafs.hpp"
+
+llvm::PreservedAnalyses jllvm::MarkSanitizersGCLeafsPass::run(llvm::Module& M, llvm::ModuleAnalysisManager&)
+{
+    constexpr llvm::StringRef instrumentationPrefixes[] = {"__asan_", "__tsan_"};
+
+    for (llvm::Function& function : M.getFunctionList())
+    {
+        llvm::StringRef name = function.getName();
+        if (llvm::none_of(instrumentationPrefixes, [&](llvm::StringRef prefix) { return name.starts_with(prefix); }))
+        {
+            continue;
+        }
+        function.addFnAttr("gc-leaf-function");
+    }
+    return llvm::PreservedAnalyses::all();
+}

--- a/src/jllvm/vm/MarkSanitizersGCLeafs.hpp
+++ b/src/jllvm/vm/MarkSanitizersGCLeafs.hpp
@@ -1,0 +1,22 @@
+
+#pragma once
+
+#include <llvm/Analysis/TargetLibraryInfo.h>
+#include <llvm/Analysis/TargetTransformInfo.h>
+#include <llvm/IR/Dominators.h>
+#include <llvm/IR/PassManager.h>
+
+namespace jllvm
+{
+/// Convenience pass placed right after any sanitizer or similar instrumentation passes.
+/// This pass does basically nothing but mark calls to instrumentation functions as "gc-leaf-functions" to improve
+/// codegen of the output and avoid calls to these functions being converted to state points.
+class MarkSanitizersGCLeafsPass : public llvm::PassInfoMixin<MarkSanitizersGCLeafsPass>
+{
+public:
+    explicit MarkSanitizersGCLeafsPass() = default;
+
+    /// Run function with signature indicating the pass manager that this is a module pass.
+    llvm::PreservedAnalyses run(llvm::Module& M, llvm::ModuleAnalysisManager& AM);
+};
+} // namespace jllvm


### PR DESCRIPTION
One of the hardest to debug errors once they occur are errors related to GC. Most of these are usually a relocation not being updated or maybe the GC collecting an object to early.

Either way, the earlier and faster we can detect these errors the better. This patch adds support for using ASAN to instrument the `toSpace` aka the not actively in use heap area by poisoning it to make any reads and writes instrumented with ASAN fail with a backtrace and error message. To make this more even more effective, passes from LLVM are added to our JIT to also instrument our produced Java code.

This makes it possible to also detect any incorrect memory operations in Java due to codegen errors and similar.

Demonstration code:
```cpp
auto* savePtr = m_activeException.get();
// causes relocation of m_activeException
m_gc.allocate(1);
llvm::errs() << savePtr->depth;
```

```
GC: Collected 0 objects, relocated 10
=================================================================
==26114==ERROR: AddressSanitizer: use-after-poison on address 0x621000003e00 at pc 0x00000edadf1c bp 0x7ffffffed370 sp 0x7ffffffed368
READ of size 4 at 0x621000003e00 thread T0
    #0 0xedadf1b in jllvm::VirtualMachine::executeMain(llvm::StringRef, llvm::ArrayRef<llvm::StringRef>) /mnt/c/Users/Markus/Documents/CLion/JLLVM/src/jllvm/vm/VirtualMachine.cpp:205:30
    #1 0xed0f33a in jllvm::main(llvm::StringRef, llvm::ArrayRef<char*>) /mnt/c/Users/Markus/Documents/CLion/JLLVM/src/jllvm/main/Main.cpp:110:15
    #2 0xed0b734 in main /mnt/c/Users/Markus/Documents/CLion/JLLVM/tools/main.cpp:11:12
    #3 0x7fffff1b3a8f in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #4 0x7fffff1b3b48 in __libc_start_main csu/../csu/libc-start.c:360:3
    #5 0xec490a4 in _start (/mnt/c/Users/Markus/Documents/CLion/JLLVM/cmake-build-debug-clang-wsl/bin/jllvm+0x6c490a4) (BuildId: 4d5fb349f8e3d54a)

0x621000003e00 is located 256 bytes inside of 4096-byte region [0x621000003d00,0x621000004d00)
allocated by thread T0 here:
    #0 0xed08e3d in operator new[](unsigned long) (/mnt/c/Users/Markus/Documents/CLion/JLLVM/cmake-build-debug-clang-wsl/bin/jllvm+0x6d08e3d) (BuildId: 4d5fb349f8e3d54a)
    #1 0xeea68cf in std::__detail::_MakeUniq<char []>::__array std::make_unique<char []>(unsigned long) /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/unique_ptr.h:1080:30
    #2 0xee94f58 in jllvm::GarbageCollector::GarbageCollector(unsigned long) /mnt/c/Users/Markus/Documents/CLion/JLLVM/src/jllvm/vm/GarbageCollector.cpp:21:18
    #3 0xedac36d in jllvm::VirtualMachine::VirtualMachine(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>>&&) /mnt/c/Users/Markus/Documents/CLion/JLLVM/src/jllvm/vm/VirtualMachine.cpp:172:7
    #4 0xed0e582 in jllvm::main(llvm::StringRef, llvm::ArrayRef<char*>) /mnt/c/Users/Markus/Documents/CLion/JLLVM/src/jllvm/main/Main.cpp:94:27
    #5 0xed0b734 in main /mnt/c/Users/Markus/Documents/CLion/JLLVM/tools/main.cpp:11:12
    #6 0x7fffff1b3a8f in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16

```