### PR TITLE
[refactor][NFC] Consolidate state from `codeGenBody` into struct

### DIFF
--- a/src/jllvm/materialization/ByteCodeCompileLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeCompileLayer.cpp
@@ -966,32 +966,31 @@ void CodeGen::codeGenInstruction(ByteCodeOp operation)
         // TODO: CheckCast
         [&](D2F)
         {
-                llvm::Value* value = operandStack.pop_back(builder.getDoubleTy());
-                operandStack.push_back(builder.CreateFPTrunc(value, builder.getFloatTy()));
-            },
-            [&](OneOf<D2I, D2L, F2I, F2L>)
-            {
-                auto [fromType, toType] = match(
-                    operation,
-                    [](...) -> std::tuple<llvm::Type*, llvm::Type*>
-                    { llvm_unreachable("Invalid conversion operation"); },
-                    [&](D2I) -> std::tuple<llvm::Type*, llvm::Type*> {
-        return {builder.getDoubleTy(), builder.getInt32Ty()};
-                    },
-                    [&](D2L) -> std::tuple<llvm::Type*, llvm::Type*> {
-                        return {builder.getDoubleTy(), builder.getInt64Ty()};
-                    },
-                    [&](F2I) -> std::tuple<llvm::Type*, llvm::Type*> {
-                        return {builder.getFloatTy(), builder.getInt32Ty()};
-                    },
-                    [&](F2L) -> std::tuple<llvm::Type*, llvm::Type*> {
-                        return {builder.getFloatTy(), builder.getInt64Ty()};
-                    });
+            llvm::Value* value = operandStack.pop_back(builder.getDoubleTy());
+            operandStack.push_back(builder.CreateFPTrunc(value, builder.getFloatTy()));
+        },
+        [&](OneOf<D2I, D2L, F2I, F2L>)
+        {
+            auto [fromType, toType] = match(
+                operation,
+                [](...) -> std::tuple<llvm::Type*, llvm::Type*> { llvm_unreachable("Invalid conversion operation"); },
+                [&](D2I) -> std::tuple<llvm::Type*, llvm::Type*> {
+                    return {builder.getDoubleTy(), builder.getInt32Ty()};
+                },
+                [&](D2L) -> std::tuple<llvm::Type*, llvm::Type*> {
+                    return {builder.getDoubleTy(), builder.getInt64Ty()};
+                },
+                [&](F2I) -> std::tuple<llvm::Type*, llvm::Type*> {
+                    return {builder.getFloatTy(), builder.getInt32Ty()};
+                },
+                [&](F2L) -> std::tuple<llvm::Type*, llvm::Type*> {
+                    return {builder.getFloatTy(), builder.getInt64Ty()};
+                });
 
-                llvm::Value* value = operandStack.pop_back(fromType);
+            llvm::Value* value = operandStack.pop_back(fromType);
 
-                operandStack.push_back(builder.CreateIntrinsic(toType, llvm::Intrinsic::fptosi_sat, {value}));
-            },
+            operandStack.push_back(builder.CreateIntrinsic(toType, llvm::Intrinsic::fptosi_sat, {value}));
+        },
         [&](OneOf<DAdd, FAdd, IAdd, LAdd>)
         {
             auto* type = match(


### PR DESCRIPTION
I think we can all agree that `codeGenBody` has gotten a bit large. The `match` statement itself isn't that horrible IMO but rather a lot of the state and variables floating around which has lead to the creation of lambdas and inline code which should have really been functions but weren't out of laziness of not wanting to pass dozens of parameters around.

This patch therefore focus on fixing that part of the equation by encapsulating all things related to codegen within a class, making it possible to access all state relevant for the generation of code from within any methods of that struct. This most importantly makes it easier to extract code from e.g. `match` statements to allow code reuse.

Some functions, like the calculation of basic blocks, or the lambdas for EH generation have already been extracted to methods.

Only admittedly odd thing is all the work happening in the constructor... Anything else felt overkill to me.