### PR TITLE
[codegen] Remove compilation of dead code

### DIFF
--- a/src/jllvm/materialization/CodeGenerator.cpp
+++ b/src/jllvm/materialization/CodeGenerator.cpp
@@ -202,71 +202,70 @@ void CodeGenerator::createBasicBlocks(const Code& code)
 
     for (auto& [offset, state] : sectionMap)
     {
-        llvm::BasicBlock* block =
-            offset == 0 ? m_builder.GetInsertBlock() :
-                          llvm::BasicBlock::Create(m_builder.getContext(), std::to_string(offset), m_function);
-        m_basicBlocks.insert({offset, {block, std::move(state)}});
+        m_basicBlocks.insert(
+            {offset, {llvm::BasicBlock::Create(m_builder.getContext(), "", m_function), std::move(state)}});
     }
 }
 
 void CodeGenerator::generateCodeBody(const Code& code)
 {
-    llvm::ArrayRef<char> byteCode = code.getCode();
-
-    llvm::DenseSet<std::uint16_t> queuedHandlers;
-    for (const auto& exception : code.getExceptionTable())
+    llvm::DenseMap<std::uint16_t, std::vector<Code::ExceptionTable>> startHandlers;
+    for (const auto& iter : code.getExceptionTable())
     {
-        m_startHandlers[exception.startPc].push_back(exception);
-        if (queuedHandlers.insert(exception.handlerPc).second)
-        {
-            m_blockStartStack.push_back(exception.handlerPc);
-        }
+        startHandlers[iter.startPc].push_back(iter);
     }
 
-    m_blockStartStack.push_back(0);
+    bool isReachable = false;
 
-    while (!m_blockStartStack.empty())
+    llvm::DenseMap<std::uint16_t, std::vector<std::list<HandlerInfo>::iterator>> endHandlers;
+    for (ByteCodeOp operation : byteCodeRange(code.getCode()))
     {
-        std::uint16_t startOffset = m_blockStartStack.back();
-        m_blockStartStack.pop_back();
-
-        generateBasicBlock(byteCode.drop_front(startOffset), startOffset);
-    }
-}
-
-void CodeGenerator::generateBasicBlock(llvm::ArrayRef<char> block, std::uint16_t offset)
-{
-    auto& [basicBlock, state] = m_basicBlocks[offset];
-    m_builder.SetInsertPoint(basicBlock);
-    m_operandStack.setState(state);
-
-    for (ByteCodeOp operation : byteCodeRange(block, offset))
-    {
-        offset = getOffset(operation);
-        if (auto result = m_endHandlers.find(offset); result != m_endHandlers.end())
+        std::size_t offset = getOffset(operation);
+        if (auto result = endHandlers.find(offset); result != endHandlers.end())
         {
             for (auto iter : result->second)
             {
                 m_activeHandlers.erase(iter);
             }
             // No longer needed.
-            m_endHandlers.erase(result);
+            endHandlers.erase(result);
         }
 
-        if (auto result = m_startHandlers.find(offset); result != m_startHandlers.end())
+        if (auto result = startHandlers.find(offset); result != startHandlers.end())
         {
-            for (const Code::ExceptionTable& exception : result->second)
+            for (const Code::ExceptionTable& iter : result->second)
             {
-                m_activeHandlers.emplace_back(exception.handlerPc, exception.catchType);
-                m_endHandlers[exception.endPc].push_back(std::prev(m_activeHandlers.end()));
+                m_activeHandlers.emplace_back(iter.handlerPc, iter.catchType);
+                endHandlers[iter.endPc].push_back(std::prev(m_activeHandlers.end()));
             }
             // No longer needed.
-            m_startHandlers.erase(result);
+            startHandlers.erase(result);
         }
 
-        if (generateInstruction(std::move(operation)))
+        if (auto result = m_basicBlocks.find(offset); result != m_basicBlocks.end())
         {
-            break;
+            // Without any branches, there will not be a terminator at the end of the basic block. Thus, we need to
+            // set this manually to the new insert point. This essentially implements implicit fallthrough from JVM
+            // bytecode.
+            if (m_builder.GetInsertBlock()->getTerminator() == nullptr)
+            {
+                m_builder.CreateBr(result->second.block);
+            }
+            m_builder.SetInsertPoint(result->second.block);
+            m_operandStack.setState(result->second.state);
+            isReachable = true;
+        }
+
+        if (isReachable)
+        {
+            if (generateInstruction(std::move(operation)))
+            {
+                isReachable = false;
+            }
+        }
+        else
+        {
+            continue;
         }
     }
 }
@@ -274,14 +273,6 @@ void CodeGenerator::generateBasicBlock(llvm::ArrayRef<char> block, std::uint16_t
 bool CodeGenerator::generateInstruction(ByteCodeOp operation)
 {
     bool end = false;
-
-    auto pushNext = [&](std::uint16_t next)
-    {
-        if (m_visitedBlocks.insert(next).second)
-        {
-            m_blockStartStack.push_back(next);
-        }
-    };
 
     match(
         operation, [](...) { llvm_unreachable("NOT YET IMPLEMENTED"); },
@@ -839,7 +830,6 @@ bool CodeGenerator::generateInstruction(ByteCodeOp operation)
         {
             std::uint16_t target = gotoOp.offset + gotoOp.target;
             m_builder.CreateBr(m_basicBlocks[target].block);
-            pushNext(target);
             end = true;
         },
         [&](I2B)
@@ -885,10 +875,8 @@ bool CodeGenerator::generateInstruction(ByteCodeOp operation)
                   IfGe, IfGt, IfLe, IfNonNull, IfNull>
                 cmpOp)
         {
-            std::uint16_t target = cmpOp.offset + cmpOp.target;
-            std::uint16_t next = cmpOp.offset + sizeof(OpCodes) + sizeof(std::int16_t);
-            llvm::BasicBlock* targetBlock = m_basicBlocks[target].block;
-            llvm::BasicBlock* nextBlock = m_basicBlocks[next].block;
+            llvm::BasicBlock* target = m_basicBlocks[cmpOp.offset + cmpOp.target].block;
+            llvm::BasicBlock* next = m_basicBlocks[cmpOp.offset + sizeof(OpCodes) + sizeof(std::int16_t)].block;
 
             llvm::Value* rhs;
             llvm::Value* lhs;
@@ -922,9 +910,7 @@ bool CodeGenerator::generateInstruction(ByteCodeOp operation)
                 [&](OneOf<IfICmpGe, IfGe>) { predicate = llvm::CmpInst::ICMP_SGE; });
 
             llvm::Value* cond = m_builder.CreateICmp(predicate, lhs, rhs);
-            m_builder.CreateCondBr(cond, targetBlock, nextBlock);
-            pushNext(target);
-            pushNext(next);
+            m_builder.CreateCondBr(cond, target, next);
             end = true;
         },
         [&](IInc iInc)
@@ -1074,20 +1060,16 @@ bool CodeGenerator::generateInstruction(ByteCodeOp operation)
         {
             llvm::Value* key = m_operandStack.pop_back();
 
-            std::uint16_t defaultOffset = switchOp.offset + switchOp.defaultOffset;
-            llvm::BasicBlock* defaultBlock = m_basicBlocks[defaultOffset].block;
+            llvm::BasicBlock* defaultBlock = m_basicBlocks[switchOp.offset + switchOp.defaultOffset].block;
 
             auto* switchInst = m_builder.CreateSwitch(key, defaultBlock, switchOp.matchOffsetsPairs.size());
 
             for (auto [match, target] : switchOp.matchOffsetsPairs)
             {
-                target = switchOp.offset + target;
-                llvm::BasicBlock* targetBlock = m_basicBlocks[target].block;
+                llvm::BasicBlock* targetBlock = m_basicBlocks[switchOp.offset + target].block;
 
                 switchInst->addCase(m_builder.getInt32(match), targetBlock);
-                pushNext(target);
             }
-            pushNext(defaultOffset);
             end = true;
         },
         [&](OneOf<LShl, LShr, LUShr>)

--- a/src/jllvm/materialization/CodeGenerator.hpp
+++ b/src/jllvm/materialization/CodeGenerator.hpp
@@ -41,6 +41,7 @@ class CodeGenerator
 
     void generateCodeBody(const Code& code);
 
+    /// Generated LLVM IR instructions for a JVM bytecode instruction, returns whether the instruction indicated the end of a basic block
     bool generateInstruction(ByteCodeOp operation);
 
     void generateEHDispatch();

--- a/src/jllvm/materialization/CodeGenerator.hpp
+++ b/src/jllvm/materialization/CodeGenerator.hpp
@@ -34,18 +34,12 @@ class CodeGenerator
 
     // std::list because we want the iterator stability when deleting handlers (requires random access).
     std::list<HandlerInfo> m_activeHandlers;
-    llvm::DenseMap<std::uint16_t, std::vector<Code::ExceptionTable>> m_startHandlers;
-    llvm::DenseMap<std::uint16_t, std::vector<std::list<HandlerInfo>::iterator>> m_endHandlers;
     // std::map because it is the easiest to use with std::list key.
     std::map<std::list<HandlerInfo>, llvm::BasicBlock*> m_alreadyGeneratedHandlers;
-    std::vector<std::uint16_t> m_blockStartStack;
-    llvm::DenseSet<std::uint16_t> m_visitedBlocks;
 
     void createBasicBlocks(const Code& code);
 
     void generateCodeBody(const Code& code);
-
-    void generateBasicBlock(llvm::ArrayRef<char> block, std::uint16_t offset);
 
     bool generateInstruction(ByteCodeOp operation);
 

--- a/src/jllvm/materialization/CodeGenerator.hpp
+++ b/src/jllvm/materialization/CodeGenerator.hpp
@@ -34,14 +34,20 @@ class CodeGenerator
 
     // std::list because we want the iterator stability when deleting handlers (requires random access).
     std::list<HandlerInfo> m_activeHandlers;
+    llvm::DenseMap<std::uint16_t, std::vector<Code::ExceptionTable>> m_startHandlers;
+    llvm::DenseMap<std::uint16_t, std::vector<std::list<HandlerInfo>::iterator>> m_endHandlers;
     // std::map because it is the easiest to use with std::list key.
     std::map<std::list<HandlerInfo>, llvm::BasicBlock*> m_alreadyGeneratedHandlers;
+    std::vector<std::uint16_t> m_blockStartStack;
+    llvm::DenseSet<std::uint16_t> m_visitedBlocks;
 
     void createBasicBlocks(const Code& code);
 
     void generateCodeBody(const Code& code);
 
-    void generateInstruction(ByteCodeOp operation);
+    void generateBasicBlock(llvm::ArrayRef<char> block, std::uint16_t offset);
+
+    bool generateInstruction(ByteCodeOp operation);
 
     void generateEHDispatch();
 

--- a/src/jllvm/materialization/CodeGeneratorUtils.cpp
+++ b/src/jllvm/materialization/CodeGeneratorUtils.cpp
@@ -93,7 +93,7 @@ struct OneOfBase : ByteCodeBase
 };
 } // namespace
 
-void ByteCodeTypeChecker::checkBasicBlock(llvm::ArrayRef<char> section, std::uint16_t offset, TypeStack typeStack)
+void ByteCodeTypeChecker::checkBasicBlock(llvm::ArrayRef<char> block, std::uint16_t offset, TypeStack typeStack)
 {
     bool done = false;
 
@@ -105,7 +105,7 @@ void ByteCodeTypeChecker::checkBasicBlock(llvm::ArrayRef<char> section, std::uin
         }
     };
 
-    for (ByteCodeOp operation : byteCodeRange(section, offset))
+    for (ByteCodeOp operation : byteCodeRange(block, offset))
     {
         if (done)
         {
@@ -447,8 +447,10 @@ ByteCodeTypeChecker::BasicBlockMap ByteCodeTypeChecker::check(const Code& code)
 
     for (const auto& exception : code.getExceptionTable())
     {
-        m_basicBlocks.insert({exception.handlerPc, {m_addressType}});
-        m_offsetStack.push_back(exception.handlerPc);
+        if (m_basicBlocks.insert({exception.handlerPc, {m_addressType}}).second)
+        {
+            m_offsetStack.push_back(exception.handlerPc);
+        }
     }
 
     m_basicBlocks.insert({0, {}});

--- a/src/jllvm/materialization/CodeGeneratorUtils.hpp
+++ b/src/jllvm/materialization/CodeGeneratorUtils.hpp
@@ -32,7 +32,7 @@ class ByteCodeTypeChecker
     llvm::Type* m_intType;
     llvm::Type* m_longType;
 
-    void checkBasicBlock(llvm::ArrayRef<char> section, std::uint16_t offset, TypeStack typeStack);
+    void checkBasicBlock(llvm::ArrayRef<char> block, std::uint16_t offset, TypeStack typeStack);
 
 public:
     ByteCodeTypeChecker(llvm::LLVMContext& context, const ClassFile& classFile)

--- a/src/jllvm/unwind/Unwinder.cpp
+++ b/src/jllvm/unwind/Unwinder.cpp
@@ -1,5 +1,7 @@
 #include "Unwinder.hpp"
 
+#include <llvm/Support/ErrorHandling.h>
+
 #include <utility>
 
 #include <unwind.h>
@@ -15,6 +17,7 @@ bool jllvm::detail::unwindInternal(void* lambdaIn, UnwindAction (*fpIn)(void*, U
             {
                 case UnwindAction::ContinueUnwinding: return _URC_NO_REASON;
                 case UnwindAction::StopUnwinding: return _URC_END_OF_STACK;
+                default: llvm_unreachable("Invalid unwind action");
             }
         },
         &data);

--- a/tests/Execution/dead-code.j
+++ b/tests/Execution/dead-code.j
@@ -1,0 +1,26 @@
+; RUN: jasmin %s -d %t
+; RUN: jllvm -Xenable-test-utils %t/Test.class
+
+.class public Test
+.super java/lang/Object
+
+.method public <init>()V
+    aload_0
+    invokespecial java/lang/Object/<init>()V
+    return
+.end method
+
+.method public static native print(Ljava/lang/String;)V
+.end method
+
+.method public static main([Ljava/lang/String;)V
+   goto X
+   ; CHECK-NOT: False
+   ldc "False"
+   invokestatic Test/print(Ljava/lang/String;)V
+X:
+   ; CHECK: True
+   ldc "True"
+   invokestatic Test/print(Ljava/lang/String;)V
+   return
+.end method


### PR DESCRIPTION
This PR fixes the issue of the type-checking pass not generating any stack information for dead code block, causing the compilation to fail. Now only reachable code will be compiled.