### PR TITLE
[gc] introspect into superclass fields as well

### DIFF
--- a/tests/Execution/super-class-fields-gc.java
+++ b/tests/Execution/super-class-fields-gc.java
@@ -1,0 +1,26 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+class Test
+{
+    public static native void print(String i);
+    public static native void print(int i);
+
+    public int[] i = new int[5];
+
+    public static void main(String[] args)
+    {
+        var other = new Other();
+        new Object();
+        new Object();
+        new Object();
+        new Object();
+        // CHECK: 5
+        print(other.i.length);
+    }
+}
+
+class Other extends Test
+{
+
+}


### PR DESCRIPTION
This is a very embarrassing oversight :) So far we've only been traversing into the direct fields of a class but forgot to traverse into the indirect fields of a class that it gained through inheritance.

This PR does a simple correct implementation for now to unblock work with a TODO how to properly optimize this in the future.