### PR TITLE
[vm] stop running class initializers during bytecode compilation

### DIFF
--- a/src/jllvm/materialization/ByteCodeCompileLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeCompileLayer.cpp
@@ -324,7 +324,7 @@ public:
         std::string method = mangleMethod(className, methodName, methodType);
         if (const ClassObject* classObject = m_classLoader.forNameLoaded("L" + className + ";"))
         {
-            if (!classObject->isInitialized())
+            if (isStatic && !classObject->isInitialized())
             {
                 buildClassInitializerInitStub(builder, *classObject);
             }
@@ -351,7 +351,7 @@ public:
                     [=, *this, desc = std::make_shared<MethodType>(std::move(desc))]
                     {
                         const ClassObject& classObject = m_classLoader.forName("L" + className + ";");
-                        if (classObject.isInitialized())
+                        if (!isStatic || classObject.isInitialized())
                         {
                             auto address = llvm::cantFail(m_mainDylib.getExecutionSession().lookup({&m_mainDylib},
                                                                                                    m_interner(method)))

--- a/src/jllvm/object/ClassLoader.hpp
+++ b/src/jllvm/object/ClassLoader.hpp
@@ -47,9 +47,8 @@ class ClassLoader
 
 public:
     /// Constructs a class loader with 'classPaths', which are all directories that class files will be searched for.
-    /// 'initializeClassObject' is called for the initialization step of a class object and should at the very least
-    /// call the class initialization function of the class object.
-    /// 'classFileLoaded' is called when a class file has been loaded and is being used by the class loader.
+    /// 'prepareClassObject' is called when a class file has been loaded and a class object derived from it. This can
+    /// be used to register the class object or prepare it in an additional action outside of the class loader.
     /// 'allocateStatic' should allocate and return 'pointer sized' storage for any static variables of reference type.
     ClassLoader(std::vector<std::string>&& classPaths,
                 llvm::unique_function<void(const ClassFile*, ClassObject&)>&& prepareClassObject,

--- a/src/jllvm/object/ClassLoader.hpp
+++ b/src/jllvm/object/ClassLoader.hpp
@@ -21,7 +21,6 @@ class ClassLoader
 {
     llvm::BumpPtrAllocator m_classAllocator;
     llvm::StringMap<ClassObject*> m_mapping;
-    llvm::SmallPtrSet<const ClassObject*, 8> m_uninitialized;
 
     llvm::BumpPtrAllocator m_stringAllocator;
     llvm::StringSaver m_stringSaver{m_stringAllocator};
@@ -29,8 +28,7 @@ class ClassLoader
     std::list<ClassFile> m_classFiles;
 
     std::vector<std::string> m_classPaths;
-    llvm::unique_function<void(ClassObject* classObject)> m_initializeClassObject;
-    llvm::unique_function<void(const ClassFile*)> m_classFileLoaded;
+    llvm::unique_function<void(const ClassFile*, ClassObject&)> m_prepareClassObject;
     llvm::unique_function<void**()> m_allocateStatic;
     std::size_t m_interfaceIdCounter = 0;
 
@@ -46,27 +44,6 @@ class ClassLoader
 
     ClassObject* m_metaClassObject = nullptr;
 
-    void initialize(ClassObject& classObject)
-    {
-        if (!m_uninitialized.contains(&classObject))
-        {
-            return;
-        }
-        m_uninitialized.erase(&classObject);
-        m_initializeClassObject(&classObject);
-    }
-
-    ClassObject& add(std::unique_ptr<llvm::MemoryBuffer>&& memoryBuffer);
-
-    enum class State
-    {
-        Prepared,    // Class object should be created, but it doesn't have to be initialized.
-        Initialized, // Class object should also be initialized.
-    };
-
-    // Internal version of 'forName'. Allows specifying whether the class object must be at minimum only prepared or
-    // also initialized.
-    ClassObject& forName(llvm::Twine fieldDescriptor, State state);
 
 public:
     /// Constructs a class loader with 'classPaths', which are all directories that class files will be searched for.
@@ -75,20 +52,16 @@ public:
     /// 'classFileLoaded' is called when a class file has been loaded and is being used by the class loader.
     /// 'allocateStatic' should allocate and return 'pointer sized' storage for any static variables of reference type.
     ClassLoader(std::vector<std::string>&& classPaths,
-                llvm::unique_function<void(ClassObject* classObject)>&& initializeClassObject,
-                llvm::unique_function<void(const ClassFile* classFile)>&& classFileLoaded,
+                llvm::unique_function<void(const ClassFile*, ClassObject&)>&& prepareClassObject,
                 llvm::unique_function<void**()> allocateStatic);
 
-    /// Loads the class object for the given class file and initializes it. This may also load transitive dependencies
+    /// Loads the class object for the given class file. This may also load transitive dependencies
     /// of the class file. Currently aborts if a class file could not be loaded.
-    const ClassObject& addAndInitialize(std::unique_ptr<llvm::MemoryBuffer>&& memoryBuffer);
+    ClassObject& add(std::unique_ptr<llvm::MemoryBuffer>&& memoryBuffer);
 
     /// Returns the class object for 'fieldDescriptor', which must be a valid field descriptor, loading it and
     /// transitive dependencies if required. Currently aborts if a class file could not be loaded.
-    const ClassObject& forName(llvm::Twine fieldDescriptor)
-    {
-        return forName(fieldDescriptor, State::Initialized);
-    }
+    ClassObject& forName(llvm::Twine fieldDescriptor);
 
     /// Returns the class object for 'fieldDescriptor', which must be a valid field descriptor,
     /// if it has been loaded previously. Null otherwise.
@@ -98,7 +71,8 @@ public:
     /// constructor as it requires the VM to already be ready to execute JVM Bytecode (one that does not depend on the
     /// bootstrap classes) and to have at the very least initialized the builtin native methods of the bootstrap
     /// classes.
-    void loadBootstrapClasses();
+    /// Returns the meta class object.
+    ClassObject& loadBootstrapClasses();
 };
 
 } // namespace jllvm

--- a/src/jllvm/vm/StringInterner.hpp
+++ b/src/jllvm/vm/StringInterner.hpp
@@ -15,7 +15,7 @@ class StringInterner
     llvm::DenseMap<std::pair<llvm::ArrayRef<std::uint8_t>, std::uint8_t>, String*> m_contentToStringMap;
     llvm::BumpPtrAllocator m_allocator;
     ClassLoader& m_classLoader;
-    const ClassObject* m_stringClass{nullptr};
+    ClassObject* m_stringClass{nullptr};
 
     void checkStructure();
 
@@ -25,6 +25,11 @@ public:
     StringInterner(ClassLoader& classLoader) : m_classLoader(classLoader) {}
 
     void loadStringClass();
+
+    ClassObject& getStringClass() const
+    {
+        return *m_stringClass;
+    }
 
     String* intern(llvm::StringRef utf8String);
 

--- a/src/jllvm/vm/VirtualMachine.hpp
+++ b/src/jllvm/vm/VirtualMachine.hpp
@@ -30,6 +30,8 @@ class VirtualMachine
     std::mt19937 m_pseudoGen;
     std::uniform_int_distribution<std::uint32_t> m_hashIntDistrib;
 
+    void initialize(ClassObject& classObject);
+
 public:
     VirtualMachine(std::vector<std::string>&& classPath);
 

--- a/tests/Execution/static-class-loader-gc.java
+++ b/tests/Execution/static-class-loader-gc.java
@@ -1,0 +1,91 @@
+// RUN: rm -rf %t && split-file %s %t
+// RUN: cd %t && javac %t/Test.java -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+//--- Test.java
+
+class Test
+{
+    public static native void print(String i);
+    public static native void print(int i);
+
+    public static void main(String[] args)
+    {
+        var i = new int[5];
+        // All these operations are the only operations that can trigger class object initialization.
+        Other.foo();
+        Other2.foo = Other3.foo;
+        new Other4();
+        // CHECK: 5
+        print(i.length);
+    }
+}
+
+//--- Other.java
+
+public class Other
+{
+    static
+    {
+        // Trigger GC
+        new Object();
+        new Object();
+        new Object();
+        new Object();
+        new Object();
+    }
+
+    public static void foo()
+    {
+
+    }
+}
+
+//--- Other2.java
+
+public class Other2
+{
+    static
+    {
+        // Trigger GC
+        new Object();
+        new Object();
+        new Object();
+        new Object();
+        new Object();
+    }
+
+    public static int foo = 3;
+}
+
+//--- Other3.java
+
+public class Other3
+{
+    static
+    {
+        // Trigger GC
+        new Object();
+        new Object();
+        new Object();
+        new Object();
+        new Object();
+    }
+
+    public static int foo = 3;
+}
+
+//--- Other4.java
+
+public class Other4
+{
+    static
+    {
+        // Trigger GC
+        new Object();
+        new Object();
+        new Object();
+        new Object();
+        new Object();
+    }
+}


### PR DESCRIPTION
As we recently discovered, due to the context switching of the JITs trampoline, the Java stack becomes unreachable to the GC while we are compiling bytecode. If a GC then occurs due to running Java code, the GC deletes essentially all objects on the Heap.

It is therefore required that Java code is NOT executed during compilation. Prior to this PR, the class loader would initialize class objects during compilation of stubs (whose whole responsibility was the loading of classes) which would then execute Java code if the class had a class initializer.

This PR fixes that by reworking how classes are initialized. First, the responsibility is taken away from the class loader as this was simply the incorrect place to do so. According to the spec, classes are only initialized by specific instructions with only a few exceptions. Therefore initialization has now been implemented in the VirtualMachine. Next, if an instruction must initialize the class object (these are `invokestatic`, `new`, `getstatic` and `putstatic`), the call to the initialization routine is now compiled into the stub if required so that it is executed on the Java stack.

See the spec here https://docs.oracle.com/javase/specs/jvms/se17/html/jvms-5.html#jvms-5.5