### PR TITLE
[JNI][NFC] Exclusively use GC roots in the JNI interface

### DIFF
--- a/src/jllvm/gc/GarbageCollector.hpp
+++ b/src/jllvm/gc/GarbageCollector.hpp
@@ -56,7 +56,7 @@ public:
     /// Allows assignment from a valid pointer to an object.
     GCUniqueRoot& operator=(T* object)
     {
-        *this->m_object = object;
+        GCRootRef<T>::operator=(object);
         return *this;
     }
 

--- a/src/jllvm/gc/RootFreeList.hpp
+++ b/src/jllvm/gc/RootFreeList.hpp
@@ -62,10 +62,17 @@ public:
         return GCRootRef<U>(m_object);
     }
 
+    /// Explicit cast to 'T*'. This operation should generally be avoided in favour of just using the 'GCRootRef' as
+    /// intended.
+    explicit operator T*() const
+    {
+        return get();
+    }
+
     /// Allows assignment from a valid pointer to an object.
     GCRootRef& operator=(T* object)
     {
-        *m_object = object;
+        *m_object = const_cast<std::remove_const_t<T>*>(object);
         return *this;
     }
 
@@ -73,8 +80,7 @@ public:
     template <class U>
     friend bool operator==(GCRootRef<T> lhs, GCRootRef<U> rhs)
     {
-        // operator-> because GCC 10 doesn't allow access to 'get()' due to bugs.
-        return lhs.get() == rhs.operator->();
+        return lhs.get() == static_cast<U*>(rhs);
     }
 
     /// Returns true if 'lhs' and 'rhs' refer to the same object.

--- a/src/jllvm/main/Main.cpp
+++ b/src/jllvm/main/Main.cpp
@@ -34,7 +34,7 @@ requires(std::is_floating_point_v<T>) struct TrivialPrinter<T>
 template <>
 struct TrivialPrinter<jllvm::String>
 {
-    auto operator()(void*, void*, jllvm::String* string)
+    auto operator()(void*, void*, jllvm::GCRootRef<jllvm::String> string)
     {
         llvm::outs() << string->toUTF8() << '\n';
     }

--- a/src/jllvm/vm/VirtualMachine.cpp
+++ b/src/jllvm/vm/VirtualMachine.cpp
@@ -182,7 +182,14 @@ jllvm::VirtualMachine::VirtualMachine(std::vector<std::string>&& classPath)
         std::pair{"jllvm_instance_of",
                   [](const Object* object, const ClassObject* classObject) -> std::int32_t
                   { return object->instanceOf(classObject); }},
-        std::pair{"activeException", m_activeException.data()});
+        std::pair{"activeException", m_activeException.data()},
+        std::pair{"jllvm_new_local_root", [&](Object* object) { return m_gc.root(object).release(); }},
+        std::pair{"jllvm_delete_local_root", [&](GCRootRef<Object> root)
+                  {
+                      auto* object = static_cast<Object*>(root);
+                      m_gc.deleteRoot(root);
+                      return object;
+                  }});
 
     registerJavaClasses(*this);
 

--- a/src/jllvm/vm/VirtualMachine.hpp
+++ b/src/jllvm/vm/VirtualMachine.hpp
@@ -47,7 +47,18 @@ public:
         return m_jit;
     }
 
+    /// Returns the garbage collector instance of the virtual machine.
+    GarbageCollector& getGC()
+    {
+        return m_gc;
+    }
+
     int executeMain(llvm::StringRef path, llvm::ArrayRef<llvm::StringRef> args);
+};
+
+template <class T>
+struct CppToLLVMType<jllvm::GCRootRef<T>> : CppToLLVMType<void*>
+{
 };
 
 } // namespace jllvm


### PR DESCRIPTION
The JNI spec requires `jobject` (which in our implementation will be an alias to `GCRootRef`) to be rooted. This PR therefore adjusts the bridge code generation to automatically create and delete these roots. Since our higher level interface in NativeImplementation.hpp builds on top of the JNI, it had to also be adjusted to now work on GCRootRef instead of raw pointers.
Documentation and implementations were therefore adjusted accordingly.

Depends on https://github.com/JLLVM/JLLVM/pull/116