### PR TITLE
[codegen] also enable GC in generated stubs

### DIFF
--- a/src/jllvm/materialization/CodeGeneratorUtils.cpp
+++ b/src/jllvm/materialization/CodeGeneratorUtils.cpp
@@ -149,6 +149,7 @@ llvm::Value* LazyClassLoaderHelper::returnConstantForClassObject(llvm::IRBuilder
                     auto* function = llvm::Function::Create(functionType, llvm::GlobalValue::ExternalLinkage,
                                                             stubSymbol, module.get());
                     function->addFnAttr(llvm::Attribute::UWTable);
+                    function->setGC("coreclr");
                     TrivialDebugInfoBuilder debugInfoBuilder(function);
                     llvm::IRBuilder<> builder(llvm::BasicBlock::Create(*context, "entry", function));
 
@@ -225,6 +226,7 @@ llvm::Value* LazyClassLoaderHelper::doCallForClassObject(llvm::IRBuilder<>& buil
                     auto* function = llvm::Function::Create(functionType, llvm::GlobalValue::ExternalLinkage, stubName,
                                                             module.get());
                     function->addFnAttr(llvm::Attribute::UWTable);
+                    function->setGC("coreclr");
                     TrivialDebugInfoBuilder debugInfoBuilder(function);
 
                     llvm::IRBuilder<> builder(llvm::BasicBlock::Create(*context, "entry", function));

--- a/tests/Execution/relocation-in-stub.java
+++ b/tests/Execution/relocation-in-stub.java
@@ -1,0 +1,35 @@
+// RUN: rm -rf %t && split-file %s %t
+// RUN: cd %t && javac %t/Other.java -d %t
+// RUN: jllvm -Xenable-test-utils %t/Other.class | FileCheck %s
+
+//--- Test.java
+
+public class Test
+{
+    public static native void print(int i);
+
+    public static void foo(int[] i)
+    {
+        i[0] = 3;
+    }
+
+    // Creates a <clinit> that does GC.
+    private static Object s = new Object();
+}
+
+
+//--- Other.java
+
+public class Other
+{
+    public static void main(String[] args)
+    {
+        var i = new int[1];
+        // First time call to 'Test', executes <clinit>.
+        Test.foo(i);
+        // Stub that called <clinit> before 'foo' should have properly relocated 'i' and changes from 'foo' should be
+        // visible in this 'i'.
+        // CHECK: 3
+        Test.print(i[0]);
+    }
+}


### PR DESCRIPTION
The stubs might do garbage collection as part of executing a class initializer. Any arguments passed into the stub, that are then passed to the actual callee, have to both be 1) found by the GC and 2) relocated by the GC. 1) worked perfectly previously as the caller of the stub registers all arguments in the stackmap bug 2) did not. 
This would cause a relocated object to not be updated in the stack frame of the stub and a dangling pointer being passed to the actual callee.