### PR TITLE
[native] implement `System.nanoTime`

### DIFF
--- a/src/jllvm/vm/NativeImplementation.cpp
+++ b/src/jllvm/vm/NativeImplementation.cpp
@@ -7,5 +7,5 @@ jllvm::VirtualMachine& jllvm::detail::virtualMachineFromJNIEnv(JNIEnv* env)
 
 void jllvm::registerJavaClasses(VirtualMachine& virtualMachine)
 {
-    addModels<ObjectModel, ClassModel, ThrowableModel, FloatModel, DoubleModel>(virtualMachine);
+    addModels<ObjectModel, ClassModel, ThrowableModel, FloatModel, DoubleModel, SystemModel>(virtualMachine);
 }

--- a/src/jllvm/vm/NativeImplementation.hpp
+++ b/src/jllvm/vm/NativeImplementation.hpp
@@ -231,6 +231,27 @@ public:
     constexpr static auto methods = std::make_tuple(addMember<&ThrowableModel::fillInStackTrace>());
 };
 
+class SystemModel : public ModelBase<Object>
+{
+public:
+    using Base::Base;
+
+    static void registerNatives(VirtualMachine&, GCRootRef<ClassObject>)
+    {
+        // Noop in our implementation.
+    }
+
+    static std::int64_t nanoTime(VirtualMachine&, GCRootRef<ClassObject>)
+    {
+        auto now = std::chrono::high_resolution_clock::now();
+        return std::chrono::time_point_cast<std::chrono::nanoseconds>(now).time_since_epoch().count();
+    }
+
+    constexpr static llvm::StringLiteral className = "java/lang/System";
+    constexpr static auto methods = std::make_tuple(addMember<&SystemModel::registerNatives>(),
+                                                    addMember<&SystemModel::nanoTime>());
+};
+
 /// Register any models for builtin Java classes in the VM.
 void registerJavaClasses(VirtualMachine& virtualMachine);
 

--- a/tests/Execution/system-nanoTime.java
+++ b/tests/Execution/system-nanoTime.java
@@ -1,0 +1,25 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class
+
+class Test
+{
+    public static native void print(long l);
+    public static native void print(boolean b);
+
+    public static void main(String[] args)
+    {
+        // Can hardly test precision, time taken or more. Only really testing its a positive integer and that it is
+        // monotonic.
+        var first = System.nanoTime();
+        var second = System.nanoTime();
+
+        // CHECK-NOT: -
+        // CHECK: {{[0-9]+}}
+        print(first);
+        // CHECK-NOT: -
+        // CHECK: {{[0-9]+}}
+        print(second);
+        // CHECK: 1
+        print(second >= first);
+    }
+}


### PR DESCRIPTION
This a very simple method useful for measuring time and even used in a few places in JVM startup. Testing it is kind of hard since it is non-deterministic. The only real properties to test is therefore that it is positive and monotonic