### PR TITLE
[instruction] Add support for all arithmetic instructions

### DIFF
--- a/tests/Execution/dadd.java
+++ b/tests/Execution/dadd.java
@@ -1,0 +1,69 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+class Test
+{
+    public static native void print(double d);
+
+    public static void main(String[] args)
+    {
+        var nan = Double.NaN;
+        var p_inf = Double.POSITIVE_INFINITY;
+        var n_inf = Double.NEGATIVE_INFINITY;
+        var p_zero = 0.0;
+        var n_zero = -0.0;
+        var p_123 = 123.456;
+        var n_123 = -123.456;
+
+        // CHECK: nan
+        // CHECK: nan
+        print(nan + 1);
+        print(1 + nan);
+
+        // CHECK: nan
+        // CHECK: nan
+        print(p_inf + n_inf);
+        print(n_inf + p_inf);
+
+        // CHECK: inf
+        // CHECK: -inf
+        print(p_inf + p_inf);
+        print(n_inf + n_inf);
+
+        // CHECK: inf
+        // CHECK: -inf
+        print(p_inf + 1);
+        print(n_inf + 1);
+
+        // CHECK: 0
+        // CHECK: 0
+        print(p_zero + n_zero);
+        print(n_zero + p_zero);
+
+        // CHECK: 0
+        // CHECK: -0
+        print(p_zero + p_zero);
+        print(n_zero + n_zero);
+
+        // CHECK: 123.456
+        // CHECK: 123.456
+        print(p_zero + p_123);
+        print(n_zero + p_123);
+
+        // CHECK: 0
+        // CHECK: 0
+        print(p_123 + n_123);
+        print(n_123 + p_123);
+
+        var x = -6.6057786;
+        var y = 1549700.4;
+        var z = -2.1339336E8;
+
+        // CHECK: 1.54969e+06
+        print(x + y);
+        // CHECK: -2.13393e+08
+        print(x + z);
+        // CHECK: -2.11844e+08
+        print(y + z);
+    }
+}

--- a/tests/Execution/ddiv.java
+++ b/tests/Execution/ddiv.java
@@ -1,0 +1,62 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+class Test
+{
+    public static native void print(double d);
+
+    public static void main(String[] args)
+    {
+        var nan = Double.NaN;
+        var p_inf = Double.POSITIVE_INFINITY;
+        var n_inf = Double.NEGATIVE_INFINITY;
+        var p_zero = 0.0;
+        var n_zero = -0.0;
+
+        // CHECK: nan
+        // CHECK: nan
+        print(nan / 2);
+        print(2 / nan);
+
+        // CHECK: nan
+        // CHECK: nan
+        print(p_inf / n_inf);
+        print(n_inf / p_inf);
+
+        // CHECK: inf
+        // CHECK: -inf
+        print(p_inf / 2);
+        print(n_inf / 2);
+
+        // CHECK: 0
+        // CHECK: -0
+        print(2 / p_inf);
+        print(2 / n_inf);
+
+        // CHECK: nan
+        // CHECK: nan
+        print(p_zero / n_zero);
+        print(n_zero / p_zero);
+
+        // CHECK: 0
+        // CHECK: -0
+        print(p_zero / 2);
+        print(n_zero / 2);
+
+        // CHECK: inf
+        // CHECK: -inf
+        print(2 / p_zero);
+        print(2 / n_zero);
+
+        var x = -4.4639528E7;
+        var y = 1.26373286E9;
+        var z = -238.710592;
+
+        // CHECK: -0.0353235
+        print(x / y);
+        // CHECK: 187003
+        print(x / z);
+        // CHECK: -5.294e+06
+        print(y / z);
+    }
+}

--- a/tests/Execution/dmul.java
+++ b/tests/Execution/dmul.java
@@ -1,0 +1,54 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+class Test
+{
+    public static native void print(double d);
+
+    public static void main(String[] args)
+    {
+        var nan = Double.NaN;
+        var p_inf = Double.POSITIVE_INFINITY;
+        var n_inf = Double.NEGATIVE_INFINITY;
+        var p_zero = 0.0;
+        var n_zero = -0.0;
+        var p_123 = 123.456;
+        var n_123 = -123.456;
+
+        // CHECK: nan
+        // CHECK: nan
+        print(nan * p_123);
+        print(p_123 * nan);
+
+        // CHECK: 15241.4
+        // CHECK: 15241.4
+        print(p_123 * p_123);
+        print(n_123 * n_123);
+
+        // CHECK: -15241.4
+        // CHECK: -15241.4
+        print(p_123 * n_123);
+        print(n_123 * p_123);
+
+        // CHECK: nan
+        // CHECK: nan
+        print(p_inf * p_zero);
+        print(n_inf * n_zero);
+
+        // CHECK: inf
+        // CHECK: -inf
+        print(p_inf * p_123);
+        print(n_inf * p_123);
+
+        var x = 6.7671592E7;
+        var y = -4.09644288E8;
+        var z = 1374.04144;
+
+        // CHECK: -2.77213e+16
+        print(x * y);
+        // CHECK: 9.29836e+10
+        print(x * z);
+        // CHECK: -5.62868e+11
+        print(y * z);
+    }
+}

--- a/tests/Execution/dneg.java
+++ b/tests/Execution/dneg.java
@@ -1,0 +1,47 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+class Test
+{
+    public static native void print(double d);
+
+    public static void main(String[] args)
+    {
+        var nan = Double.NaN;
+        var p_inf = Double.POSITIVE_INFINITY;
+        var n_inf = Double.NEGATIVE_INFINITY;
+        var p_zero = 0.0;
+        var n_zero = -0.0;
+        var p_123 = 123.456;
+        var n_123 = -123.456;
+
+        // CHECK: nan
+        print(-nan);
+
+        // CHECK: -inf
+        // CHECK: inf
+        print(-p_inf);
+        print(-n_inf);
+
+        // CHECK: -0
+        // CHECK: 0
+        print(-p_zero);
+        print(-n_zero);
+
+        // CHECK: -123.456
+        // CHECK: 123.456
+        print(-p_123);
+        print(-n_123);
+
+        var x = 1.06639384E8;
+        var y = -5.4427053E8;
+        var z = -4.29113472;
+
+        // CHECK: -1.06639e+08
+        print(-x);
+        // CHECK: 5.44271e+08
+        print(-y);
+        // CHECK: 4.29113
+        print(-z);
+    }
+}

--- a/tests/Execution/drem.java
+++ b/tests/Execution/drem.java
@@ -1,0 +1,59 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+class Test
+{
+    public static native void print(double d);
+
+    public static void main(String[] args)
+    {
+        var nan = Double.NaN;
+        var p_inf = Double.POSITIVE_INFINITY;
+        var n_inf = Double.NEGATIVE_INFINITY;
+        var p_zero = 0.0;
+        var n_zero = -0.0;
+        var p_123 = 123.456;
+        var n_123 = -123.456;
+
+        // CHECK: nan
+        // CHECK: nan
+        print(nan % p_123);
+        print(n_123 % nan);
+
+        // CHECK: 0.456
+        // CHECK: -0.456
+        print(p_123 % 3);
+        print(n_123 % 3);
+
+        // CHECK: nan
+        // CHECK: nan
+        print(p_inf % 3);
+        print(n_inf % 3);
+
+        // CHECK: nan
+        // CHECK: nan
+        print(p_123 % p_zero);
+        print(p_123 % n_zero);
+
+        // CHECK: 123.456
+        // CHECK: 123.456
+        print(p_123 % p_inf);
+        print(p_123 % n_inf);
+
+        // CHECK: 0
+        // CHECK: -0
+        print(p_zero % p_123);
+        print(n_zero % p_123);
+
+        var x = 3.52095328E9;
+        var y = -5.9460864E8;
+        var z = 1425.10118;
+
+        // CHECK: 5.4791e+08
+        print(x % y);
+        // CHECK: 1397.81
+        print(x % z);
+        // CHECK: -848.758
+        print(y % z);
+    }
+}

--- a/tests/Execution/dsub.java
+++ b/tests/Execution/dsub.java
@@ -1,0 +1,74 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+class Test
+{
+    public static native void print(double d);
+
+    public static void main(String[] args)
+    {
+        var nan = Double.NaN;
+        var p_inf = Double.POSITIVE_INFINITY;
+        var n_inf = Double.NEGATIVE_INFINITY;
+        var p_zero = 0.0;
+        var n_zero = -0.0;
+        var p_123 = 123.456;
+        var n_123 = -123.456;
+
+        // CHECK: nan
+        // CHECK: nan
+        print(nan - 1);
+        print(1 - nan);
+
+        // CHECK: inf
+        // CHECK: -inf
+        print(p_inf - n_inf);
+        print(n_inf - p_inf);
+
+        // CHECK: nan
+        // CHECK: nan
+        print(p_inf - p_inf);
+        print(n_inf - n_inf);
+
+        // CHECK: inf
+        // CHECK: -inf
+        print(p_inf - 1);
+        print(n_inf - 1);
+
+        // CHECK: -inf
+        // CHECK: inf
+        print(1 - p_inf);
+        print(1 - n_inf);
+
+        // CHECK: 0
+        // CHECK: -0
+        print(p_zero - n_zero);
+        print(n_zero - p_zero);
+
+        // CHECK: 0
+        // CHECK: 0
+        print(p_zero - p_zero);
+        print(n_zero - n_zero);
+
+        // CHECK: -123.456
+        // CHECK: -123.456
+        print(p_zero - p_123);
+        print(n_zero - p_123);
+
+        // CHECK: 246.912
+        // CHECK: -246.912
+        print(p_123 - n_123);
+        print(n_123 - p_123);
+
+        var x = 1.83799936E8;
+        var y = -1.09827904E9;
+        var z = 1.1562734E7;
+
+        // CHECK: 1.28208e+09
+        print(x - y);
+        // CHECK: 1.72237e+08
+        print(x - z);
+        // CHECK: -1.10984e+09
+        print(y - z);
+    }
+}

--- a/tests/Execution/ladd.java
+++ b/tests/Execution/ladd.java
@@ -1,0 +1,20 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+class Test
+{
+    public static native void print(long l);
+
+    public static void main(String[] args)
+    {
+        long x = 3l;
+        long y = 2l;
+        long z = 1l;
+        // CHECK: 5
+        print(x+y);
+        // CHECK: 4
+        print(x+1l);
+        // CHECK: -9223372036854775808
+        print(Long.MAX_VALUE+z);
+    }
+}

--- a/tests/Execution/ldiv.java
+++ b/tests/Execution/ldiv.java
@@ -1,0 +1,35 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+class Test
+{
+    public static native void print(long l);
+
+    public static void main(String[] args)
+    {
+        long x = 3l;
+        long y = 2l;
+        // CHECK: 1
+        // CHECK-NOT:-
+        print(x/y);
+        // CHECK: 3
+        // CHECK-NOT:-
+        print(x/1l);
+        // CHECK: 9
+        // CHECK-NOT:-
+        print(27l/x);
+        // CHECK: 9
+        // CHECK-NOT:-
+        print(28l/x);
+        // CHECK: 0
+        // CHECK-NOT:-
+        print(Long.MAX_VALUE/Long.MIN_VALUE);
+        // CHECK: -3
+        print(x/-1l);
+        // CHECK: 0
+        // CHECK-NOT:-
+        print(-1l/x);
+        // CHECK: -5
+        print(-15l/3l);
+    }
+}

--- a/tests/Execution/lmul.java
+++ b/tests/Execution/lmul.java
@@ -1,0 +1,20 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+class Test
+{
+    public static native void print(long l);
+
+    public static void main(String[] args)
+    {
+        long x = 3l;
+        long y = 2l;
+        long z = 1l;
+        // CHECK: 6
+        print(x*y);
+        // CHECK: 3
+        print(x*1l);
+        // CHECK: -9223372036854775808
+        print(Long.MAX_VALUE*Long.MIN_VALUE);
+    }
+}

--- a/tests/Execution/lrem.java
+++ b/tests/Execution/lrem.java
@@ -1,0 +1,27 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+class Test
+{
+    public static native void print(long l);
+
+    public static void main(String[] args)
+    {
+        long x = 3l;
+        long y = 2l;
+        long a = -40l;
+        long b = 5601l;
+        // CHECK: 1
+        print(x%y);
+        // CHECK: 0
+        print(x%1l);
+        // CHECK: 0
+        print(27l%x);
+        // CHECK: 1
+        print(28l%x);
+        // CHECK: -40
+        print(a%b);
+        // CHECK: 1
+        print(b%a);
+    }
+}

--- a/tests/Execution/lsub.java
+++ b/tests/Execution/lsub.java
@@ -1,0 +1,25 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+class Test
+{
+    public static native void print(long l);
+
+    public static void main(String[] args)
+    {
+        long x = 3l;
+        long y = 2l;
+        long z = 1l;
+        // CHECK-NOT:-
+        // CHECK: 1
+        print(x-y);
+        // CHECK-NOT:-
+        // CHECK: 2
+        print(x-1l);
+        // CHECK-NOT:-
+        // CHECK: 9223372036854775807
+        print(Long.MIN_VALUE-z);
+        // CHECK: -1
+        print(y-x);
+    }
+}


### PR DESCRIPTION
This PR includes support for creating appropriate LLVM instructions on processing the `dadd`, `ddiv`, `dmul`, `dneg`, `drem` , `dsub`, `ladd`, `ldiv`, `lmul`, `lneg`, `lrem`  and `lsub` JVM instructions.