### PR TITLE
[object][NFC] reduce number of Itable slots

### DIFF
--- a/src/jllvm/materialization/CodeGeneratorUtils.hpp
+++ b/src/jllvm/materialization/CodeGeneratorUtils.hpp
@@ -130,6 +130,10 @@ class LazyClassLoaderHelper
 
     using ResolutionResult = swl::variant<VTableOffset, ITableOffset, std::string>;
 
+    static ResolutionResult vTableResult(const ClassObject* classObject, const Method* method);
+
+    static ResolutionResult iTableResult(const ClassObject* interface, const Method* method);
+
     static ResolutionResult virtualMethodResolution(const ClassObject* classObject, llvm::StringRef methodName,
                                                     llvm::StringRef methodType);
 

--- a/tests/Execution/private-invoke-interface.java
+++ b/tests/Execution/private-invoke-interface.java
@@ -1,0 +1,41 @@
+// RUN: rm -rf %t && split-file %s %t
+// RUN: cd %t && javac %t/Other.java -d %t
+// RUN: jllvm -Xenable-test-utils %t/Main.class | FileCheck %s
+
+//--- Test.java
+
+public class Test
+{
+    public static native void print(int i);
+}
+
+//--- Main.java
+
+public interface Main
+{
+    public static void main(String[] args)
+    {
+        Other t = new Other();
+        // CHECK: 6
+        t.foo();
+        Main o = t;
+        // CHECK: 5
+        o.foo();
+    }
+
+    private void foo()
+    {
+        Test.print(5);
+    }
+}
+
+
+//--- Other.java
+
+public class Other implements Main
+{
+    public void foo()
+    {
+        Test.print(6);
+    }
+}


### PR DESCRIPTION
Similar to https://github.com/JLLVM/JLLVM/pull/142, this reduces the amount of slots allocated in an I-Table for an interface. Interface methods can't actually be final, hence no test was added for that case here. Private interface methods can't be overwritten (same logic as for normal class methods) hence there is no need to create slots for them.

Depends on https://github.com/JLLVM/JLLVM/pull/145