### PR TITLE
[codegen] use dummy debug location to avoid LLVM verifier error

### DIFF
--- a/src/jllvm/materialization/CodeGenerator.cpp
+++ b/src/jllvm/materialization/CodeGenerator.cpp
@@ -168,6 +168,11 @@ void CodeGenerator::generateCode(const Code& code)
                                       llvm::DINode::FlagZero, llvm::DISubprogram::SPFlagDefinition);
     m_function->setSubprogram(subprogram);
 
+    // Dummy debug location until we generate proper debug location. This is required by LLVM as it requires any call
+    // to a function that has debug info and is eligible to be inlined to have debug locations on the call.
+    // This is currently the case for self-recursive functions.
+    m_builder.SetCurrentDebugLocation(llvm::DILocation::get(m_builder.getContext(), 1, 1, subprogram));
+
     // We need pointer size bytes, since that is the largest type we may store in a local.
     std::generate(m_locals.begin(), m_locals.end(), [&] { return m_builder.CreateAlloca(m_builder.getPtrTy()); });
 

--- a/tests/Execution/recursive-function-debug-info-crash.java
+++ b/tests/Execution/recursive-function-debug-info-crash.java
@@ -1,0 +1,22 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class
+
+class Test
+{
+    public static native void print(int i);
+
+    public static int fib(int i)
+    {
+        if (i == 0 || i == 1)
+        {
+            return i;
+        }
+        return fib(i - 1) + fib(i - 2);
+    }
+
+    public static void main(String[] args)
+    {
+        // CHECK: 8
+        print(fib(6));
+    }
+}


### PR DESCRIPTION
LLVM requires any call to an inlineable function with debug info to have debug line location, otherwise it'd throw a verifier error. Even tho we are a per-method JIT, this can still occur in self-recursive functions as LLVM could inline the function into itself. This PR just adds some dummy debug line location for the time being.