### PR TITLE
[CI] Enable GitHub Actions merge queue

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -9,6 +9,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "**" ]
+  merge_group:
 
 jobs:
   Builds:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "**" ]
+  merge_group:
 
 permissions:
   contents: read


### PR DESCRIPTION
See https://github.blog/changelog/2023-02-08-pull-request-merge-queue-public-beta/ for details.

I'd like to enable the merge queues beta to make sure that any pull request we are merging into `main` is actually tested with up-to-date `main`. This should make it impossible for `main` to ever be red since PRs are scheduled with the current HEAD and only merged after CI has successfully completed.

This PR adds `merge_group` as trigger to all our required CIs as is required for the feature to work (https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions)