### PR TITLE
[native] implement `Reflection.getCallerClass` and callstack metadata

### DIFF
--- a/src/jllvm/gc/RootFreeList.hpp
+++ b/src/jllvm/gc/RootFreeList.hpp
@@ -83,7 +83,7 @@ public:
     }
 
     /// Returns true if 'lhs' and 'rhs' refer to the same object.
-    friend bool operator==(GCRootRef<T> lhs, T* object)
+    friend bool operator==(GCRootRef<T> lhs, const T* object)
     {
         return lhs.get() == object;
     }

--- a/src/jllvm/materialization/ByteCodeCompileLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeCompileLayer.cpp
@@ -28,6 +28,7 @@ void jllvm::ByteCodeCompileLayer::emit(std::unique_ptr<llvm::orc::Materializatio
     if (llvm::Triple(LLVM_HOST_TRIPLE).isOSBinFormatMachO())
     {
         sectionName = "__TEXT," + sectionName;
+        sectionName += ",regular,pure_instructions";
     }
 
     auto* ptrType = llvm::PointerType::get(*context, 0);

--- a/src/jllvm/materialization/ByteCodeCompileLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeCompileLayer.cpp
@@ -8,7 +8,8 @@
 #define DEBUG_TYPE "jvm"
 
 void jllvm::ByteCodeCompileLayer::emit(std::unique_ptr<llvm::orc::MaterializationResponsibility> mr,
-                                       const MethodInfo* methodInfo, const ClassFile* classFile)
+                                       const MethodInfo* methodInfo, const ClassFile* classFile, const Method* method,
+                                       const ClassObject* classObject)
 {
     std::string methodName = mangleMethod(*methodInfo, *classFile);
     LLVM_DEBUG({ llvm::dbgs() << "Emitting LLVM IR for " << methodName << '\n'; });
@@ -22,6 +23,23 @@ void jllvm::ByteCodeCompileLayer::emit(std::unique_ptr<llvm::orc::Materializatio
         llvm::Function::Create(descriptorToType(descriptor, methodInfo->isStatic(), module->getContext()),
                                llvm::GlobalValue::ExternalLinkage, mangleMethod(*methodInfo, *classFile), module.get());
     function->setGC("coreclr");
+
+    std::string sectionName = "java";
+    if (llvm::Triple(LLVM_HOST_TRIPLE).isOSBinFormatMachO())
+    {
+        sectionName = "__TEXT," + sectionName;
+    }
+
+    auto* ptrType = llvm::PointerType::get(*context, 0);
+    function->setPrefixData(llvm::ConstantStruct::get(
+        llvm::StructType::get(*context, {referenceType(*context), ptrType}),
+        {llvm::ConstantExpr::getIntToPtr(llvm::ConstantInt::get(m_dataLayout.getIntPtrType(*context),
+                                                                reinterpret_cast<std::uintptr_t>(classObject)),
+                                         referenceType(*context)),
+         llvm::ConstantExpr::getIntToPtr(
+             llvm::ConstantInt::get(m_dataLayout.getIntPtrType(*context), reinterpret_cast<std::uintptr_t>(method)),
+             ptrType)}));
+    function->setSection(sectionName);
     function->addFnAttr(llvm::Attribute::UWTable);
 #ifdef LLVM_ADDRESS_SANITIZER_BUILD
     function->addFnAttr(llvm::Attribute::SanitizeAddress);

--- a/src/jllvm/materialization/ByteCodeCompileLayer.hpp
+++ b/src/jllvm/materialization/ByteCodeCompileLayer.hpp
@@ -42,6 +42,6 @@ public:
     }
 
     void emit(std::unique_ptr<llvm::orc::MaterializationResponsibility> mr, const MethodInfo* methodInfo,
-              const ClassFile* classFile) override;
+              const ClassFile* classFile, const Method* method, const ClassObject* classObject) override;
 };
 } // namespace jllvm

--- a/src/jllvm/materialization/ByteCodeCompileUtils.hpp
+++ b/src/jllvm/materialization/ByteCodeCompileUtils.hpp
@@ -4,6 +4,7 @@
 #include <llvm/IR/LLVMContext.h>
 
 #include <jllvm/class/Descriptors.hpp>
+#include <jllvm/object/ClassObject.hpp>
 
 namespace jllvm
 {
@@ -28,4 +29,15 @@ llvm::Type* descriptorToType(const FieldType& type, llvm::LLVMContext& context);
 
 /// Returns the corresponding LLVM function type for a given, possible static, Java method descriptor.
 llvm::FunctionType* descriptorToType(const MethodType& type, bool isStatic, llvm::LLVMContext& context);
+
+/// Metadata attached to Java methods produced by any 'ByteCodeLayer' implementation.
+struct JavaMethodMetadata
+{
+    /// Class object of the enclosing class of the method.
+    const ClassObject* classObject;
+    /// Method meta-object of the compiled method.
+    const Method* method;
+};
+
+void applyJavaMethodAttributes(llvm::Function* function, const JavaMethodMetadata& metadata);
 } // namespace jllvm

--- a/src/jllvm/materialization/ByteCodeLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeLayer.cpp
@@ -20,9 +20,11 @@ std::string jllvm::mangleMethod(const MethodInfo& methodInfo, const ClassFile& c
     return mangleMethod(className, methodName, descriptor);
 }
 
-llvm::Error jllvm::ByteCodeLayer::add(llvm::orc::JITDylib& dylib, const MethodInfo* method, const ClassFile* classFile)
+llvm::Error jllvm::ByteCodeLayer::add(llvm::orc::JITDylib& dylib, const MethodInfo* methodInfo,
+                                      const ClassFile* classFile, const Method* method, const ClassObject* classObject)
 {
-    return dylib.define(std::make_unique<ByteCodeMaterializationUnit>(*this, method, classFile));
+    return dylib.define(
+        std::make_unique<ByteCodeMaterializationUnit>(*this, methodInfo, classFile, method, classObject));
 }
 
 llvm::orc::MaterializationUnit::Interface jllvm::ByteCodeLayer::getSymbolsProvided(const MethodInfo* methodInfo,

--- a/src/jllvm/materialization/ByteCodeLayer.hpp
+++ b/src/jllvm/materialization/ByteCodeLayer.hpp
@@ -2,7 +2,8 @@
 
 #include <llvm/ExecutionEngine/Orc/Mangling.h>
 
-#include "jllvm/class/ClassFile.hpp"
+#include <jllvm/class/ClassFile.hpp>
+#include <jllvm/object/ClassObject.hpp>
 
 namespace jllvm
 {
@@ -27,10 +28,11 @@ public:
 
     /// Method called by the JIT to emit the requested symbols.
     virtual void emit(std::unique_ptr<llvm::orc::MaterializationResponsibility> mr, const MethodInfo* methodInfo,
-                      const ClassFile* classFile) = 0;
+                      const ClassFile* classFile, const Method* method, const ClassObject* classObject) = 0;
 
     /// Adds a materialization unit for the given method and class file to 'dylib'.
-    llvm::Error add(llvm::orc::JITDylib& dylib, const MethodInfo* method, const ClassFile* classFile);
+    llvm::Error add(llvm::orc::JITDylib& dylib, const MethodInfo* methodInfo, const ClassFile* classFile,
+                    const Method* method, const ClassObject* classObject);
 
     /// Returns the map of symbols provided by the method and class file.
     llvm::orc::MaterializationUnit::Interface getSymbolsProvided(const MethodInfo* methodInfo,

--- a/src/jllvm/materialization/ByteCodeMaterializationUnit.cpp
+++ b/src/jllvm/materialization/ByteCodeMaterializationUnit.cpp
@@ -2,5 +2,5 @@
 
 void jllvm::ByteCodeMaterializationUnit::materialize(std::unique_ptr<llvm::orc::MaterializationResponsibility> r)
 {
-    m_layer.emit(std::move(r), m_method, m_classFile);
+    m_layer.emit(std::move(r), m_methodInfo, m_classFile, m_method, m_classObject);
 }

--- a/src/jllvm/materialization/ByteCodeMaterializationUnit.hpp
+++ b/src/jllvm/materialization/ByteCodeMaterializationUnit.hpp
@@ -10,18 +10,22 @@ namespace jllvm
 class ByteCodeMaterializationUnit : public llvm::orc::MaterializationUnit
 {
     jllvm::ByteCodeLayer& m_layer;
-    const jllvm::MethodInfo* m_method;
+    const jllvm::MethodInfo* m_methodInfo;
     const jllvm::ClassFile* m_classFile;
+    const Method* m_method;
+    const ClassObject* m_classObject;
 
 public:
     /// Creates a materialization unit for the method 'methodInfo' of the class 'classFile'.
     /// Compilation is done using 'layer'.
-    ByteCodeMaterializationUnit(jllvm::ByteCodeLayer& layer, const jllvm::MethodInfo* methodInfo,
-                                const jllvm::ClassFile* classFile)
+    ByteCodeMaterializationUnit(jllvm::ByteCodeLayer& layer, const MethodInfo* methodInfo, const ClassFile* classFile,
+                                const Method* method, const ClassObject* classObject)
         : llvm::orc::MaterializationUnit(layer.getSymbolsProvided(methodInfo, classFile)),
           m_layer(layer),
-          m_method(methodInfo),
-          m_classFile(classFile)
+          m_methodInfo(methodInfo),
+          m_classFile(classFile),
+          m_method(method),
+          m_classObject(classObject)
     {
     }
 

--- a/src/jllvm/materialization/ByteCodeOnDemandLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeOnDemandLayer.cpp
@@ -25,7 +25,8 @@ jllvm::ByteCodeOnDemandLayer::PerDylibResources&
 }
 
 void jllvm::ByteCodeOnDemandLayer::emit(std::unique_ptr<llvm::orc::MaterializationResponsibility> mr,
-                                        const jllvm::MethodInfo* methodInfo, const jllvm::ClassFile* classFile)
+                                        const jllvm::MethodInfo* methodInfo, const jllvm::ClassFile* classFile,
+                                        const Method* method, const ClassObject* classObject)
 {
     auto& pdr = getPerDylibResources(mr->getTargetJITDylib());
 
@@ -36,7 +37,7 @@ void jllvm::ByteCodeOnDemandLayer::emit(std::unique_ptr<llvm::orc::Materializati
     }
 
     // Add materialization unit to the implementation dylib.
-    llvm::cantFail(m_baseLayer.add(pdr.getImplDylib(), methodInfo, classFile));
+    llvm::cantFail(m_baseLayer.add(pdr.getImplDylib(), methodInfo, classFile, method, classObject));
 
     // Use a lazy-reexport to create the required symbols instead. The reexport will emit the stubs in this dylib
     // satisfying the dynamic linker. Once they are called, lookups are done in the implementation dylib causing

--- a/src/jllvm/materialization/ByteCodeOnDemandLayer.hpp
+++ b/src/jllvm/materialization/ByteCodeOnDemandLayer.hpp
@@ -63,7 +63,7 @@ public:
     }
 
     void emit(std::unique_ptr<llvm::orc::MaterializationResponsibility> mr, const MethodInfo* methodInfo,
-              const ClassFile* classFile) override;
+              const ClassFile* classFile, const Method* method, const ClassObject* classObject) override;
 };
 
 } // namespace jllvm

--- a/src/jllvm/materialization/CodeGeneratorUtils.cpp
+++ b/src/jllvm/materialization/CodeGeneratorUtils.cpp
@@ -526,7 +526,7 @@ llvm::Value* LazyClassLoaderHelper::returnConstantForClassObject(llvm::IRBuilder
                     auto module = std::make_unique<llvm::Module>(stubSymbol, *context);
 
                     module->setDataLayout(m_dataLayout);
-                    module->setTargetTriple(m_triple.str());
+                    module->setTargetTriple(LLVM_HOST_TRIPLE);
 
                     auto* functionType = llvm::FunctionType::get(
                         CppToLLVMType<typename llvm::function_traits<std::decay_t<F>>::result_t>::get(context.get()),
@@ -605,7 +605,7 @@ llvm::Value* LazyClassLoaderHelper::doCallForClassObject(llvm::IRBuilder<>& buil
                     auto module = std::make_unique<llvm::Module>(stubName, *context);
 
                     module->setDataLayout(m_dataLayout);
-                    module->setTargetTriple(m_triple.str());
+                    module->setTargetTriple(LLVM_HOST_TRIPLE);
 
                     auto* functionType = descriptorToType(*desc, isStatic, *context);
 

--- a/src/jllvm/materialization/CodeGeneratorUtils.hpp
+++ b/src/jllvm/materialization/CodeGeneratorUtils.hpp
@@ -120,7 +120,6 @@ class LazyClassLoaderHelper
     llvm::orc::IRLayer& m_baseLayer;
     llvm::orc::MangleAndInterner& m_interner;
     llvm::DataLayout m_dataLayout;
-    llvm::Triple m_triple;
 
     static void buildClassInitializerInitStub(llvm::IRBuilder<>& builder, const ClassObject& classObject);
 

--- a/src/jllvm/materialization/JNIImplementationLayer.cpp
+++ b/src/jllvm/materialization/JNIImplementationLayer.cpp
@@ -49,7 +49,8 @@ std::string jllvm::formJNIMethodName(llvm::StringRef className, llvm::StringRef 
 }
 
 void jllvm::JNIImplementationLayer::emit(std::unique_ptr<llvm::orc::MaterializationResponsibility> mr,
-                                         const jllvm::MethodInfo* methodInfo, const jllvm::ClassFile* classFile)
+                                         const jllvm::MethodInfo* methodInfo, const jllvm::ClassFile* classFile,
+                                         const Method* method, const ClassObject* classObject)
 {
     // Things that should happen here:
     // 1. Materialize a stub calling a compile callback to be called when the native method is called.
@@ -109,6 +110,26 @@ void jllvm::JNIImplementationLayer::emit(std::unique_ptr<llvm::orc::Materializat
                 function->setSubprogram(subprogram);
                 function->addFnAttr(llvm::Attribute::UWTable);
 
+                std::string sectionName = "java";
+                if (llvm::Triple(LLVM_HOST_TRIPLE).isOSBinFormatMachO())
+                {
+                    sectionName = "__TEXT," + sectionName;
+                }
+
+                llvm::Constant* classObjectLLVMConstant = llvm::ConstantExpr::getIntToPtr(
+                    llvm::ConstantInt::get(m_dataLayout.getIntPtrType(*context),
+                                           reinterpret_cast<std::uintptr_t>(classObject)),
+                    referenceType(*context));
+
+                auto* ptrType = llvm::PointerType::get(*context, 0);
+                function->setPrefixData(llvm::ConstantStruct::get(
+                    llvm::StructType::get(*context, {referenceType(*context), ptrType}),
+                    {classObjectLLVMConstant,
+                     llvm::ConstantExpr::getIntToPtr(llvm::ConstantInt::get(m_dataLayout.getIntPtrType(*context),
+                                                                            reinterpret_cast<std::uintptr_t>(method)),
+                                                     ptrType)}));
+                function->setSection(sectionName);
+
                 llvm::IRBuilder<> builder(llvm::BasicBlock::Create(*context, "entry", function));
 
                 llvm::Value* environment = builder.CreateAlloca(llvm::StructType::get(builder.getPtrTy()));
@@ -120,8 +141,7 @@ void jllvm::JNIImplementationLayer::emit(std::unique_ptr<llvm::orc::Materializat
                 llvm::SmallVector<llvm::Value*> args{environment};
                 if (methodInfo->isStatic())
                 {
-                    // TODO: get class object and insert here.
-                    args.push_back(llvm::ConstantPointerNull::get(referenceType(*context)));
+                    args.push_back(classObjectLLVMConstant);
                 }
                 for (llvm::Argument& arg : function->args())
                 {

--- a/src/jllvm/materialization/JNIImplementationLayer.cpp
+++ b/src/jllvm/materialization/JNIImplementationLayer.cpp
@@ -123,9 +123,8 @@ void jllvm::JNIImplementationLayer::emit(std::unique_ptr<llvm::orc::Materializat
                 llvm::SmallVector<llvm::Value*> args{environment};
                 if (methodInfo->isStatic())
                 {
-                    args.push_back(
-                        builder.CreateIntToPtr(builder.getInt64(reinterpret_cast<std::uintptr_t>(m_jniNativeFunctions)),
-                                               referenceType(*context)));
+                    args.push_back(builder.CreateIntToPtr(
+                        builder.getInt64(reinterpret_cast<std::uintptr_t>(classObject)), referenceType(*context)));
                 }
                 for (llvm::Argument& arg : function->args())
                 {

--- a/src/jllvm/materialization/JNIImplementationLayer.cpp
+++ b/src/jllvm/materialization/JNIImplementationLayer.cpp
@@ -114,6 +114,7 @@ void jllvm::JNIImplementationLayer::emit(std::unique_ptr<llvm::orc::Materializat
                 if (llvm::Triple(LLVM_HOST_TRIPLE).isOSBinFormatMachO())
                 {
                     sectionName = "__TEXT," + sectionName;
+                    sectionName += ",regular,pure_instructions";
                 }
 
                 llvm::Constant* classObjectLLVMConstant = llvm::ConstantExpr::getIntToPtr(

--- a/src/jllvm/materialization/JNIImplementationLayer.hpp
+++ b/src/jllvm/materialization/JNIImplementationLayer.hpp
@@ -55,6 +55,6 @@ public:
     }
 
     void emit(std::unique_ptr<llvm::orc::MaterializationResponsibility> mr, const MethodInfo* methodInfo,
-              const ClassFile* classFile) override;
+              const ClassFile* classFile, const Method* method, const ClassObject* classObject) override;
 };
 } // namespace jllvm

--- a/src/jllvm/vm/JIT.cpp
+++ b/src/jllvm/vm/JIT.cpp
@@ -51,15 +51,11 @@ public:
         config.PostAllocationPasses.emplace_back(
             [&](llvm::jitlink::LinkGraph& g)
             {
-                for (auto iter : g.defined_symbols())
-                {
-                    llvm::dbgs() << *iter << '\n';
-                }
-
                 std::string sectionName = "java";
                 if (llvm::Triple(LLVM_HOST_TRIPLE).isOSBinFormatMachO())
                 {
                     sectionName = "__TEXT," + sectionName;
+                    sectionName += ",regular,pure_instructions";
                 }
 
                 llvm::jitlink::Section* section = g.findSectionByName(sectionName);

--- a/src/jllvm/vm/JIT.cpp
+++ b/src/jllvm/vm/JIT.cpp
@@ -51,6 +51,11 @@ public:
         config.PostAllocationPasses.emplace_back(
             [&](llvm::jitlink::LinkGraph& g)
             {
+                for (auto iter : g.defined_symbols())
+                {
+                    llvm::dbgs() << *iter << '\n';
+                }
+
                 std::string sectionName = "java";
                 if (llvm::Triple(LLVM_HOST_TRIPLE).isOSBinFormatMachO())
                 {

--- a/src/jllvm/vm/JIT.cpp
+++ b/src/jllvm/vm/JIT.cpp
@@ -55,7 +55,6 @@ public:
                 if (llvm::Triple(LLVM_HOST_TRIPLE).isOSBinFormatMachO())
                 {
                     sectionName = "__TEXT," + sectionName;
-                    sectionName += ",regular,pure_instructions";
                 }
 
                 llvm::jitlink::Section* section = g.findSectionByName(sectionName);

--- a/src/jllvm/vm/JIT.hpp
+++ b/src/jllvm/vm/JIT.hpp
@@ -45,6 +45,8 @@ class JIT
     ByteCodeOnDemandLayer m_byteCodeOnDemandLayer;
     JNIImplementationLayer m_jniLayer;
 
+    llvm::DenseSet<void*> m_javaFrames;
+
     void optimize(llvm::Module& module);
 
     JIT(std::unique_ptr<llvm::orc::ExecutionSession>&& session, std::unique_ptr<llvm::orc::EPCIndirectionUtils>&& epciu,
@@ -116,12 +118,38 @@ public:
 
     /// Adds and registers a class file in the JIT. This has to be done prior to being able to lookup and execute
     /// any methods defined within the class file.
-    void add(const ClassFile* classFile);
+    void add(const ClassFile* classFile, const ClassObject* classObject);
 
     /// Returns the interner used by the JIT.
     llvm::orc::MangleAndInterner& getInterner()
     {
         return m_interner;
+    }
+
+    /// Returns the set of all function pointers that are compiled Java methods.
+    const llvm::DenseSet<void*>& getJavaFrames() const
+    {
+        return m_javaFrames;
+    }
+
+    /// Metadata attached to Java methods produced by any 'ByteCodeLayer' implementation.
+    struct JavaMethodMetadata
+    {
+        /// Class object of the enclosing class of the method.
+        ClassObject* classObject;
+        /// Method meta-object of the compiled method.
+        Method* method;
+    };
+
+    /// Returns the metadata associated with any compiled Java method.
+    /// Returns an empty optional if the function pointer is not a Java method.
+    std::optional<JavaMethodMetadata> getJavaMethodMetadata(std::uintptr_t functionPointer)
+    {
+        if (!m_javaFrames.contains(reinterpret_cast<void*>(functionPointer)))
+        {
+            return std::nullopt;
+        }
+        return reinterpret_cast<const JavaMethodMetadata*>(functionPointer)[-1];
     }
 
     /// Looks up the method 'methodName' within the class 'className' with the type given by 'methodDescriptor'

--- a/src/jllvm/vm/JIT.hpp
+++ b/src/jllvm/vm/JIT.hpp
@@ -132,15 +132,6 @@ public:
         return m_javaFrames;
     }
 
-    /// Metadata attached to Java methods produced by any 'ByteCodeLayer' implementation.
-    struct JavaMethodMetadata
-    {
-        /// Class object of the enclosing class of the method.
-        ClassObject* classObject;
-        /// Method meta-object of the compiled method.
-        Method* method;
-    };
-
     /// Returns the metadata associated with any compiled Java method.
     /// Returns an empty optional if the function pointer is not a Java method.
     std::optional<JavaMethodMetadata> getJavaMethodMetadata(std::uintptr_t functionPointer)

--- a/src/jllvm/vm/NativeImplementation.cpp
+++ b/src/jllvm/vm/NativeImplementation.cpp
@@ -1,5 +1,7 @@
 #include "NativeImplementation.hpp"
 
+#include <jllvm/unwind/Unwinder.hpp>
+
 jllvm::VirtualMachine& jllvm::detail::virtualMachineFromJNIEnv(JNIEnv* env)
 {
     return *reinterpret_cast<jllvm::VirtualMachine*>(env->functions->reserved0);
@@ -7,5 +9,31 @@ jllvm::VirtualMachine& jllvm::detail::virtualMachineFromJNIEnv(JNIEnv* env)
 
 void jllvm::registerJavaClasses(VirtualMachine& virtualMachine)
 {
-    addModels<ObjectModel, ClassModel, ThrowableModel, FloatModel, DoubleModel, SystemModel>(virtualMachine);
+    addModels<ObjectModel, ClassModel, ThrowableModel, FloatModel, DoubleModel, SystemModel, ReflectionModel, CDSModel>(
+        virtualMachine);
+}
+
+const jllvm::ClassObject* jllvm::ReflectionModel::getCallerClass(VirtualMachine& virtualMachine,
+                                                                 GCRootRef<ClassObject> classObject)
+{
+    ClassObject* result = nullptr;
+    unwindStack(
+        [&](UnwindFrame frame)
+        {
+            std::uintptr_t fp = frame.getFunctionPointer();
+            std::optional<JIT::JavaMethodMetadata> data = virtualMachine.getJIT().getJavaMethodMetadata(fp);
+            if (!data)
+            {
+                return UnwindAction::ContinueUnwinding;
+            }
+
+            if (data->classObject == classObject)
+            {
+                return UnwindAction::ContinueUnwinding;
+            }
+            // TODO: If the method has the Java annotation '@CallerSensitive' it should be skipped by this method.
+            result = data->classObject;
+            return UnwindAction::StopUnwinding;
+        });
+    return result;
 }

--- a/src/jllvm/vm/NativeImplementation.cpp
+++ b/src/jllvm/vm/NativeImplementation.cpp
@@ -16,12 +16,12 @@ void jllvm::registerJavaClasses(VirtualMachine& virtualMachine)
 const jllvm::ClassObject* jllvm::ReflectionModel::getCallerClass(VirtualMachine& virtualMachine,
                                                                  GCRootRef<ClassObject> classObject)
 {
-    ClassObject* result = nullptr;
+    const ClassObject* result = nullptr;
     unwindStack(
         [&](UnwindFrame frame)
         {
             std::uintptr_t fp = frame.getFunctionPointer();
-            std::optional<JIT::JavaMethodMetadata> data = virtualMachine.getJIT().getJavaMethodMetadata(fp);
+            std::optional<JavaMethodMetadata> data = virtualMachine.getJIT().getJavaMethodMetadata(fp);
             if (!data)
             {
                 return UnwindAction::ContinueUnwinding;

--- a/src/jllvm/vm/NativeImplementation.hpp
+++ b/src/jllvm/vm/NativeImplementation.hpp
@@ -252,6 +252,51 @@ public:
                                                     addMember<&SystemModel::nanoTime>());
 };
 
+class ReflectionModel : public ModelBase<>
+{
+public:
+    using Base::Base;
+
+    static const ClassObject* getCallerClass(VirtualMachine& virtualMachine, GCRootRef<ClassObject> classObject);
+
+    constexpr static llvm::StringLiteral className = "jdk/internal/reflect/Reflection";
+    constexpr static auto methods = std::make_tuple(addMember<&ReflectionModel::getCallerClass>());
+};
+
+class CDSModel : public ModelBase<Object>
+{
+public:
+    using Base::Base;
+
+    static bool isDumpingClassList0(VirtualMachine&, GCRootRef<ClassObject>)
+    {
+        return false;
+    }
+
+    static bool isDumpingArchive0(VirtualMachine&, GCRootRef<ClassObject>)
+    {
+        return false;
+    }
+
+    static bool isSharingEnabled0(VirtualMachine&, GCRootRef<ClassObject>)
+    {
+        return false;
+    }
+
+    static std::int64_t getRandomSeedForDumping(VirtualMachine&, GCRootRef<ClassObject>)
+    {
+        return 0;
+    }
+
+    static void initializeFromArchive(VirtualMachine&, GCRootRef<ClassObject>, GCRootRef<ClassObject>) {}
+
+    constexpr static llvm::StringLiteral className = "jdk/internal/misc/CDS";
+    constexpr static auto methods =
+        std::make_tuple(addMember<&CDSModel::isDumpingClassList0>(), addMember<&CDSModel::isDumpingArchive0>(),
+                        addMember<&CDSModel::isSharingEnabled0>(), addMember<&CDSModel::getRandomSeedForDumping>(),
+                        addMember<&CDSModel::initializeFromArchive>());
+};
+
 /// Register any models for builtin Java classes in the VM.
 void registerJavaClasses(VirtualMachine& virtualMachine);
 

--- a/src/jllvm/vm/VirtualMachine.cpp
+++ b/src/jllvm/vm/VirtualMachine.cpp
@@ -118,7 +118,7 @@ jllvm::VirtualMachine::VirtualMachine(std::vector<std::string>&& classPath)
         std::move(classPath),
         [this](const ClassFile* classFile, ClassObject& classObject)
         {
-            m_jit.add(classFile);
+            m_jit.add(classFile, &classObject);
             if (classObject.isInterface() || classObject.isAbstract())
             {
                 return;

--- a/tests/Execution/reflection-get-caller-class.java
+++ b/tests/Execution/reflection-get-caller-class.java
@@ -1,0 +1,32 @@
+// RUN: rm -rf %t && split-file %s %t
+// RUN: cd %t && javac --add-exports java.base/jdk.internal.reflect=ALL-UNNAMED %t/Other.java -d %t
+// RUN: jllvm -Xenable-test-utils %t/Other.class | FileCheck %s
+
+//--- Test.java
+
+import jdk.internal.reflect.Reflection;
+
+public class Test
+{
+    public static native void print(boolean b);
+
+    public static void foo()
+    {
+        Test.print(Reflection.getCallerClass() == Test.class);
+    }
+}
+
+//--- Other.java
+
+import jdk.internal.reflect.Reflection;
+
+public class Other
+{
+    public static void main(String[] args)
+    {
+        // CHECK: 1
+        Test.print(Reflection.getCallerClass() == Other.class);
+        // CHECK: 1
+        Test.foo();
+    }
+}


### PR DESCRIPTION
This method is used relatively extensively within the OpenJDK, mostly to provide reflection capabilities. This includes at VM startup. The method also served as a good motivation to implement adding metadata to compiled Java methods that can be fetched during unwinding. This mechanism allows getting reflective information about any Java method from stacktraces. This mechanism can later also be used to implement symbolized stacktraces of exceptions.

The basic mechanism used to implement all of this is 1) adding the metadata into the `prefix` attribute of LLVM functions. These are placed immediately before the function in the resulting assembly. 2) Marking Java functions as originating from Java. This is achieved by putting them into "java" sections. This is required for 3) maintaining a set of all Java method addresses in the linker. This is used to identify a method as having metadata.