### PR TITLE
[vm] eagerly load string class object for string interner

### DIFF
--- a/src/jllvm/vm/StringInterner.cpp
+++ b/src/jllvm/vm/StringInterner.cpp
@@ -1,15 +1,5 @@
 #include "StringInterner.hpp"
 
-const jllvm::ClassObject* jllvm::StringInterner::getStringClassObject()
-{
-    if (!m_stringClass)
-    {
-        m_stringClass = &m_classLoader.forName(stringDescriptor);
-        checkStructure();
-    }
-    return m_stringClass;
-}
-
 void jllvm::StringInterner::checkStructure()
 {
 #ifdef NDEBUG
@@ -52,7 +42,7 @@ jllvm::String* jllvm::StringInterner::createString(llvm::ArrayRef<std::uint8_t> 
     llvm::copy(buffer, value->begin());
 
     auto* string = new (m_allocator.Allocate(sizeof(String), alignof(String)))
-        String(getStringClassObject(), value, static_cast<std::uint8_t>(encoding));
+        String(m_stringClass, value, static_cast<std::uint8_t>(encoding));
 
     m_contentToStringMap.insert({{{value->begin(), value->end()}, static_cast<std::uint8_t>(encoding)}, string});
 

--- a/src/jllvm/vm/StringInterner.cpp
+++ b/src/jllvm/vm/StringInterner.cpp
@@ -1,5 +1,11 @@
 #include "StringInterner.hpp"
 
+void jllvm::StringInterner::loadStringClass()
+{
+    m_stringClass = &m_classLoader.forName(stringDescriptor);
+    checkStructure();
+}
+
 void jllvm::StringInterner::checkStructure()
 {
 #ifdef NDEBUG

--- a/src/jllvm/vm/StringInterner.hpp
+++ b/src/jllvm/vm/StringInterner.hpp
@@ -9,7 +9,6 @@ namespace jllvm
 {
 class StringInterner
 {
-    static constexpr auto stringDescriptor = "Ljava/lang/String;";
     static constexpr auto byteArrayDescriptor = "[B";
 
     llvm::DenseMap<std::pair<llvm::ArrayRef<std::uint8_t>, std::uint8_t>, String*> m_contentToStringMap;
@@ -17,14 +16,17 @@ class StringInterner
     ClassLoader& m_classLoader;
     const ClassObject* m_stringClass{nullptr};
 
-    const ClassObject* getStringClassObject();
-
     void checkStructure();
 
     String* createString(llvm::ArrayRef<std::uint8_t> buffer, jllvm::CompactEncoding encoding);
 
 public:
     StringInterner(ClassLoader& classLoader) : m_classLoader(classLoader) {}
+
+    void setStringClass(const ClassObject* stringClass)
+    {
+        m_stringClass = stringClass;
+    }
 
     String* intern(llvm::StringRef utf8String);
 

--- a/src/jllvm/vm/StringInterner.hpp
+++ b/src/jllvm/vm/StringInterner.hpp
@@ -9,6 +9,7 @@ namespace jllvm
 {
 class StringInterner
 {
+    static constexpr auto stringDescriptor = "Ljava/lang/String;";
     static constexpr auto byteArrayDescriptor = "[B";
 
     llvm::DenseMap<std::pair<llvm::ArrayRef<std::uint8_t>, std::uint8_t>, String*> m_contentToStringMap;
@@ -23,10 +24,7 @@ class StringInterner
 public:
     StringInterner(ClassLoader& classLoader) : m_classLoader(classLoader) {}
 
-    void setStringClass(const ClassObject* stringClass)
-    {
-        m_stringClass = stringClass;
-    }
+    void loadStringClass();
 
     String* intern(llvm::StringRef utf8String);
 

--- a/src/jllvm/vm/VirtualMachine.cpp
+++ b/src/jllvm/vm/VirtualMachine.cpp
@@ -195,7 +195,7 @@ jllvm::VirtualMachine::VirtualMachine(std::vector<std::string>&& classPath)
 
     m_classLoader.loadBootstrapClasses();
 
-    m_stringInterner.setStringClass(&m_classLoader.forName("[Ljava/lang/String;"));
+    m_stringInterner.loadStringClass();
 }
 
 int jllvm::VirtualMachine::executeMain(llvm::StringRef path, llvm::ArrayRef<llvm::StringRef> args)

--- a/src/jllvm/vm/VirtualMachine.cpp
+++ b/src/jllvm/vm/VirtualMachine.cpp
@@ -194,6 +194,8 @@ jllvm::VirtualMachine::VirtualMachine(std::vector<std::string>&& classPath)
     registerJavaClasses(*this);
 
     m_classLoader.loadBootstrapClasses();
+
+    m_stringInterner.setStringClass(&m_classLoader.forName("[Ljava/lang/String;"));
 }
 
 int jllvm::VirtualMachine::executeMain(llvm::StringRef path, llvm::ArrayRef<llvm::StringRef> args)

--- a/tests/Execution/string-interner-gc.java
+++ b/tests/Execution/string-interner-gc.java
@@ -1,0 +1,22 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+class Test
+{
+    public static native void print(String i);
+    public static native void print(int i);
+
+    public static void usesStringLiteral()
+    {
+        print("a string literal");
+    }
+
+    public static void main(String[] args)
+    {
+        var i = new int[5];
+        // CHECK: a string literal
+        usesStringLiteral();
+        // CHECK: 5
+        print(i.length);
+    }
+}


### PR DESCRIPTION
We cannot load the string class object lazily due to it occurring during bytecode compilation. Bytecode compilation, due to being lazy/on-demand is implemented using trampolines in the JIT which do a kind of "context-switch", making the Java stack unreachable for the unwinder and causing the GC to think all objects so far are unreachable. This would cause all of them to be deleted causing massive issues.

This patch fixes that by simply eagerly loading the string object for the string interner.