### PR TITLE
[codegen] Add most basic debug info to Java functions

### DIFF
--- a/src/jllvm/materialization/CodeGenerator.hpp
+++ b/src/jllvm/materialization/CodeGenerator.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <llvm/IR/DIBuilder.h>
+
 #include <jllvm/class/ByteCodeIterator.hpp>
 #include <jllvm/vm/StringInterner.hpp>
 
@@ -17,6 +19,7 @@ class CodeGenerator
     StringInterner& m_stringInterner;
     const MethodType& m_functionMethodType;
     llvm::IRBuilder<> m_builder;
+    llvm::DIBuilder m_debugBuilder;
     OperandStack m_operandStack;
     std::vector<llvm::AllocaInst*> m_locals;
     llvm::DenseMap<std::uint16_t, llvm::BasicBlock*> m_basicBlocks;
@@ -53,6 +56,7 @@ public:
           m_stringInterner{stringInterner},
           m_functionMethodType{methodType},
           m_builder{llvm::BasicBlock::Create(function->getContext(), "entry", function)},
+          m_debugBuilder{*function->getParent()},
           m_operandStack{m_builder, maxStack},
           m_locals{maxLocals}
     {

--- a/src/jllvm/materialization/CodeGeneratorUtils.cpp
+++ b/src/jllvm/materialization/CodeGeneratorUtils.cpp
@@ -57,9 +57,23 @@ public:
         function->setSubprogram(m_subProgram);
     }
 
+    ~TrivialDebugInfoBuilder()
+    {
+        finalize();
+    }
+
+    TrivialDebugInfoBuilder(const TrivialDebugInfoBuilder&) = delete;
+    TrivialDebugInfoBuilder(TrivialDebugInfoBuilder&&) = delete;
+    TrivialDebugInfoBuilder& operator=(const TrivialDebugInfoBuilder&) = delete;
+    TrivialDebugInfoBuilder& operator=(TrivialDebugInfoBuilder&&) = delete;
+
     void finalize()
     {
-        m_debugBuilder.finalizeSubprogram(m_subProgram);
+        if (!m_subProgram)
+        {
+            return;
+        }
+        m_debugBuilder.finalizeSubprogram(std::exchange(m_subProgram, nullptr));
         m_debugBuilder.finalize();
     }
 };


### PR DESCRIPTION
This adds nothing but the name of the function, currently still in the mangled form, as debug info in the produced LLVM. This is luckily enough to have the debugger display the name of the function in the callstack.

Example of callstack in GDB:
![image](https://github.com/JLLVM/JLLVM/assets/6625526/3f7fb011-63cc-4022-b983-273fc2346d98)