### PR TITLE
[test] Add `jasmin` as java assembler

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,8 +1,11 @@
+CPMAddPackage("gh:davidar/jasmin#2.4")
+
 find_package(Python3 3.6 COMPONENTS Interpreter REQUIRED)
 
 set(JLLVM_TEST_DEPENDS
         FileCheck count not split-file
         jllvm
+        jasmin
         )
 
 configure_file(

--- a/tests/Execution/jasmin.j
+++ b/tests/Execution/jasmin.j
@@ -1,0 +1,22 @@
+; RUN: jasmin %s -d %t
+; RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+.class public Test
+.super java/lang/Object
+
+.method public <init>()V
+    aload_0
+    invokenonvirtual java/lang/Object/<init>()V
+    return
+.end method
+
+.method public static native print(Ljava/lang/String;)V
+.end method
+
+.method public static main([Ljava/lang/String;)V
+    ldc "Hello Jasmin!"
+
+    ; CHECK: Hello Jasmin!
+    invokestatic Test/print(Ljava/lang/String;)V
+
+    return
+.end method

--- a/tests/lit.cfg.py
+++ b/tests/lit.cfg.py
@@ -20,7 +20,7 @@ config.name = 'JLLVM'
 config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
 
 # suffixes: A list of file extensions to treat as test files.
-config.suffixes = ['.java']
+config.suffixes = ['.java', '.j']
 
 # test_source_root: The root path where tests are located.
 config.test_source_root = os.path.dirname(__file__)
@@ -55,7 +55,7 @@ tool_dirs = [
 ]
 
 tools = [
-    'jllvm', 'javac'
+    'jllvm', 'javac', ToolSubst('jasmin', f'java -jar {config.jasmin_src}/jasmin.jar')
 ]
 
 llvm_config.add_tool_substitutions(tools, tool_dirs)

--- a/tests/lit.site.cfg.py.in
+++ b/tests/lit.site.cfg.py.in
@@ -15,6 +15,7 @@ config.jllvm_src_root = "@JLLVM_SOURCE_DIR@"
 config.jllvm_obj_root = "@JLLVM_BINARY_DIR@"
 config.jllvm_tools_dir = "@JLLVM_TOOLS_DIR@"
 config.java_home = "@JAVA_HOME@"
+config.jasmin_src = "@jasmin_SOURCE_DIR@"
 
 # Support substitution of the tools_dir with user parameters. This is
 # used when we can't determine the tool dir at configuration time.


### PR DESCRIPTION
This PR adds `jasmin` as a java assembler tool for testing the implementation of opcodes that `javac` does not emit.