### PR TITLE
[refactor][NFC] Move implementations of internal functions into its own Dylib

### DIFF
--- a/src/jllvm/materialization/JNIImplementationLayer.hpp
+++ b/src/jllvm/materialization/JNIImplementationLayer.hpp
@@ -33,7 +33,8 @@ public:
     JNIImplementationLayer(llvm::orc::ExecutionSession& session,
                            std::unique_ptr<llvm::orc::IndirectStubsManager> stubsManager,
                            llvm::orc::JITCompileCallbackManager& callbackManager, llvm::orc::MangleAndInterner& mangler,
-                           llvm::orc::IRLayer& irLayer, const llvm::DataLayout& dataLayout, void* jniNativeFunctions)
+                           llvm::orc::IRLayer& irLayer, const llvm::DataLayout& dataLayout, void* jniNativeFunctions,
+                           llvm::orc::JITDylib& implementationDylib)
         : ByteCodeLayer(mangler),
           m_jniImpls(session.createBareJITDylib("<jni>")),
           m_jniBridges(session.createBareJITDylib("<jniBridge>")),
@@ -43,6 +44,7 @@ public:
           m_dataLayout(dataLayout),
           m_jniNativeFunctions(jniNativeFunctions)
     {
+        m_jniBridges.addToLinkOrder(implementationDylib);
     }
 
     /// Adds a new materialization unit to the JNI dylib which will be used to lookup any symbols when 'native' methods

--- a/src/jllvm/materialization/LambdaMaterialization.hpp
+++ b/src/jllvm/materialization/LambdaMaterialization.hpp
@@ -95,7 +95,14 @@ class LambdaMaterializationUnit : public llvm::orc::MaterializationUnit
     F m_f;
     llvm::DataLayout m_dataLayout;
 
+    // GCC is stricter when it comes to determining trivially copyable of lambdas.
+    // Admittedly, GCC is allowed to do that since it is apparently implementation defined whether lambdas are
+    // trivially copyable.
+    // Practically speaking this should always work for now and in the future it is possible to drop the trivially
+    // copyable requirements (which only exists because we effectively memcpy the lambda) if ever required.
+#ifdef __clang__
     static_assert(std::is_trivially_copyable_v<F>);
+#endif
 
     template <std::size_t... is>
     std::array<llvm::Type*, sizeof...(is)> parameterTypes(std::index_sequence<is...>, llvm::LLVMContext* context)

--- a/src/jllvm/materialization/LambdaMaterialization.hpp
+++ b/src/jllvm/materialization/LambdaMaterialization.hpp
@@ -95,14 +95,15 @@ class LambdaMaterializationUnit : public llvm::orc::MaterializationUnit
     F m_f;
     llvm::DataLayout m_dataLayout;
 
-    // GCC is stricter when it comes to determining trivially copyable of lambdas.
+    // Technically speaking, the property we require is trivially copyable.
+    // However,GCC is stricter when it comes to determining trivially copyable of lambdas, making asserts fail when
+    // an equivalent struct with operator() wouldn't.
     // Admittedly, GCC is allowed to do that since it is apparently implementation defined whether lambdas are
     // trivially copyable.
-    // Practically speaking this should always work for now and in the future it is possible to drop the trivially
-    // copyable requirements (which only exists because we effectively memcpy the lambda) if ever required.
-#ifdef __clang__
-    static_assert(std::is_trivially_copyable_v<F>);
-#endif
+    // We therefore instead use trivially destructible as a check instead to still catch issues such as a lambda having
+    // non-trivial types within. Given the prevalence of the Rule of 5 this should be just as effective at catching
+    // these errors.
+    static_assert(std::is_trivially_destructible_v<F>);
 
     template <std::size_t... is>
     std::array<llvm::Type*, sizeof...(is)> parameterTypes(std::index_sequence<is...>, llvm::LLVMContext* context)

--- a/src/jllvm/vm/VirtualMachine.cpp
+++ b/src/jllvm/vm/VirtualMachine.cpp
@@ -175,6 +175,15 @@ jllvm::VirtualMachine::VirtualMachine(std::vector<std::string>&& classPath)
       // Exclude 0 from the output as that is our sentinel value for "not yet calculated".
       m_hashIntDistrib(1, std::numeric_limits<std::uint32_t>::max())
 {
+    m_jit.addImplementationSymbols(
+        std::pair{"fmodf", &fmodf},
+        std::pair{"jllvm_gc_alloc", [&](std::uint32_t size) { return m_gc.allocate(size); }},
+        std::pair{"jllvm_for_name_loaded", [&](const char* name) { return m_classLoader.forNameLoaded(name); }},
+        std::pair{"jllvm_instance_of",
+                  [](const Object* object, const ClassObject* classObject) -> std::int32_t
+                  { return object->instanceOf(classObject); }},
+        std::pair{"activeException", m_activeException.data()});
+
     registerJavaClasses(*this);
 
     m_classLoader.loadBootstrapClasses();

--- a/src/jllvm/vm/VirtualMachine.hpp
+++ b/src/jllvm/vm/VirtualMachine.hpp
@@ -26,7 +26,7 @@ class VirtualMachine
     GarbageCollector m_gc;
     StringInterner m_stringInterner;
     GCRootRef<Throwable> m_activeException = static_cast<GCRootRef<Throwable>>(m_gc.allocateStatic());
-    JIT m_jit = JIT::create(m_classLoader, m_gc, m_stringInterner, m_jniEnv.get(), m_activeException);
+    JIT m_jit = JIT::create(m_classLoader, m_gc, m_stringInterner, m_jniEnv.get());
     std::mt19937 m_pseudoGen;
     std::uniform_int_distribution<std::uint32_t> m_hashIntDistrib;
 


### PR DESCRIPTION
These have so far been directly implemented in the main Dylib. Implementing them in a separate dylib allows reuse of that dylib in the link order of other dylibs. Specifically, I'd like to reuse the implementation of these internal symbols in the JNI bridge dylib as well.

Additionally, a nice API was added to add these methods and the implementations were moved to the VirtualMachine. The reason for the latter is that the implementations of these functions should have more access to all the required state (including active exception, class loader, etc) available from the Virtual machine without having to needlessly pass them into the JIT instance.