### PR TITLE
[instruction] Add support for all `const` instructions

### DIFF
--- a/src/jllvm/materialization/ByteCodeCompileLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeCompileLayer.cpp
@@ -718,15 +718,13 @@ void codeGenBody(llvm::Function* function, const Code& code, const ClassFile& cl
             operation, [](...) { llvm_unreachable("NOT YET IMPLEMENTED"); },
             [&](OneOf<AALoad, BALoad, CALoad, DALoad, FALoad, IALoad, LALoad, SALoad>)
             {
-                llvm::Type* type = match(
+                auto* type = match(
                     operation, [](...) -> llvm::Type* { llvm_unreachable("Invalid array load operation"); },
                     [&](AALoad) -> llvm::Type* { return referenceType(builder.getContext()); },
-                    [&](BALoad) -> llvm::Type* { return builder.getInt8Ty(); },
-                    [&](OneOf<CALoad, SALoad>) -> llvm::Type* { return builder.getInt16Ty(); },
-                    [&](DALoad) -> llvm::Type* { return builder.getDoubleTy(); },
-                    [&](FALoad) -> llvm::Type* { return builder.getFloatTy(); },
-                    [&](IALoad) -> llvm::Type* { return builder.getInt32Ty(); },
-                    [&](LALoad) -> llvm::Type* { return builder.getInt64Ty(); });
+                    [&](BALoad) { return builder.getInt8Ty(); },
+                    [&](OneOf<CALoad, SALoad>) { return builder.getInt16Ty(); },
+                    [&](DALoad) { return builder.getDoubleTy(); }, [&](FALoad) { return builder.getFloatTy(); },
+                    [&](IALoad) { return builder.getInt32Ty(); }, [&](LALoad) { return builder.getInt64Ty(); });
 
                 llvm::Value* index = operandStack.pop_back(builder.getInt32Ty());
                 // TODO: throw NullPointerException if array is null
@@ -791,29 +789,26 @@ void codeGenBody(llvm::Function* function, const Code& code, const ClassFile& cl
             { operandStack.push_back(llvm::ConstantPointerNull::get(referenceType(builder.getContext()))); },
             [&](OneOf<ALoad, DLoad, FLoad, ILoad, LLoad> load)
             {
-                llvm::Type* type = match(
+                auto* type = match(
                     operation, [](...) -> llvm::Type* { llvm_unreachable("Invalid load operation"); },
-                    [&](ALoad) -> llvm::Type* { return referenceType(builder.getContext()); },
-                    [&](DLoad) -> llvm::Type* { return builder.getDoubleTy(); },
-                    [&](FLoad) -> llvm::Type* { return builder.getFloatTy(); },
-                    [&](ILoad) -> llvm::Type* { return builder.getInt32Ty(); },
-                    [&](LLoad) -> llvm::Type* { return builder.getInt64Ty(); });
+                    [&](ALoad) { return referenceType(builder.getContext()); },
+                    [&](DLoad) { return builder.getDoubleTy(); }, [&](FLoad) { return builder.getFloatTy(); },
+                    [&](ILoad) { return builder.getInt32Ty(); }, [&](LLoad) { return builder.getInt64Ty(); });
 
                 operandStack.push_back(builder.CreateLoad(type, locals[load.index]));
             },
             [&](OneOf<ALoad0, DLoad0, FLoad0, ILoad0, LLoad0, ALoad1, DLoad1, FLoad1, ILoad1, LLoad1, ALoad2, DLoad2,
                       FLoad2, ILoad2, LLoad2, ALoad3, DLoad3, FLoad3, ILoad3, LLoad3>)
             {
-                llvm::Type* type = match(
+                auto* type = match(
                     operation, [](...) -> llvm::Type* { llvm_unreachable("Invalid load operation"); },
-                    [&](OneOf<ALoad0, ALoad1, ALoad2, ALoad3>) -> llvm::Type*
-                    { return referenceType(builder.getContext()); },
-                    [&](OneOf<DLoad0, DLoad1, DLoad2, DLoad3>) -> llvm::Type* { return builder.getDoubleTy(); },
-                    [&](OneOf<FLoad0, FLoad1, FLoad2, FLoad3>) -> llvm::Type* { return builder.getFloatTy(); },
-                    [&](OneOf<ILoad0, ILoad1, ILoad2, ILoad3>) -> llvm::Type* { return builder.getInt32Ty(); },
-                    [&](OneOf<LLoad0, LLoad1, LLoad2, LLoad3>) -> llvm::Type* { return builder.getInt64Ty(); });
+                    [&](OneOf<ALoad0, ALoad1, ALoad2, ALoad3>) { return referenceType(builder.getContext()); },
+                    [&](OneOf<DLoad0, DLoad1, DLoad2, DLoad3>) { return builder.getDoubleTy(); },
+                    [&](OneOf<FLoad0, FLoad1, FLoad2, FLoad3>) { return builder.getFloatTy(); },
+                    [&](OneOf<ILoad0, ILoad1, ILoad2, ILoad3>) { return builder.getInt32Ty(); },
+                    [&](OneOf<LLoad0, LLoad1, LLoad2, LLoad3>) { return builder.getInt64Ty(); });
 
-                std::uint8_t index = match(
+                auto index = match(
                     operation, [](...) -> std::uint8_t { llvm_unreachable("Invalid load operation"); },
                     [&](OneOf<ALoad0, DLoad0, FLoad0, ILoad0, LLoad0>) { return 0; },
                     [&](OneOf<ALoad1, DLoad1, FLoad1, ILoad1, LLoad1>) { return 1; },
@@ -859,11 +854,9 @@ void codeGenBody(llvm::Function* function, const Code& code, const ClassFile& cl
             {
                 llvm::Type* type = match(
                     operation, [](...) -> llvm::Type* { llvm_unreachable("Invalid load operation"); },
-                    [&](AReturn) -> llvm::Type* { return referenceType(builder.getContext()); },
-                    [&](DReturn) -> llvm::Type* { return builder.getDoubleTy(); },
-                    [&](FReturn) -> llvm::Type* { return builder.getFloatTy(); },
-                    [&](IReturn) -> llvm::Type* { return builder.getInt32Ty(); },
-                    [&](LReturn) -> llvm::Type* { return builder.getInt64Ty(); });
+                    [&](AReturn) { return referenceType(builder.getContext()); },
+                    [&](DReturn) { return builder.getDoubleTy(); }, [&](FReturn) { return builder.getFloatTy(); },
+                    [&](IReturn) { return builder.getInt32Ty(); }, [&](LReturn) { return builder.getInt64Ty(); });
 
                 llvm::Value* value = operandStack.pop_back(type);
 
@@ -896,11 +889,9 @@ void codeGenBody(llvm::Function* function, const Code& code, const ClassFile& cl
             {
                 auto* type = match(
                     operation, [](...) -> llvm::Type* { llvm_unreachable("Invalid store operation"); },
-                    [&](AStore) -> llvm::Type* { return referenceType(builder.getContext()); },
-                    [&](DStore) -> llvm::Type* { return builder.getDoubleTy(); },
-                    [&](FStore) -> llvm::Type* { return builder.getFloatTy(); },
-                    [&](IStore) -> llvm::Type* { return builder.getInt32Ty(); },
-                    [&](LStore) -> llvm::Type* { return builder.getInt64Ty(); });
+                    [&](AStore) { return referenceType(builder.getContext()); },
+                    [&](DStore) { return builder.getDoubleTy(); }, [&](FStore) { return builder.getFloatTy(); },
+                    [&](IStore) { return builder.getInt32Ty(); }, [&](LStore) { return builder.getInt64Ty(); });
 
                 builder.CreateStore(operandStack.pop_back(type), locals[store.index]);
             },
@@ -909,19 +900,18 @@ void codeGenBody(llvm::Function* function, const Code& code, const ClassFile& cl
             {
                 auto* type = match(
                     operation, [](...) -> llvm::Type* { llvm_unreachable("Invalid store operation"); },
-                    [&](OneOf<AStore0, AStore1, AStore2, AStore3>) -> llvm::Type*
-                    { return referenceType(builder.getContext()); },
-                    [&](OneOf<DStore0, DStore1, DStore2, DStore3>) -> llvm::Type* { return builder.getDoubleTy(); },
-                    [&](OneOf<FStore0, FStore1, FStore2, FStore3>) -> llvm::Type* { return builder.getFloatTy(); },
-                    [&](OneOf<IStore0, IStore1, IStore2, IStore3>) -> llvm::Type* { return builder.getInt32Ty(); },
-                    [&](OneOf<LStore0, LStore1, LStore2, LStore3>) -> llvm::Type* { return builder.getInt64Ty(); });
+                    [&](OneOf<AStore0, AStore1, AStore2, AStore3>) { return referenceType(builder.getContext()); },
+                    [&](OneOf<DStore0, DStore1, DStore2, DStore3>) { return builder.getDoubleTy(); },
+                    [&](OneOf<FStore0, FStore1, FStore2, FStore3>) { return builder.getFloatTy(); },
+                    [&](OneOf<IStore0, IStore1, IStore2, IStore3>) { return builder.getInt32Ty(); },
+                    [&](OneOf<LStore0, LStore1, LStore2, LStore3>) { return builder.getInt64Ty(); });
 
                 auto index = match(
                     operation, [](...) -> std::uint8_t { llvm_unreachable("Invalid store operation"); },
-                    [&](OneOf<AStore0, DStore0, FStore0, IStore0, LStore0>) -> std::uint8_t { return 0; },
-                    [&](OneOf<AStore1, DStore1, FStore1, IStore1, LStore1>) -> std::uint8_t { return 1; },
-                    [&](OneOf<AStore2, DStore2, FStore2, IStore2, LStore2>) -> std::uint8_t { return 2; },
-                    [&](OneOf<AStore3, DStore3, FStore3, IStore3, LStore3>) -> std::uint8_t { return 3; });
+                    [&](OneOf<AStore0, DStore0, FStore0, IStore0, LStore0>) { return 0; },
+                    [&](OneOf<AStore1, DStore1, FStore1, IStore1, LStore1>) { return 1; },
+                    [&](OneOf<AStore2, DStore2, FStore2, IStore2, LStore2>) { return 2; },
+                    [&](OneOf<AStore3, DStore3, FStore3, IStore3, LStore3>) { return 3; });
 
                 builder.CreateStore(operandStack.pop_back(type), locals[index]);
             },
@@ -952,20 +942,16 @@ void codeGenBody(llvm::Function* function, const Code& code, const ClassFile& cl
             {
                 auto* value = match(
                     operation, [](...) -> llvm::Value* { llvm_unreachable("Invalid const operation"); },
-                    [&](DConst0) -> llvm::Value* { return llvm::ConstantFP::get(builder.getDoubleTy(), 0.0); },
-                    [&](DConst1) -> llvm::Value* { return llvm::ConstantFP::get(builder.getDoubleTy(), 1.0); },
-                    [&](FConst0) -> llvm::Value* { return llvm::ConstantFP::get(builder.getFloatTy(), 0.0); },
-                    [&](FConst1) -> llvm::Value* { return llvm::ConstantFP::get(builder.getFloatTy(), 1.0); },
-                    [&](FConst2) -> llvm::Value* { return llvm::ConstantFP::get(builder.getFloatTy(), 2.0); },
-                    [&](IConstM1) -> llvm::Value* { return builder.getInt32(-1); },
-                    [&](IConst0) -> llvm::Value* { return builder.getInt32(0); },
-                    [&](IConst1) -> llvm::Value* { return builder.getInt32(1); },
-                    [&](IConst2) -> llvm::Value* { return builder.getInt32(2); },
-                    [&](IConst3) -> llvm::Value* { return builder.getInt32(3); },
-                    [&](IConst4) -> llvm::Value* { return builder.getInt32(4); },
-                    [&](IConst5) -> llvm::Value* { return builder.getInt32(5); },
-                    [&](LConst0) -> llvm::Value* { return builder.getInt64(0); },
-                    [&](LConst1) -> llvm::Value* { return builder.getInt64(1); });
+                    [&](DConst0) { return llvm::ConstantFP::get(builder.getDoubleTy(), 0.0); },
+                    [&](DConst1) { return llvm::ConstantFP::get(builder.getDoubleTy(), 1.0); },
+                    [&](FConst0) { return llvm::ConstantFP::get(builder.getFloatTy(), 0.0); },
+                    [&](FConst1) { return llvm::ConstantFP::get(builder.getFloatTy(), 1.0); },
+                    [&](FConst2) { return llvm::ConstantFP::get(builder.getFloatTy(), 2.0); },
+                    [&](IConstM1) { return builder.getInt32(-1); }, [&](IConst0) { return builder.getInt32(0); },
+                    [&](IConst1) { return builder.getInt32(1); }, [&](IConst2) { return builder.getInt32(2); },
+                    [&](IConst3) { return builder.getInt32(3); }, [&](IConst4) { return builder.getInt32(4); },
+                    [&](IConst5) { return builder.getInt32(5); }, [&](LConst0) { return builder.getInt64(0); },
+                    [&](LConst1) { return builder.getInt64(1); });
 
                 operandStack.push_back(value);
             },

--- a/tests/Execution/jni-primitives.java
+++ b/tests/Execution/jni-primitives.java
@@ -3,39 +3,41 @@
 
 class Test
 {
-    public static native void print(byte i);
-    public static native void print(char i);
-    public static native void print(double i);
-    public static native void print(float i);
+    public static native void print(byte b);
+    public static native void print(char c);
+    public static native void print(double d);
+    public static native void print(float f);
     public static native void print(int i);
-    public static native void print(long i);
-    public static native void print(short i);
-    public static native void print(boolean i);
+    public static native void print(long l);
+    public static native void print(short s);
+    public static native void print(boolean b);
 
     public static void main(String[] args)
     {
         byte b = -1;
+        char c = 0; // Java char does not support assignment from negative values
+        double d = 1.0;
+        float f = 2.0f;
+        int i = 3;
+        long l = 4;
+        short s = 5;
+        boolean z = false;
+
+        // CHECK: -1
         print(b);
-        short s = -1;
-        print(s);
-        int i = -1;
+        // CHECK: 0
+        print(c);
+        // CHECK: 1
+        print(d);
+        // CHECK: 2
+        print(f);
+        // CHECK: 3
         print(i);
-
-        // TODO: Needs 'ldc2_w' https://github.com/JLLVM/JLLVM/issues/17
-        // long l = -1;
-        // print(l);
-
-        // Java char does not support assignment from negative values
-        char c = 5;
-        print(5);
-
-        print(true);
-
-        print(0.0f);
+        // CHECK: 4
+        print(l);
+        // CHECK: 5
+        print(s);
+        // CHECK: 0
+        print(z);
     }
 }
-
-// CHECK-COUNT-3: -1
-// CHECK: 5
-// CHECK: 1
-// CHECK: 0


### PR DESCRIPTION
This PR includes support for creating appropriate LLVM instructions on
processing the `dconst0`, `dconst1`, `lconst0` and `lconst1` JVM instructions.