### PR TITLE
[native] implement `Double` and `Float` bit conversions

### DIFF
--- a/src/jllvm/vm/NativeImplementation.cpp
+++ b/src/jllvm/vm/NativeImplementation.cpp
@@ -7,5 +7,5 @@ jllvm::VirtualMachine& jllvm::detail::virtualMachineFromJNIEnv(JNIEnv* env)
 
 void jllvm::registerJavaClasses(VirtualMachine& virtualMachine)
 {
-    addModels<ObjectModel, ClassModel, ThrowableModel>(virtualMachine);
+    addModels<ObjectModel, ClassModel, ThrowableModel, FloatModel, DoubleModel>(virtualMachine);
 }

--- a/src/jllvm/vm/NativeImplementation.hpp
+++ b/src/jllvm/vm/NativeImplementation.hpp
@@ -129,6 +129,21 @@ public:
         // Noop until (if?) we need some C++ initialization code.
     }
 
+    static const ClassObject* getPrimitiveClass(VirtualMachine& vm, GCRootRef<ClassObject>, GCRootRef<String> string)
+    {
+        static llvm::DenseMap<llvm::StringRef, char> mapping = {
+            {"boolean", 'Z'}, {"char", 'C'},  {"byte", 'B'}, {"short", 'S'}, {"int", 'I'},
+            {"double", 'D'},  {"float", 'F'}, {"void", 'V'}, {"long", 'L'},
+        };
+        std::string utf8 = string->toUTF8();
+        char c = mapping.lookup(utf8);
+        if (c == 0)
+        {
+            return nullptr;
+        }
+        return &vm.getClassLoader().forName(llvm::Twine(c));
+    }
+
     bool isArray()
     {
         return javaThis->isArray();
@@ -146,7 +161,53 @@ public:
     constexpr static llvm::StringLiteral className = "java/lang/Class";
     constexpr static auto methods =
         std::make_tuple(addMember<&ClassModel::registerNatives>(), addMember<&ClassModel::isArray>(),
-                        addMember<&ClassModel::desiredAssertionStatus0>());
+                        addMember<&ClassModel::desiredAssertionStatus0>(), addMember<&ClassModel::getPrimitiveClass>());
+};
+
+class FloatModel : public ModelBase<>
+{
+public:
+    using Base::Base;
+
+    static std::uint32_t floatToRawIntBits(VirtualMachine&, GCRootRef<ClassObject>, float value)
+    {
+        std::uint32_t repr;
+        std::memcpy(&repr, &value, sizeof(float));
+        return repr;
+    }
+
+    static float intBitsToFloat(VirtualMachine&, GCRootRef<ClassObject>, std::uint32_t value)
+    {
+        float repr;
+        std::memcpy(&repr, &value, sizeof(float));
+        return repr;
+    }
+
+    constexpr static llvm::StringLiteral className = "java/lang/Float";
+    constexpr static auto methods = std::make_tuple(addMember<&floatToRawIntBits>(), addMember<&intBitsToFloat>());
+};
+
+class DoubleModel : public ModelBase<>
+{
+public:
+    using Base::Base;
+
+    static std::uint64_t doubleToRawLongBits(VirtualMachine&, GCRootRef<ClassObject>, double value)
+    {
+        std::uint64_t repr;
+        std::memcpy(&repr, &value, sizeof(double));
+        return repr;
+    }
+
+    static double longBitsToDouble(VirtualMachine&, GCRootRef<ClassObject>, std::uint64_t value)
+    {
+        double repr;
+        std::memcpy(&repr, &value, sizeof(double));
+        return repr;
+    }
+
+    constexpr static llvm::StringLiteral className = "java/lang/Double";
+    constexpr static auto methods = std::make_tuple(addMember<&doubleToRawLongBits>(), addMember<&longBitsToDouble>());
 };
 
 /// Model implementation for the native methods of Javas 'Thowable' class.

--- a/src/jllvm/vm/NativeImplementation.hpp
+++ b/src/jllvm/vm/NativeImplementation.hpp
@@ -171,6 +171,7 @@ public:
 
     static std::uint32_t floatToRawIntBits(VirtualMachine&, GCRootRef<ClassObject>, float value)
     {
+        // TODO: Use std::bit_cast once supported by our C++20.
         std::uint32_t repr;
         std::memcpy(&repr, &value, sizeof(float));
         return repr;
@@ -178,6 +179,7 @@ public:
 
     static float intBitsToFloat(VirtualMachine&, GCRootRef<ClassObject>, std::uint32_t value)
     {
+        // TODO: Use std::bit_cast once supported by our C++20.
         float repr;
         std::memcpy(&repr, &value, sizeof(float));
         return repr;
@@ -194,6 +196,7 @@ public:
 
     static std::uint64_t doubleToRawLongBits(VirtualMachine&, GCRootRef<ClassObject>, double value)
     {
+        // TODO: Use std::bit_cast once supported by our C++20.
         std::uint64_t repr;
         std::memcpy(&repr, &value, sizeof(double));
         return repr;
@@ -201,6 +204,7 @@ public:
 
     static double longBitsToDouble(VirtualMachine&, GCRootRef<ClassObject>, std::uint64_t value)
     {
+        // TODO: Use std::bit_cast once supported by our C++20.
         double repr;
         std::memcpy(&repr, &value, sizeof(double));
         return repr;

--- a/src/jllvm/vm/VirtualMachine.hpp
+++ b/src/jllvm/vm/VirtualMachine.hpp
@@ -55,6 +55,12 @@ public:
         return m_gc;
     }
 
+    /// Returns the class loader instance of the virtual machine.
+    ClassLoader& getClassLoader()
+    {
+        return m_classLoader;
+    }
+
     int executeMain(llvm::StringRef path, llvm::ArrayRef<llvm::StringRef> args);
 
     template <class... Args>

--- a/tests/Execution/double-float-bits.java
+++ b/tests/Execution/double-float-bits.java
@@ -1,0 +1,50 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+class Test
+{
+    public static native void print(boolean b);
+    public static native void print(double b);
+    public static native void print(float b);
+
+    public static void main(String[] args)
+    {
+        // CHECK: 1
+        print(Double.doubleToRawLongBits(Double.POSITIVE_INFINITY) == 0x7ff0000000000000L);
+
+        // CHECK: 1
+        print(Double.doubleToRawLongBits(Double.NEGATIVE_INFINITY) == 0xfff0000000000000L);
+
+        // CHECK: 1
+        print(Double.doubleToRawLongBits(Double.NaN) == 0x7ff8000000000000L);
+
+        // CHECK: 1
+        print(Double.doubleToRawLongBits(-5.25) == 0xC015000000000000L);
+
+        // CHECK: -5.25
+        print(Double.longBitsToDouble(Double.doubleToRawLongBits(-5.25)));
+
+        // CHECK: 1
+        print(Double.longBitsToDouble(0xfff0000000000000L) == Double.NEGATIVE_INFINITY);
+
+
+
+        // CHECK: 1
+        print(Float.floatToRawIntBits(Float.POSITIVE_INFINITY) == 0x7f800000);
+
+        // CHECK: 1
+        print(Float.floatToRawIntBits(Float.NEGATIVE_INFINITY) == 0xff800000);
+
+        // CHECK: 1
+        print(Float.floatToRawIntBits(Float.NaN) == 0x7fc00000);
+
+        // CHECK: 1
+        print(Float.floatToRawIntBits(-5.25f) == 0xc0a80000);
+
+        // CHECK: -5.25
+        print(Float.intBitsToFloat(Float.floatToRawIntBits(-5.25f)));
+
+        // CHECK: 1
+        print(Float.intBitsToFloat(0xff800000) == Float.NEGATIVE_INFINITY);
+    }
+}


### PR DESCRIPTION
These are simple native methods to convert between integer reinterpretations and the actual floating point number.