### PR TITLE
[instruction] Add support for `goto_w` instruction

### DIFF
--- a/src/jllvm/materialization/ByteCodeCompileLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeCompileLayer.cpp
@@ -1730,13 +1730,12 @@ void CodeGen::codeGenInstruction(ByteCodeOp operation)
             }
             operandStack.push_back(field);
         },
-        [&](Goto gotoOp)
+        [&](OneOf<Goto, GotoW> gotoOp)
         {
             auto index = gotoOp.target + gotoOp.offset;
             basicBlockStackStates.insert({basicBlocks[index], operandStack.saveState()});
             builder.CreateBr(basicBlocks[index]);
         },
-        // TODO: GotoW
         [&](I2B)
         {
             llvm::Value* value = operandStack.pop_back();

--- a/tests/Execution/wide.j
+++ b/tests/Execution/wide.j
@@ -1,0 +1,42 @@
+; RUN: jasmin %s -d %t
+; RUN: jllvm -Xenable-test-utils %t/Test.class
+
+.class public Test
+.super java/lang/Object
+
+.method public <init>()V
+    aload_0
+    invokespecial java/lang/Object/<init>()V
+    return
+.end method
+
+.method public static native print(I)V
+.end method
+
+.method public static goto_w(I)V
+    .limit stack 2
+    iload_0
+    iconst_1
+    if_icmpne Else
+    iconst_0
+    invokestatic  Test/print(I)V
+    goto_w End
+Else:
+    iconst_1
+    invokestatic  Test/print(I)V
+End:
+    return
+.end method
+
+.method public static main([Ljava/lang/String;)V
+.limit stack 4
+    iconst_0
+    ; CHECK: 1
+    invokestatic  Test/goto_w(I)V
+
+    iconst_1
+    ; CHECK: 0
+    invokestatic  Test/goto_w(I)V
+
+    return
+.end method


### PR DESCRIPTION
This PR includes support for creating appropriate LLVM instructions on processing the `goto_w` JVM instruction.