### PR TITLE
[instruction] Add support for `wide` instruction

### DIFF
--- a/src/jllvm/class/ByteCode.def
+++ b/src/jllvm/class/ByteCode.def
@@ -225,12 +225,20 @@ GENERATE_SELECTOR(
     },
     parseIInc, 3, 0x84)
 GENERATE_SELECTOR(LookupSwitch, SwitchOp, {}, parseLookupSwitch, lookupSwitchSize(m_current, m_offset), 0xab)
-GENERATE_SELECTOR(MultiANewArray, PoolIndexedOp, { std::uint8_t dimensions; }, parseMultiANewArray, 4, 0xc5)
+GENERATE_SELECTOR(
+    MultiANewArray, PoolIndexedOp, { std::uint8_t dimensions; }, parseMultiANewArray, 4, 0xc5)
 GENERATE_SELECTOR(NewArray, ArrayOp, {}, parseNewArray, 2, 0xbc)
 GENERATE_SELECTOR(
     SIPush, ByteCodeBase, { std::int16_t value{}; }, parseSIPush, 3, 0x11)
 GENERATE_SELECTOR(TableSwitch, SwitchOp, {}, parseTableSwitch, tableSwitchSize(m_current, m_offset), 0xaa)
-GENERATE_SELECTOR_END(Wide, ByteCodeBase, {/* TODO */}, parseNotImplemented, wideSize(m_current), 0xc4)
+GENERATE_SELECTOR_END(
+    Wide, ByteCodeBase,
+    {
+        OpCodes opCode{};
+        std::uint16_t index{};
+        std::optional<std::int16_t> value{};
+    },
+    parseWide, wideSize(m_current), 0xc4)
 
 #undef BRANCH_OFFSET_OP
 #undef POOL_INDEX_OP

--- a/src/jllvm/class/ByteCodeIterator.cpp
+++ b/src/jllvm/class/ByteCodeIterator.cpp
@@ -66,35 +66,35 @@ ByteCodeOp parseBranchOffset(const char* bytes, std::size_t offset)
     }
 }
 
-template <std::same_as<BIPush> OpCode>
+template <std::same_as<BIPush>>
 ByteCodeOp parseBIPush(const char* bytes, std::size_t offset)
 {
     consume<OpCodes>(bytes);
     return BIPush{offset, consume<std::int8_t>(bytes)};
 }
 
-template <std::same_as<NewArray> OpCode>
+template <std::same_as<NewArray>>
 ByteCodeOp parseNewArray(const char* bytes, std::size_t offset)
 {
     consume<OpCodes>(bytes);
     return NewArray{offset, consume<ArrayOp::ArrayType>(bytes)};
 }
 
-template <std::same_as<IInc> OpCode>
+template <std::same_as<IInc>>
 ByteCodeOp parseIInc(const char* bytes, std::size_t offset)
 {
     consume<OpCodes>(bytes);
     return IInc{offset, consume<std::uint8_t>(bytes), consume<std::int8_t>(bytes)};
 }
 
-template <std::same_as<SIPush> OpCode>
+template <std::same_as<SIPush>>
 ByteCodeOp parseSIPush(const char* bytes, std::size_t offset)
 {
     consume<OpCodes>(bytes);
     return SIPush{offset, consume<std::int16_t>(bytes)};
 }
 
-template <std::same_as<MultiANewArray> OpCode>
+template <std::same_as<MultiANewArray>>
 ByteCodeOp parseMultiANewArray(const char* bytes, std::size_t offset)
 {
     consume<OpCodes>(bytes);
@@ -104,7 +104,7 @@ ByteCodeOp parseMultiANewArray(const char* bytes, std::size_t offset)
     return MultiANewArray{offset, index, dimensions};
 }
 
-template <std::same_as<LookupSwitch> OpCode>
+template <std::same_as<LookupSwitch>>
 ByteCodeOp parseLookupSwitch(const char* bytes, std::size_t offset)
 {
     bytes += 4 - (offset % 4);
@@ -123,7 +123,7 @@ ByteCodeOp parseLookupSwitch(const char* bytes, std::size_t offset)
     return LookupSwitch{offset, std::move(matchOffsetsPairs), defaultOffset};
 }
 
-template <std::same_as<TableSwitch> OpCode>
+template <std::same_as<TableSwitch>>
 ByteCodeOp parseTableSwitch(const char* bytes, std::size_t offset)
 {
     bytes += 4 - (offset % 4);
@@ -144,10 +144,19 @@ ByteCodeOp parseTableSwitch(const char* bytes, std::size_t offset)
     return TableSwitch{offset, std::move(matchOffsetsPairs), defaultOffset};
 }
 
-template <class>
-ByteCodeOp parseNotImplemented(const char*, std::size_t)
+template <std::same_as<Wide>>
+ByteCodeOp parseWide(const char* bytes, std::size_t offset)
 {
-    llvm::report_fatal_error("NOT YET IMPLEMENTED");
+    consume<OpCodes>(bytes);
+    auto opCode = consume<OpCodes>(bytes);
+    auto index = consume<std::uint16_t>(bytes);
+    std::optional<std::int16_t> value{};
+    if (opCode == OpCodes::IInc)
+    {
+        value = consume<std::int16_t>(bytes);
+    }
+
+    return Wide{offset, opCode, index, value};
 }
 
 std::size_t lookupSwitchSize(const char* bytes, std::size_t offset)

--- a/tests/Execution/wide.j
+++ b/tests/Execution/wide.j
@@ -10,7 +10,25 @@
     return
 .end method
 
+.method public static native print(D)V
+.end method
+
+.method public static native print(F)V
+.end method
+
 .method public static native print(I)V
+.end method
+
+.method public static native print(J)V
+.end method
+
+.method public static native print(Ljava/lang/String;)V
+.end method
+
+.method public static print(LTest;)V
+    ldc "Test"
+    invokestatic  Test/print(Ljava/lang/String;)V
+    return
 .end method
 
 .method public static goto_w(I)V
@@ -28,6 +46,64 @@ End:
     return
 .end method
 
+.method public static wide_a(LTest;)V
+    .limit stack 2
+    .limit locals 300
+    aload_0
+    astore_w 260
+    aload_w 260
+    invokestatic  Test/print(LTest;)V
+    return
+.end method
+
+.method public static wide_d(D)V
+    .limit stack 2
+    .limit locals 300
+    dload_0
+    dstore_w 260
+    dload_w 260
+    invokestatic  Test/print(D)V
+    return
+.end method
+
+.method public static wide_f(F)V
+    .limit stack 2
+    .limit locals 300
+    fload_0
+    fstore_w 260
+    fload_w 260
+    invokestatic  Test/print(F)V
+    return
+.end method
+
+.method public static wide_i(I)V
+    .limit locals 300
+    iload_0
+    istore_w 260
+    iload_w 260
+    invokestatic  Test/print(I)V
+    return
+.end method
+
+.method public static wide_l(J)V
+    .limit stack 2
+    .limit locals 300
+    lload_0
+    lstore_w 260
+    lload_w 260
+    invokestatic  Test/print(J)V
+    return
+.end method
+
+.method public static wide_iinc(I)V
+    .limit stack 2
+    .limit locals 300
+    iinc_w 0 260
+    iload_0
+    invokestatic  Test/print(I)V
+    return
+.end method
+
 .method public static main([Ljava/lang/String;)V
 .limit stack 4
     iconst_0
@@ -37,6 +113,30 @@ End:
     iconst_1
     ; CHECK: 0
     invokestatic  Test/goto_w(I)V
+
+    new Test
+    ; CHECK: Test
+    invokestatic  Test/wide_a(LTest;)V
+
+    dconst_0
+    ; CHECK: 0
+    invokestatic  Test/wide_d(D)V
+
+    fconst_1
+    ; CHECK: 1
+    invokestatic  Test/wide_f(F)V
+
+    iconst_2
+    ; CHECK: 2
+    invokestatic  Test/wide_i(I)V
+
+    ldc2_w  3
+    ; CHECK: 3
+    invokestatic  Test/wide_l(J)V
+
+    iconst_4
+    ; CHECK: 264
+    invokestatic  Test/wide_iinc(I)V
 
     return
 .end method


### PR DESCRIPTION
This PR includes support for creating appropriate LLVM instructions on processing the `wide` JVM instruction.
Implementing `wide` in conjunction with `ret` is left as a TODO, since  `ret` is yet to be implemented.