### PR TITLE
[test] add Catch2 as unit testing library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,8 @@ else()
     option(JLLVM_ENABLE_ASSERTIONS "Enable assertions" ON)
 endif()
 
+include(cmake/CPM.cmake)
+
 find_package(Threads REQUIRED)
 link_libraries(Threads::Threads)
 find_package(LLVM REQUIRED CONFIG)
@@ -93,3 +95,4 @@ add_subdirectory(tools)
 include(CTest)
 enable_testing()
 add_subdirectory(tests)
+add_subdirectory(unittests)

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -1,0 +1,33 @@
+set(CPM_DOWNLOAD_VERSION 0.38.1)
+
+if(CPM_SOURCE_CACHE)
+  set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+elseif(DEFINED ENV{CPM_SOURCE_CACHE})
+  set(CPM_DOWNLOAD_LOCATION "$ENV{CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+else()
+  set(CPM_DOWNLOAD_LOCATION "${CMAKE_BINARY_DIR}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+endif()
+
+# Expand relative path. This is important if the provided path contains a tilde (~)
+get_filename_component(CPM_DOWNLOAD_LOCATION ${CPM_DOWNLOAD_LOCATION} ABSOLUTE)
+
+function(download_cpm)
+  message(STATUS "Downloading CPM.cmake to ${CPM_DOWNLOAD_LOCATION}")
+  file(DOWNLOAD
+       https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
+       ${CPM_DOWNLOAD_LOCATION}
+  )
+endfunction()
+
+if(NOT (EXISTS ${CPM_DOWNLOAD_LOCATION}))
+  download_cpm()
+else()
+  # resume download if it previously failed
+  file(READ ${CPM_DOWNLOAD_LOCATION} check)
+  if("${check}" STREQUAL "")
+    download_cpm()
+  endif()
+  unset(check)
+endif()
+
+include(${CPM_DOWNLOAD_LOCATION})

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -1,0 +1,9 @@
+
+CPMAddPackage("gh:catchorg/Catch2@3.3.2")
+
+list(APPEND CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/extras)
+include(Catch)
+
+add_executable(HelloWorldTest HelloWorldTest.cpp)
+target_link_libraries(HelloWorldTest Catch2::Catch2WithMain)
+catch_discover_tests(HelloWorldTest)

--- a/unittests/HelloWorldTest.cpp
+++ b/unittests/HelloWorldTest.cpp
@@ -1,0 +1,6 @@
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("Hello World", "[HelloWorld]")
+{
+    SUCCEED();
+}


### PR DESCRIPTION
We are currently only relying on integration tests for our test suite which nicely ensures that all components are working but has the issue of not really properly allowing to test small details/aspects within our components.

I'd therefore like to add Catch2 as a unit testing library. My concrete use case is that I want to test various allocation patterns in the GC for correctness in an upcoming revision.

To conveniently add the library everywhere without having to vendor it, CPM was used which automatically downloads the library, includes it in cmake and makes it available. Additionally, Catch2 has great integration with test discovery with `ctest` (the testing driver we use), making it run all `TEST_CASE`s in a single process in parallel

A `HelloWorldTest` was added as "demonstration/example" and should be removed once a proper unit test is added