### PR TITLE
[instruction] Implement l2d, l2f and l2i instructions and change precision for double prints

### DIFF
--- a/src/jllvm/main/Main.cpp
+++ b/src/jllvm/main/Main.cpp
@@ -26,6 +26,7 @@ requires(std::is_floating_point_v<T>) struct TrivialPrinter<T>
     auto operator()(void*, void*, T value)
     {
         std::stringstream str;
+        str.precision(std::numeric_limits<T>::digits10);
         str << std::defaultfloat << value << '\n';
         llvm::outs() << str.str();
     }

--- a/src/jllvm/materialization/ByteCodeCompileLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeCompileLayer.cpp
@@ -1661,9 +1661,21 @@ void CodeGen::codeGenInstruction(ByteCodeOp operation)
         },
         // TODO: JSR
         // TODO: JSRw
-        // TODO: L2D
-        // TODO: L2F
-        // TODO: L2I
+        [&](L2D)
+        {
+            llvm::Value* value = operandStack.pop_back();
+            operandStack.push_back(builder.CreateSIToFP(value, builder.getDoubleTy()));
+        },
+        [&](L2F)
+        {
+            llvm::Value* value = operandStack.pop_back();
+            operandStack.push_back(builder.CreateSIToFP(value, builder.getFloatTy()));
+        },
+        [&](L2I)
+        {
+            llvm::Value* value = operandStack.pop_back();
+            operandStack.push_back(builder.CreateTrunc(value, builder.getInt32Ty()));
+        },
         // TODO: LAnd
         // TODO: LCmp
         [&](OneOf<LDC, LDCW, LDC2W> ldc)

--- a/tests/Execution/dadd.java
+++ b/tests/Execution/dadd.java
@@ -59,11 +59,11 @@ class Test
         var y = 1549700.4;
         var z = -2.1339336E8;
 
-        // CHECK: 1.54969e+06
+        // CHECK: 1549693.7942214
         print(x + y);
-        // CHECK: -2.13393e+08
+        // CHECK: -213393366.605779
         print(x + z);
-        // CHECK: -2.11844e+08
+        // CHECK: -211843659.6
         print(y + z);
     }
 }

--- a/tests/Execution/ddiv.java
+++ b/tests/Execution/ddiv.java
@@ -52,11 +52,11 @@ class Test
         var y = 1.26373286E9;
         var z = -238.710592;
 
-        // CHECK: -0.0353235
+        // CHECK: -0.0353235477314406
         print(x / y);
-        // CHECK: 187003
+        // CHECK: 187002.711635016
         print(x / z);
-        // CHECK: -5.294e+06
+        // CHECK: -5293995.75197736
         print(y / z);
     }
 }

--- a/tests/Execution/dmul.java
+++ b/tests/Execution/dmul.java
@@ -20,13 +20,13 @@ class Test
         print(nan * p_123);
         print(p_123 * nan);
 
-        // CHECK: 15241.4
-        // CHECK: 15241.4
+        // CHECK: 15241.383936
+        // CHECK: 15241.383936
         print(p_123 * p_123);
         print(n_123 * n_123);
 
-        // CHECK: -15241.4
-        // CHECK: -15241.4
+        // CHECK: -15241.383936
+        // CHECK: -15241.383936
         print(p_123 * n_123);
         print(n_123 * p_123);
 
@@ -44,11 +44,11 @@ class Test
         var y = -4.09644288E8;
         var z = 1374.04144;
 
-        // CHECK: -2.77213e+16
+        // CHECK: -2.77212811226665e+16
         print(x * y);
-        // CHECK: 9.29836e+10
+        // CHECK: 92983571718.7725
         print(x * z);
-        // CHECK: -5.62868e+11
+        // CHECK: -562868227371.295
         print(y * z);
     }
 }

--- a/tests/Execution/dneg.java
+++ b/tests/Execution/dneg.java
@@ -37,11 +37,11 @@ class Test
         var y = -5.4427053E8;
         var z = -4.29113472;
 
-        // CHECK: -1.06639e+08
+        // CHECK: -106639384
         print(-x);
-        // CHECK: 5.44271e+08
+        // CHECK: 544270530
         print(-y);
-        // CHECK: 4.29113
+        // CHECK: 4.29113472
         print(-z);
     }
 }

--- a/tests/Execution/drem.java
+++ b/tests/Execution/drem.java
@@ -49,11 +49,11 @@ class Test
         var y = -5.9460864E8;
         var z = 1425.10118;
 
-        // CHECK: 5.4791e+08
+        // CHECK: 547910080
         print(x % y);
-        // CHECK: 1397.81
+        // CHECK: 1397.81175972065
         print(x % z);
-        // CHECK: -848.758
+        // CHECK: -848.757979952823
         print(y % z);
     }
 }

--- a/tests/Execution/dsub.java
+++ b/tests/Execution/dsub.java
@@ -64,11 +64,11 @@ class Test
         var y = -1.09827904E9;
         var z = 1.1562734E7;
 
-        // CHECK: 1.28208e+09
+        // CHECK: 1282078976
         print(x - y);
-        // CHECK: 1.72237e+08
+        // CHECK: 172237202
         print(x - z);
-        // CHECK: -1.10984e+09
+        // CHECK: -1109841774
         print(y - z);
     }
 }

--- a/tests/Execution/float-casts.java
+++ b/tests/Execution/float-casts.java
@@ -29,9 +29,9 @@ class Test
         print((double) p_zero);
         //CHECK: -0
         print((double) n_zero);
-        //CHECK: 9.32337e+18
+        //CHECK: 9.32337151988938e+18
         print((double) p_long_max_plus);
-        //CHECK: -9.32337e+18
+        //CHECK: -9.32337151988938e+18
         print((double) n_long_max_plus);
 
         //CHECK: 0

--- a/tests/Execution/ldc2_w.java
+++ b/tests/Execution/ldc2_w.java
@@ -14,7 +14,7 @@ class Test
         print(-987.654);
 
         // larger double than Float.MAX_VALUE
-        // CHECK: 4.40282e+38
+        // CHECK: 4.4028235e+38
         print(4.4028235E38);
 
         // CHECK: 123456

--- a/tests/Execution/long-casts.java
+++ b/tests/Execution/long-casts.java
@@ -1,0 +1,37 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+class Test
+{
+    public static native void print(int i);
+    public static native void print(double d);
+    public static native void print(float f);
+
+    public static void main(String[] args)
+    {
+        long x = (long)Integer.MAX_VALUE+1;
+        long y = Long.MAX_VALUE;
+        long z = Long.MIN_VALUE;
+
+        //CHECK: -2147483648
+        print((int) x);
+        //CHECK: -1
+        print((int) y);
+        //CHECK: 0
+        print((int) z);
+
+        //CHECK: 2.14748e+09
+        print((float) x);
+        //CHECK: 9.22337e+18
+        print((float) y);
+        //CHECK: -9.22337e+18
+        print((float) z);
+
+        //CHECK: 2147483648
+        print((double) x);
+        //CHECK: 9.22337203685478e+18
+        print((double) y);
+        //CHECK: -9.22337203685478e+18
+        print((double) z);
+    }
+}


### PR DESCRIPTION
This PR includes support for creating appropriate LLVM instructions on processing the l2d, l2f and l2i JVM instructions. Additionally, this PR improves precision for double prints. Thus, double values now have higher precision than float values.

fixes https://github.com/JLLVM/JLLVM/issues/133