### PR TITLE
[instruction] Add support for double cast instructions

### DIFF
--- a/src/jllvm/materialization/ByteCodeCompileLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeCompileLayer.cpp
@@ -931,9 +931,34 @@ void codeGenBody(llvm::Function* function, const Code& code, const ClassFile& cl
                 operandStack.push_back(res);
             },
             // TODO: CheckCast
-            // TODO: D2F
-            // TODO: D2I
-            // TODO: D2L
+            [&](D2F)
+            {
+                llvm::Value* value = operandStack.pop_back(builder.getDoubleTy());
+                operandStack.push_back(builder.CreateFPTrunc(value, builder.getFloatTy()));
+            },
+            [&](OneOf<D2I, D2L, F2I, F2L>)
+            {
+                auto [fromType, toType] = match(
+                    operation,
+                    [](...) -> std::tuple<llvm::Type*, llvm::Type*>
+                    { llvm_unreachable("Invalid conversion operation"); },
+                    [&](D2I) -> std::tuple<llvm::Type*, llvm::Type*> {
+                        return {builder.getDoubleTy(), builder.getInt32Ty()};
+                    },
+                    [&](D2L) -> std::tuple<llvm::Type*, llvm::Type*> {
+                        return {builder.getDoubleTy(), builder.getInt64Ty()};
+                    },
+                    [&](F2I) -> std::tuple<llvm::Type*, llvm::Type*> {
+                        return {builder.getFloatTy(), builder.getInt32Ty()};
+                    },
+                    [&](F2L) -> std::tuple<llvm::Type*, llvm::Type*> {
+                        return {builder.getFloatTy(), builder.getInt64Ty()};
+                    });
+
+                llvm::Value* value = operandStack.pop_back(fromType);
+
+                operandStack.push_back(builder.CreateIntrinsic(toType, llvm::Intrinsic::fptosi_sat, {value}));
+            },
             [&](OneOf<DAdd, FAdd, IAdd, LAdd>)
             {
                 auto* type = match(
@@ -1106,13 +1131,6 @@ void codeGenBody(llvm::Function* function, const Code& code, const ClassFile& cl
             {
                 llvm::Value* value = operandStack.pop_back(builder.getFloatTy());
                 operandStack.push_back(builder.CreateFPExt(value, builder.getDoubleTy()));
-            },
-            [&](OneOf<F2I, F2L>)
-            {
-                llvm::Value* value = operandStack.pop_back(builder.getFloatTy());
-                llvm::Type* type = holds_alternative<F2I>(operation) ? builder.getInt32Ty() : builder.getInt64Ty();
-
-                operandStack.push_back(builder.CreateIntrinsic(type, llvm::Intrinsic::fptosi_sat, {value}));
             },
             [&](GetField getField)
             {

--- a/tests/Execution/double-casts.java
+++ b/tests/Execution/double-casts.java
@@ -1,0 +1,77 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+class Test
+{
+    public static native void print(int i);
+    public static native void print(float f);
+    public static native void print(long l);
+
+    public static void main(String[] args)
+    {
+        var nan = Double.NaN;
+        var p_inf = Double.POSITIVE_INFINITY;
+        var n_inf = Double.NEGATIVE_INFINITY;
+        var p_zero = 0.0;
+        var n_zero = -0.0;
+        var p_19 = 1.9;
+        var n_19 = -1.9;
+        var p_long_max_plus = 9323372036854775807.0;
+        var n_long_max_plus = -9323372036854775807.0;
+        var p_float_max_plus = 3.4028235E40;
+        var n_float_max_plus = -3.4028235E40;
+
+        //CHECK: nan
+        print((float) nan);
+        //CHECK: inf
+        print((float) p_inf);
+        //CHECK: -inf
+        print((float) n_inf);
+        //CHECK: 0
+        print((float) p_zero);
+        //CHECK: -0
+        print((float) n_zero);
+        //CHECK: inf
+        print((float) p_float_max_plus);
+        //CHECK: -inf
+        print((float) n_float_max_plus);
+
+        //CHECK: 0
+        print((int) nan);
+        //CHECK: 2147483647
+        print((int) p_inf);
+        //CHECK: -2147483648
+        print((int) n_inf);
+        //CHECK: 0
+        print((int) p_zero);
+        //CHECK: 0
+        print((int) n_zero);
+        //CHECK: 1
+        print((int) p_19);
+        //CHECK: -1
+        print((int) n_19);
+        //CHECK: 2147483647
+        print((int) p_long_max_plus);
+        //CHECK: -2147483648
+        print((int) n_long_max_plus);
+
+        //CHECK: 0
+        print((long) nan);
+        //CHECK: 9223372036854775807
+        print((long) p_inf);
+        //CHECK: -9223372036854775808
+        print((long) n_inf);
+        //CHECK: 0
+        print((long) p_zero);
+        //CHECK: 0
+        print((long) n_zero);
+        //CHECK: 1
+        print((long) p_19);
+        //CHECK: -1
+        print((long) n_19);
+        //CHECK: 9223372036854775807
+        print((long) p_long_max_plus);
+        //CHECK: -9223372036854775808
+        print((long) n_long_max_plus);
+    }
+}


### PR DESCRIPTION
This PR includes support for creating appropriate LLVM instructions on processing the `d2f`, `d2i` and `d2l` JVM instructions.