### PR TITLE
[object][NFC] reduce number of VTable slots

### DIFF
--- a/src/jllvm/class/ClassFile.hpp
+++ b/src/jllvm/class/ClassFile.hpp
@@ -383,7 +383,7 @@ public:
     /// Returns true if this method requires a VTable slot.
     bool needsVTableSlot(const ClassFile& classFile) const
     {
-        return !isStatic() && getName(classFile) != "<init>";
+        return !isPrivate() && !isFinal() && !isStatic() && getName(classFile) != "<init>";
     }
 
     /// Returns the name of this method.

--- a/src/jllvm/materialization/CodeGeneratorUtils.cpp
+++ b/src/jllvm/materialization/CodeGeneratorUtils.cpp
@@ -265,9 +265,10 @@ LazyClassLoaderHelper::ResolutionResult LazyClassLoaderHelper::virtualMethodReso
             { return !method.isStatic() && method.getName() == methodName && method.getType() == methodType; });
         if (iter != methods.end())
         {
-            if (iter->isFinal())
+            if (!iter->getVTableSlot())
             {
-                // Final method can't be overwritten and we can just create a direct call to it.
+                // Methods that can't be overwritten, like final or private methods won't have a v-table slot and we
+                // can just create a direct call to them.
                 return mangleMethod(curr->getClassName(), iter->getName(), iter->getType());
             }
             return VTableOffset{*iter->getVTableSlot()};

--- a/src/jllvm/object/ClassLoader.cpp
+++ b/src/jllvm/object/ClassLoader.cpp
@@ -42,7 +42,7 @@ VTableAssignment assignVTableSlots(const jllvm::ClassFile& classFile, const jllv
     llvm::DenseMap<const jllvm::MethodInfo*, std::uint16_t> assignment;
     for (const MethodInfo& iter : classFile.getMethods())
     {
-        // If the method can never overwrite we don't need to assign it a v-table slot.
+        // If the method can't be overwritten we don't need to assign it a v-table slot.
         if (!iter.needsVTableSlot(classFile))
         {
             continue;

--- a/tests/Execution/final-method-call.java
+++ b/tests/Execution/final-method-call.java
@@ -1,0 +1,32 @@
+// RUN: rm -rf %t && split-file %s %t
+// RUN: cd %t && javac %t/Other.java -d %t
+// RUN: jllvm -Xenable-test-utils %t/Other.class | FileCheck %s
+
+//--- Test.java
+
+public class Test
+{
+    public static native void print(int i);
+}
+
+//--- A.java
+
+public class A
+{
+    public final void a()
+    {
+        Test.print(5);
+    }
+}
+
+//--- Other.java
+
+public class Other extends A
+{
+    public static void main(String[] args)
+    {
+        Other c = new Other();
+        // CHECK: 5
+        c.a();
+    }
+}


### PR DESCRIPTION
Since our new `invokevirtual` implementation it is now perfectly possible to create direct calls to methods if after resolution we know they can't be overwritten. This is the case for any private or final instance methods for example.

This PR uses that capability to reduce the amount of V-Table slots we create for class objects.