### PR TITLE
[codegen][gc] reliably retrieve RSP during unwinding

### DIFF
--- a/src/jllvm/gc/GarbageCollector.cpp
+++ b/src/jllvm/gc/GarbageCollector.cpp
@@ -118,7 +118,7 @@ void collectStackRoots(const llvm::DenseMap<std::uintptr_t, std::vector<jllvm::S
                 }
                 case jllvm::StackMapEntry::Indirect:
                 {
-                    auto rp = _Unwind_GetGR(context, iter.registerNumber);
+                    auto rp = _Unwind_GetCFA(context);
                     auto** ptr = reinterpret_cast<ObjectRepr**>(rp + iter.offset);
                     for (std::size_t i = 0; i < iter.count; i++)
                     {
@@ -175,7 +175,7 @@ void replaceStackRoots(const llvm::DenseMap<std::uintptr_t, std::vector<jllvm::S
                 }
                 case jllvm::StackMapEntry::Indirect:
                 {
-                    auto rp = _Unwind_GetGR(context, iter.registerNumber);
+                    auto rp = _Unwind_GetCFA(context);
                     auto** ptr = reinterpret_cast<ObjectRepr**>(rp + iter.offset);
                     for (std::size_t i = 0; i < iter.count; i++)
                     {

--- a/src/jllvm/materialization/ByteCodeCompileLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeCompileLayer.cpp
@@ -22,6 +22,7 @@ void jllvm::ByteCodeCompileLayer::emit(std::unique_ptr<llvm::orc::Materializatio
         llvm::Function::Create(descriptorToType(descriptor, methodInfo->isStatic(), module->getContext()),
                                llvm::GlobalValue::ExternalLinkage, mangleMethod(*methodInfo, *classFile), module.get());
     function->setGC("coreclr");
+    function->addFnAttr(llvm::Attribute::UWTable);
 #ifdef LLVM_ADDRESS_SANITIZER_BUILD
     function->addFnAttr(llvm::Attribute::SanitizeAddress);
 #endif

--- a/src/jllvm/materialization/CodeGeneratorUtils.cpp
+++ b/src/jllvm/materialization/CodeGeneratorUtils.cpp
@@ -148,6 +148,7 @@ llvm::Value* LazyClassLoaderHelper::returnConstantForClassObject(llvm::IRBuilder
 
                     auto* function = llvm::Function::Create(functionType, llvm::GlobalValue::ExternalLinkage,
                                                             stubSymbol, module.get());
+                    function->addFnAttr(llvm::Attribute::UWTable);
                     TrivialDebugInfoBuilder debugInfoBuilder(function);
                     llvm::IRBuilder<> builder(llvm::BasicBlock::Create(*context, "entry", function));
 
@@ -223,6 +224,7 @@ llvm::Value* LazyClassLoaderHelper::doCallForClassObject(llvm::IRBuilder<>& buil
 
                     auto* function = llvm::Function::Create(functionType, llvm::GlobalValue::ExternalLinkage, stubName,
                                                             module.get());
+                    function->addFnAttr(llvm::Attribute::UWTable);
                     TrivialDebugInfoBuilder debugInfoBuilder(function);
 
                     llvm::IRBuilder<> builder(llvm::BasicBlock::Create(*context, "entry", function));

--- a/src/jllvm/materialization/JNIImplementationLayer.cpp
+++ b/src/jllvm/materialization/JNIImplementationLayer.cpp
@@ -107,6 +107,7 @@ void jllvm::JNIImplementationLayer::emit(std::unique_ptr<llvm::orc::Materializat
                 auto* function = llvm::Function::Create(descriptorToType(methodType, methodInfo->isStatic(), *context),
                                                         llvm::GlobalValue::ExternalLinkage, bridgeName, module.get());
                 function->setSubprogram(subprogram);
+                function->addFnAttr(llvm::Attribute::UWTable);
 
                 llvm::IRBuilder<> builder(llvm::BasicBlock::Create(*context, "entry", function));
 

--- a/src/jllvm/materialization/LambdaMaterialization.hpp
+++ b/src/jllvm/materialization/LambdaMaterialization.hpp
@@ -173,6 +173,7 @@ public:
 
         llvm::Function* function =
             llvm::Function::Create(functionType, llvm::GlobalValue::ExternalLinkage, m_symbol, module.get());
+        function->addFnAttr(llvm::Attribute::UWTable);
 
         auto* type = llvm::ArrayType::get(llvm::Type::getInt8Ty(*context), sizeof(F));
         auto* closure = new llvm::GlobalVariable(

--- a/tests/Execution/dynamic-stack-usage-gc.java
+++ b/tests/Execution/dynamic-stack-usage-gc.java
@@ -1,0 +1,96 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+class Test
+{
+    public static native void print(int i);
+
+    public static void lotsOfParamsThatArePassedOnStack(
+        Object[] first,
+        Object[] second,
+        Object[] third,
+        Object[] fourth,
+        Object[] fifth,
+        Object[] sixth,
+        Object[] seventh,
+        Object[] eighth,
+        Object[] ninth,
+        Object[] tenth,
+        Object[] eleventh,
+        Object[] twelveth,
+        Object[] thirteenth,
+        Object[] fourteenth,
+        Object[] fifteenth)
+    {
+        new Object();
+        // CHECK: 0
+        print(first.length);
+        new Object();
+        // CHECK: 1
+        print(second.length);
+        new Object();
+        // CHECK: 2
+        print(third.length);
+        new Object();
+        // CHECK: 3
+        print(fourth.length);
+        new Object();
+        // CHECK: 4
+        print(fifth.length);
+        new Object();
+        // CHECK: 5
+        print(sixth.length);
+        new Object();
+        // CHECK: 6
+        print(seventh.length);
+        new Object();
+        // CHECK: 7
+        print(eighth.length);
+        new Object();
+        // CHECK: 8
+        print(ninth.length);
+        new Object();
+        // CHECK: 9
+        print(tenth.length);
+        new Object();
+        // CHECK: 10
+        print(eleventh.length);
+        new Object();
+        // CHECK: 11
+        print(twelveth.length);
+        new Object();
+        // CHECK: 12
+        print(thirteenth.length);
+        new Object();
+        // CHECK: 13
+        print(fourteenth.length);
+        new Object();
+        // CHECK: 14
+        print(fifteenth.length);
+        new Object();
+    }
+
+    public static void main(String[] args)
+    {
+        var i = new int[5];
+        lotsOfParamsThatArePassedOnStack(
+            new Object[0],
+            new Object[1],
+            new Object[2],
+            new Object[3],
+            new Object[4],
+            new Object[5],
+            new Object[6],
+            new Object[7],
+            new Object[8],
+            new Object[9],
+            new Object[10],
+            new Object[11],
+            new Object[12],
+            new Object[13],
+            new Object[14]
+        );
+        // CHECK: 5
+        print(i.length);
+    }
+}


### PR DESCRIPTION
Unwinding the stack is a very complicated topic and it turns out DWARF CFI is very complicated. When working with deeper call-stacks I have discovered multiple occurrences of the unwinder being unable to retrieve the stack pointer and crashing instead.

I have tried multiple combinations of: using libunwind instead of libgcc, all kinds of compiler flags, both in our JIT and C++ compiler, testing with GCC, using the level 1 libunwind API and so on and on, but would usually end up just having crashes elsewhere.

The version that basically worked perfectly for everything I've tested was fetching the Canonical Frame Address (CFA) ~~which as far as I can tell is equal to the stack pointer but always available~~ is equal to the stack pointer at the beginning of the function, which seemingly works for all our code for now... (https://maskray.me/blog/2020-11-08-stack-unwinding). The code previously used `_Unwind_GetGR` which uses a dwarf register number and a more generic mechanism to be able to fetch any (callee-saved) register, but is seemingly unreliable in libgcc (?).

Future work should explore using libunwind and using its API for JIT frame registrations (I suspect libgcc is at fault here).