### PR TITLE
[support] fix java compact encoding to UTF-8 conversion

### DIFF
--- a/tests/Execution/compact-string-to-utf8.java
+++ b/tests/Execution/compact-string-to-utf8.java
@@ -1,0 +1,13 @@
+// RUN: javac -encoding utf-8 %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+class Test
+{
+    public static native void print(String s);
+
+    public static void main(String[] args)
+    {
+        // CHECK: öüäß
+        print("öüäß");
+    }
+}


### PR DESCRIPTION
The compact encoding used in Java is not UTF-8 put Latin1 which are sadly not identical. Latin1 is essentially a truncated version of UTF-32, only supporting the first 256 codepoints. UTF-8 is only identical in the first 128 codepoints. All after have be encoded in a multi-byte scheme.