### PR TITLE
[JNI] add concept of `local` frames to manage roots during JNI calls

### DIFF
--- a/src/jllvm/vm/VirtualMachine.cpp
+++ b/src/jllvm/vm/VirtualMachine.cpp
@@ -174,12 +174,6 @@ jllvm::VirtualMachine::VirtualMachine(std::vector<std::string>&& classPath)
                   { return object->instanceOf(classObject); }},
         std::pair{"activeException", m_activeException.data()},
         std::pair{"jllvm_new_local_root", [&](Object* object) { return m_gc.root(object).release(); }},
-        std::pair{"jllvm_delete_local_root", [&](GCRootRef<Object> root)
-                  {
-                      auto* object = static_cast<Object*>(root);
-                      m_gc.deleteRoot(root);
-                      return object;
-                  }},
         std::pair{"jllvm_initialize_class_object", [&](ClassObject* classObject)
                   {
                       // This should have been checked inline in LLVM IR.
@@ -206,7 +200,9 @@ jllvm::VirtualMachine::VirtualMachine(std::vector<std::string>&& classPath)
                           m_gc.root(m_gc.allocate(&m_classLoader.forName("Ljava/lang/ClassCastException;")));
                       executeObjectConstructor(root, "(Ljava/lang/String;)V", string);
                       return static_cast<Object*>(root);
-                  }});
+                  }},
+        std::pair{"jllvm_push_local_frame", [&] { m_gc.pushLocalFrame(); }},
+        std::pair{"jllvm_pop_local_frame", [&] { m_gc.popLocalFrame(); }});
 
     registerJavaClasses(*this);
 


### PR DESCRIPTION
We currently had issues avoiding double frees of roots when creating roots during JNI calls. The reason is that it is cumbersome to determine whether a root returned by a native function happens to be a root passed into the function or whether it is a global root and whatnot.

Instead, adopt a strategy that is actually mandated by the JNI spec: Create new "local root frames" in which all local roots during a JNI call are allocated that are then automatically freed on return. These also correspond to the `PushLocalFrame` and `PopLocalFrame` functions defined here https://docs.oracle.com/en/java/javase/17/docs/specs/jni/functions.html#pushlocalframe

With these, we can simply pop the frame at the end of a JNI call to free all local roots.