### PR TITLE
[native] initial implementation of `Unsafe`

### DIFF
--- a/src/jllvm/gc/RootFreeList.hpp
+++ b/src/jllvm/gc/RootFreeList.hpp
@@ -111,6 +111,13 @@ public:
         return *get();
     }
 
+    /// Returns the address of the Java object.
+    /// The address is only valid until the next garbage collection.
+    T* address() const
+    {
+        return get();
+    }
+
     /// Returns the underlying root referred to by this 'GCRootRef'.
     void** data() const
     {

--- a/src/jllvm/vm/NativeImplementation.cpp
+++ b/src/jllvm/vm/NativeImplementation.cpp
@@ -9,8 +9,8 @@ jllvm::VirtualMachine& jllvm::detail::virtualMachineFromJNIEnv(JNIEnv* env)
 
 void jllvm::registerJavaClasses(VirtualMachine& virtualMachine)
 {
-    addModels<ObjectModel, ClassModel, ThrowableModel, FloatModel, DoubleModel, SystemModel, ReflectionModel, CDSModel>(
-        virtualMachine);
+    addModels<ObjectModel, ClassModel, ThrowableModel, FloatModel, DoubleModel, SystemModel, ReflectionModel, CDSModel,
+              UnsafeModel>(virtualMachine);
 }
 
 const jllvm::ClassObject* jllvm::ReflectionModel::getCallerClass(VirtualMachine& virtualMachine,

--- a/src/jllvm/vm/NativeImplementation.hpp
+++ b/src/jllvm/vm/NativeImplementation.hpp
@@ -297,6 +297,174 @@ public:
                         addMember<&CDSModel::initializeFromArchive>());
 };
 
+class UnsafeModel : public ModelBase<>
+{
+    template <class T>
+    bool compareAndSet(GCRootRef<Object> object, std::uint64_t offset, T expected, T desired)
+    {
+        // TODO: use C++20 std::atomic_ref instead of atomic builtins in the future.
+        return __atomic_compare_exchange_n(reinterpret_cast<T*>(reinterpret_cast<char*>(object.address()) + offset),
+                                           &expected, desired, false, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+    }
+
+    template <class T>
+    T getVolatile(GCRootRef<Object> object, std::uint64_t offset)
+    {
+        // TODO: use C++20 std::atomic_ref instead of atomic builtins in the future.
+        return __atomic_load_n(reinterpret_cast<T*>(reinterpret_cast<char*>(object.address()) + offset),
+                               __ATOMIC_SEQ_CST);
+    }
+
+    template <class T>
+    void putVolatile(GCRootRef<Object> object, std::uint64_t offset, T value)
+    {
+        // TODO: use C++20 std::atomic_ref instead of atomic builtins in the future.
+        __atomic_store_n(reinterpret_cast<T*>(reinterpret_cast<char*>(object.address()) + offset), value,
+                         __ATOMIC_SEQ_CST);
+    }
+
+public:
+    using Base::Base;
+
+    static void registerNatives(VirtualMachine&, GCRootRef<ClassObject>) {}
+
+    std::uint32_t arrayBaseOffset0(GCRootRef<ClassObject> arrayClass)
+    {
+        assert(arrayClass->isArray());
+        const ClassObject* componentType = arrayClass->getComponentType();
+        if (!componentType->isPrimitive())
+        {
+            return Array<>::arrayElementsOffset();
+        }
+
+        static llvm::DenseMap<llvm::StringRef, std::uint32_t> mapping = {
+            {"Z", Array<bool>::arrayElementsOffset()},         {"C", Array<std::uint16_t>::arrayElementsOffset()},
+            {"B", Array<std::int8_t>::arrayElementsOffset()},  {"S", Array<std::int16_t>::arrayElementsOffset()},
+            {"I", Array<std::int32_t>::arrayElementsOffset()}, {"D", Array<double>::arrayElementsOffset()},
+            {"F", Array<float>::arrayElementsOffset()},        {"L", Array<std::int64_t>::arrayElementsOffset()},
+        };
+        return mapping.lookup(componentType->getClassName());
+    }
+
+    std::uint32_t arrayIndexScale0(GCRootRef<ClassObject> arrayClass)
+    {
+        assert(arrayClass->isArray());
+        const ClassObject* componentType = arrayClass->getComponentType();
+        if (!componentType->isPrimitive())
+        {
+            return sizeof(Object*);
+        }
+
+        static llvm::DenseMap<llvm::StringRef, std::uint32_t> mapping = {
+            {"Z", sizeof(bool)},         {"C", sizeof(std::uint16_t)}, {"B", sizeof(std::int8_t)},
+            {"S", sizeof(std::int16_t)}, {"I", sizeof(std::int32_t)},  {"D", sizeof(double)},
+            {"F", sizeof(float)},        {"L", sizeof(std::int64_t)},
+        };
+        return mapping.lookup(componentType->getClassName());
+    }
+
+    std::uint32_t objectFieldOffset1(GCRootRef<ClassObject> clazz, GCRootRef<String> fieldName)
+    {
+        std::string fieldNameStr = fieldName->toUTF8();
+        for (const ClassObject* curr : clazz->getSuperClasses())
+        {
+            const Field* iter = llvm::find_if(curr->getFields(), [&](const Field& field)
+                                              { return !field.isStatic() && field.getName() == fieldNameStr; });
+            if (iter != curr->getFields().end())
+            {
+                return iter->getOffset();
+            }
+        }
+
+        // TODO: throw InternalError
+        return 0;
+    }
+
+    void storeFence()
+    {
+        std::atomic_thread_fence(std::memory_order_release);
+    }
+
+    void loadFence()
+    {
+        std::atomic_thread_fence(std::memory_order_acquire);
+    }
+
+    void fullFence()
+    {
+        std::atomic_thread_fence(std::memory_order_seq_cst);
+    }
+
+    bool compareAndSetByte(GCRootRef<Object> object, std::uint64_t offset, std::int8_t expected, std::int8_t desired)
+    {
+        return compareAndSet(object, offset, expected, desired);
+    }
+
+    bool compareAndSetShort(GCRootRef<Object> object, std::uint64_t offset, std::int16_t expected, std::int16_t desired)
+    {
+        return compareAndSet(object, offset, expected, desired);
+    }
+
+    bool compareAndSetChar(GCRootRef<Object> object, std::uint64_t offset, std::uint16_t expected,
+                           std::uint16_t desired)
+    {
+        return compareAndSet(object, offset, expected, desired);
+    }
+
+    bool compareAndSetBoolean(GCRootRef<Object> object, std::uint64_t offset, bool expected, bool desired)
+    {
+        return compareAndSet(object, offset, expected, desired);
+    }
+
+    bool compareAndSetInt(GCRootRef<Object> object, std::uint64_t offset, std::int32_t expected, std::int32_t desired)
+    {
+        return compareAndSet(object, offset, expected, desired);
+    }
+
+    bool compareAndSetLong(GCRootRef<Object> object, std::uint64_t offset, std::int64_t expected, std::int64_t desired)
+    {
+        return compareAndSet(object, offset, expected, desired);
+    }
+
+    bool compareAndSetReference(GCRootRef<Object> object, std::uint64_t offset, GCRootRef<Object> expected,
+                                GCRootRef<Object> desired)
+    {
+        return compareAndSet(object, offset, expected.address(), desired.address());
+    }
+
+    Object* getReferenceVolatile(GCRootRef<Object> object, std::uint64_t offset)
+    {
+        return getVolatile<Object*>(object, offset);
+    }
+
+    std::int32_t getIntVolatile(GCRootRef<Object> object, std::uint64_t offset)
+    {
+        return getVolatile<std::int32_t>(object, offset);
+    }
+
+    void putReferenceVolatile(GCRootRef<Object> object, std::uint64_t offset, GCRootRef<Object> value)
+    {
+        putVolatile(object, offset, value.address());
+    }
+
+    void putIntVolatile(GCRootRef<Object> object, std::uint64_t offset, std::int32_t value)
+    {
+        putVolatile(object, offset, value);
+    }
+
+    constexpr static llvm::StringLiteral className = "jdk/internal/misc/Unsafe";
+    constexpr static auto methods =
+        std::make_tuple(addMember<&UnsafeModel::registerNatives>(), addMember<&UnsafeModel::arrayBaseOffset0>(),
+                        addMember<&UnsafeModel::arrayIndexScale0>(), addMember<&UnsafeModel::objectFieldOffset1>(),
+                        addMember<&UnsafeModel::storeFence>(), addMember<&UnsafeModel::loadFence>(),
+                        addMember<&UnsafeModel::fullFence>(), addMember<&UnsafeModel::compareAndSetByte>(),
+                        addMember<&UnsafeModel::compareAndSetShort>(), addMember<&UnsafeModel::compareAndSetChar>(),
+                        addMember<&UnsafeModel::compareAndSetBoolean>(), addMember<&UnsafeModel::compareAndSetInt>(),
+                        addMember<&UnsafeModel::compareAndSetLong>(), addMember<&UnsafeModel::compareAndSetReference>(),
+                        addMember<&UnsafeModel::getIntVolatile>(), addMember<&UnsafeModel::getReferenceVolatile>(),
+                        addMember<&UnsafeModel::putIntVolatile>(), addMember<&UnsafeModel::putReferenceVolatile>());
+};
+
 /// Register any models for builtin Java classes in the VM.
 void registerJavaClasses(VirtualMachine& virtualMachine);
 

--- a/tests/Execution/unsafe-array-base-and-index.java
+++ b/tests/Execution/unsafe-array-base-and-index.java
@@ -1,0 +1,31 @@
+// RUN: javac --add-exports java.base/jdk.internal.misc=ALL-UNNAMED %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+import jdk.internal.misc.Unsafe;
+
+class Test
+{
+    private static final Unsafe u = Unsafe.getUnsafe();
+
+    static native void print(String s);
+
+    public static void main(String[] args)
+    {
+        var i = new int[5];
+        u.putIntVolatile(i, u.ARRAY_INT_BASE_OFFSET + 3 * u.ARRAY_INT_INDEX_SCALE, 96);
+        if (i[3] == 96)
+        {
+            // CHECK: Success
+            print("Success");
+        }
+
+        var t = new Test[5];
+        var tmp = new Test();
+        u.putReferenceVolatile(t, u.ARRAY_OBJECT_BASE_OFFSET + 3 * u.ARRAY_OBJECT_INDEX_SCALE, tmp);
+        if (t[3] == tmp)
+        {
+            // CHECK: Success
+            print("Success");
+        }
+    }
+}

--- a/tests/Execution/unsafe-compare-and-set.java
+++ b/tests/Execution/unsafe-compare-and-set.java
@@ -1,0 +1,132 @@
+// RUN: javac --add-exports java.base/jdk.internal.misc=ALL-UNNAMED %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+import jdk.internal.misc.Unsafe;
+
+class Test
+{
+    private static final Unsafe u = Unsafe.getUnsafe();
+
+    private static long Z_OFFSET;
+    private static long B_OFFSET;
+    private static long S_OFFSET;
+    private static long C_OFFSET;
+    private static long I_OFFSET;
+    private static long L_OFFSET;
+    private static long T_OFFSET;
+
+    static {
+        Z_OFFSET = u.objectFieldOffset(Test.class, "z");
+        B_OFFSET = u.objectFieldOffset(Test.class, "b");
+        S_OFFSET = u.objectFieldOffset(Test.class, "s");
+        C_OFFSET = u.objectFieldOffset(Test.class, "c");
+        I_OFFSET = u.objectFieldOffset(Test.class, "i");
+        L_OFFSET = u.objectFieldOffset(Test.class, "l");
+        T_OFFSET = u.objectFieldOffset(Test.class, "t");
+    }
+
+    public boolean z = true;
+    public byte b = 7;
+    public short s = 7;
+    public char c = 'x';
+    public int i = 7;
+    public long l = 7;
+    public Test t = null;
+
+    static native void print(String s);
+
+    public static void main(String[] args)
+    {
+        var t = new Test();
+        if (u.compareAndSetByte(t, B_OFFSET, (byte)7, (byte)96)
+            && t.b == (byte)96)
+        {
+            // CHECK: Success
+            print("Success");
+        }
+
+        // Expected does not match anymore.
+        if (!u.compareAndSetByte(t, B_OFFSET, (byte)7, (byte)7)
+            && t.b == (byte)96)
+        {
+            // CHECK: Success
+            print("Success");
+        }
+
+        if (u.compareAndSetShort(t, S_OFFSET, (short)7, (short)96)
+            && t.b == (short)96)
+        {
+            // CHECK: Success
+            print("Success");
+        }
+
+        // Expected does not match anymore.
+        if (!u.compareAndSetShort(t, S_OFFSET, (short)7, (short)7)
+            && t.s == (short)96)
+        {
+            // CHECK: Success
+            print("Success");
+        }
+
+        if (u.compareAndSetChar(t, C_OFFSET, 'x', 'A')
+            && t.c == 'A')
+        {
+            // CHECK: Success
+            print("Success");
+        }
+
+        // Expected does not match anymore.
+        if (!u.compareAndSetChar(t, C_OFFSET, 'x', 'x')
+            && t.c == 'A')
+        {
+            // CHECK: Success
+            print("Success");
+        }
+
+        if (u.compareAndSetInt(t, I_OFFSET, 7, 96)
+            && t.i == 96)
+        {
+            // CHECK: Success
+            print("Success");
+        }
+
+        // Expected does not match anymore.
+        if (!u.compareAndSetInt(t, I_OFFSET, 7, 7)
+            && t.i == 96)
+        {
+            // CHECK: Success
+            print("Success");
+        }
+
+        if (u.compareAndSetLong(t, L_OFFSET, 7, 96)
+            && t.l == 96)
+        {
+            // CHECK: Success
+            print("Success");
+        }
+
+        // Expected does not match anymore.
+        if (!u.compareAndSetLong(t, L_OFFSET, 7, 7)
+            && t.l == 96)
+        {
+            // CHECK: Success
+            print("Success");
+        }
+
+        var tmp = new Test();
+        if (u.compareAndSetReference(t, T_OFFSET, null, tmp)
+            && t.t == tmp)
+        {
+            // CHECK: Success
+            print("Success");
+        }
+
+        // Expected does not match anymore.
+        if (!u.compareAndSetReference(t, T_OFFSET, null, null)
+            && t.t == tmp)
+        {
+            // CHECK: Success
+            print("Success");
+        }
+    }
+}

--- a/tests/Execution/unsafe-fences.java
+++ b/tests/Execution/unsafe-fences.java
@@ -1,0 +1,22 @@
+// RUN: javac --add-exports java.base/jdk.internal.misc=ALL-UNNAMED %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+import jdk.internal.misc.Unsafe;
+
+class Test
+{
+    private static final Unsafe u = Unsafe.getUnsafe();
+
+    static native void print(String s);
+
+    public static void main(String[] args)
+    {
+        // Check that calls to these work at least. Can't really test their side effect.
+        u.loadFence();
+        u.storeFence();
+        u.fullFence();
+
+        // CHECK: Success
+        print("Success");
+    }
+}

--- a/tests/Execution/unsafe-get-put-volatile.java
+++ b/tests/Execution/unsafe-get-put-volatile.java
@@ -1,0 +1,67 @@
+// RUN: javac --add-exports java.base/jdk.internal.misc=ALL-UNNAMED %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+import jdk.internal.misc.Unsafe;
+
+class Test
+{
+    private static final Unsafe u = Unsafe.getUnsafe();
+
+    private static long Z_OFFSET;
+    private static long B_OFFSET;
+    private static long S_OFFSET;
+    private static long C_OFFSET;
+    private static long I_OFFSET;
+    private static long L_OFFSET;
+    private static long T_OFFSET;
+
+    static {
+        Z_OFFSET = u.objectFieldOffset(Test.class, "z");
+        B_OFFSET = u.objectFieldOffset(Test.class, "b");
+        S_OFFSET = u.objectFieldOffset(Test.class, "s");
+        C_OFFSET = u.objectFieldOffset(Test.class, "c");
+        I_OFFSET = u.objectFieldOffset(Test.class, "i");
+        L_OFFSET = u.objectFieldOffset(Test.class, "l");
+        T_OFFSET = u.objectFieldOffset(Test.class, "t");
+    }
+
+    public boolean z = true;
+    public byte b = 7;
+    public short s = 7;
+    public char c = 'x';
+    public int i = 7;
+    public long l = 7;
+    public Test t = null;
+
+    static native void print(String s);
+
+    public static void main(String[] args)
+    {
+        var t = new Test();
+
+        if (u.getReferenceVolatile(t, T_OFFSET) == null)
+        {
+            // CHECK: Success
+            print("Success");
+        }
+        var tmp = new Test();
+        u.putReferenceVolatile(t, T_OFFSET, tmp);
+        if (t.t == tmp)
+        {
+            // CHECK: Success
+            print("Success");
+        }
+
+        if (u.getIntVolatile(t, I_OFFSET) == 7)
+        {
+            // CHECK: Success
+            print("Success");
+        }
+        u.putIntVolatile(t, I_OFFSET, 96);
+        if (t.i == 96)
+        {
+            // CHECK: Success
+            print("Success");
+        }
+    }
+}


### PR DESCRIPTION
The operations implemented here are as far as I could tell the most common uses of `Unsafe` and the ones required for both `System.initPhase1` and `StringBuilder` e.g.

In short, `Unsafe` offers operations to get the byte offset of fields within objects followed by operations that operate on byteoffsets into the these objects. The accessors implemented here and most often used are atomic ones, allowing atomic accesses to fields of a Java objects.

Atomic load, store and xchg are currently implemented with Compiler builtins as C's `_Atomic` and C++s `std::atomic` do not support operating on arbitrary pointers, while these builtins do. C++20 has `std::atomic_ref` that has these capabilities but these are not yet supported in libc++.

In the future all these implementations should actually be compiler intrinsics specially detected and compiled in the compilation process (the JNI call cost massively outweighs the implementations).

The tests mostly check the easily observable semantics. The atomicity is not really testable AFAIK.