### PR TITLE
[codegen] Add type information to `OperandStack`

### DIFF
--- a/src/jllvm/class/ByteCodeIterator.hpp
+++ b/src/jllvm/class/ByteCodeIterator.hpp
@@ -113,7 +113,7 @@ inline auto byteCodeRange(llvm::ArrayRef<char> current)
     return llvm::make_range(ByteCodeIterator(current.begin()), ByteCodeIterator(current.end()));
 }
 
-inline auto getOffset(const ByteCodeOp& op)
+inline std::size_t getOffset(const ByteCodeOp& op)
 {
     return match(op, [](const auto& op) { return op.offset; });
 }

--- a/src/jllvm/materialization/ByteCodeCompileLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeCompileLayer.cpp
@@ -119,11 +119,10 @@ class OperandStack
 {
     std::vector<std::pair<llvm::AllocaInst*, llvm::Type*>> m_values;
     llvm::IRBuilder<>& m_builder;
-    size_t m_topOfStack;
+    size_t m_topOfStack{};
 
 public:
-    OperandStack(u_int16_t maxStack, llvm::IRBuilder<>& builder)
-        : m_builder(builder), m_values(maxStack), m_topOfStack{0}
+    OperandStack(u_int16_t maxStack, llvm::IRBuilder<>& builder) : m_builder(builder), m_values(maxStack)
     {
         std::generate(
             m_values.begin(), m_values.end(),
@@ -135,7 +134,9 @@ public:
     {
         auto [alloc, type] = m_values[--m_topOfStack];
         if (expected)
+        {
             type = expected;
+        }
 
         return m_builder.CreateLoad(type, alloc);
     }

--- a/src/jllvm/materialization/ByteCodeCompileLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeCompileLayer.cpp
@@ -207,15 +207,10 @@ public:
         std::generate(m_values.begin(), m_values.end(), [&] { return builder.CreateAlloca(builder.getPtrTy()); });
     }
 
-    llvm::Value* pop_back(llvm::Type* expected = nullptr)
+    llvm::Value* pop_back()
     {
         llvm::AllocaInst* alloc = m_values[--m_topOfStack];
         llvm::Type* type = m_types[m_topOfStack];
-        if (expected)
-        {
-            type = expected;
-        }
-
         return m_builder.CreateLoad(type, alloc);
     }
 
@@ -247,7 +242,7 @@ public:
 
     State getHandlerState() const
     {
-        return {{jllvm::referenceType(m_builder.getContext())}, 1u};
+        return {{jllvm::referenceType(m_builder.getContext())}, 1};
     }
 
     void setHandlerStack(llvm::Value* value)
@@ -1107,7 +1102,7 @@ void CodeGen::codeGenInstruction(ByteCodeOp operation)
         [&](OneOf<CheckCast, InstanceOf> op)
         {
             llvm::PointerType* ty = referenceType(builder.getContext());
-            llvm::Value* object = operandStack.pop_back(ty);
+            llvm::Value* object = operandStack.pop_back();
             llvm::Value* null = llvm::ConstantPointerNull::get(ty);
 
             llvm::Value* isNull = builder.CreateICmpEQ(object, null);
@@ -1476,13 +1471,10 @@ void CodeGen::codeGenInstruction(ByteCodeOp operation)
             MethodType descriptor =
                 parseMethodType(refInfo->nameAndTypeIndex.resolve(classFile)->descriptorIndex.resolve(classFile)->text);
 
-            int i = descriptor.parameters.size() - 1;
             std::vector<llvm::Value*> args(descriptor.parameters.size() + 1);
             for (auto& iter : llvm::reverse(args))
             {
-                iter =
-                    operandStack.pop_back(i >= 0 ? descriptorToType(descriptor.parameters[i--], builder.getContext()) :
-                                                   referenceType(builder.getContext()));
+                iter = operandStack.pop_back();
             }
 
             llvm::StringRef className = refInfo->classIndex.resolve(classFile)->nameIndex.resolve(classFile)->text;
@@ -1558,13 +1550,10 @@ void CodeGen::codeGenInstruction(ByteCodeOp operation)
             MethodType descriptor =
                 parseMethodType(refInfo->nameAndTypeIndex.resolve(classFile)->descriptorIndex.resolve(classFile)->text);
 
-            int i = descriptor.parameters.size() - 1;
             std::vector<llvm::Value*> args(descriptor.parameters.size() + (isStatic ? 0 : /*objectref*/ 1));
             for (auto& iter : llvm::reverse(args))
             {
-                iter =
-                    operandStack.pop_back(i >= 0 ? descriptorToType(descriptor.parameters[i--], builder.getContext()) :
-                                                   referenceType(builder.getContext()));
+                iter = operandStack.pop_back();
             }
 
             llvm::StringRef className = refInfo->classIndex.resolve(classFile)->nameIndex.resolve(classFile)->text;
@@ -1600,13 +1589,10 @@ void CodeGen::codeGenInstruction(ByteCodeOp operation)
             MethodType descriptor =
                 parseMethodType(refInfo->nameAndTypeIndex.resolve(classFile)->descriptorIndex.resolve(classFile)->text);
 
-            int i = descriptor.parameters.size() - 1;
             std::vector<llvm::Value*> args(descriptor.parameters.size() + 1);
             for (auto& iter : llvm::reverse(args))
             {
-                iter =
-                    operandStack.pop_back(i >= 0 ? descriptorToType(descriptor.parameters[i--], builder.getContext()) :
-                                                   referenceType(builder.getContext()));
+                iter = operandStack.pop_back();
             }
             llvm::StringRef className = refInfo->classIndex.resolve(classFile)->nameIndex.resolve(classFile)->text;
             llvm::StringRef methodName =

--- a/tests/Execution/blocks-with-different-types-on-stack.j
+++ b/tests/Execution/blocks-with-different-types-on-stack.j
@@ -1,0 +1,37 @@
+; RUN: jasmin %s -d %t
+; RUN: jllvm -Xenable-test-utils %t/Test.class
+
+.class public Test
+.super java/lang/Object
+
+.field public static foo Ljava/lang/Object;
+
+.method public <init>()V
+    aload_0
+    invokespecial java/lang/Object/<init>()V
+    return
+.end method
+
+.method public static native print(I)V
+.end method
+
+.method public static main([Ljava/lang/String;)V
+.limit stack 2
+Block1:
+    new java/lang/Object
+    dup
+    invokespecial java/lang/Object/<init>()V
+    iconst_1
+    ifge Block3
+Block2:
+    pop
+    iconst_0
+    goto Block4
+Block3:
+    putstatic Test/foo Ljava/lang/Object;
+    iconst_1
+Block4:
+    ; CHECK: 1
+    invokestatic Test/print(I)V
+    return
+.end method

--- a/tests/Execution/handler-stack-pointer.j
+++ b/tests/Execution/handler-stack-pointer.j
@@ -1,0 +1,33 @@
+; RUN: jasmin %s -d %t
+; RUN: jllvm -Xenable-test-utils %t/Test.class
+
+.class public Test
+.super java/lang/Object
+
+.field public static foo Ljava/lang/RuntimeException;
+
+.method public <init>()V
+    aload_0
+    invokespecial java/lang/Object/<init>()V
+    return
+.end method
+
+.method public static native print(Ljava/lang/String;)V
+.end method
+
+.method public static main([Ljava/lang/String;)V
+.limit stack 4
+.catch java/lang/RuntimeException from L1 to Handler using Handler
+L1:
+    iconst_0 ; bottom of stack is the integer
+
+    new java/lang/RuntimeException
+    dup
+    ldc "Hello"
+    invokespecial java/lang/RuntimeException/<init>(Ljava/lang/String;)V
+    athrow
+
+Handler:
+    putstatic Test/foo Ljava/lang/RuntimeException;
+    return
+.end method


### PR DESCRIPTION
This PR adds type information the the `OperandStack`, thereby enabling popping without having to specify the type.
It also allows for checking the type of the popped value in order to implement operations with multiple forms depending on the type.