### PR TITLE
[native][refactor][NFC] move implementations out of `NativeImplementation.hpp`

### DIFF
--- a/src/jllvm/vm/CMakeLists.txt
+++ b/src/jllvm/vm/CMakeLists.txt
@@ -1,7 +1,8 @@
 llvm_map_components_to_libnames(llvm_native_libs ${LLVM_NATIVE_ARCH})
 
 add_library(JLLVMVirtualMachine VirtualMachine.cpp JIT.cpp StackMapRegistrationPlugin.cpp
-        JNIImplementation.cpp NativeImplementation.cpp StringInterner.cpp MarkSanitizersGCLeafs.cpp)
+        JNIImplementation.cpp NativeImplementation.cpp StringInterner.cpp MarkSanitizersGCLeafs.cpp native/Lang.cpp
+        native/JDK.cpp)
 target_link_libraries(JLLVMVirtualMachine
         PRIVATE ${llvm_native_libs}
         PUBLIC JLLVMClassParser JLLVMObject JLLVMGC LLVMExecutionEngine LLVMOrcJIT LLVMJITLink JLLVMMaterialization

--- a/src/jllvm/vm/JNIImplementation.cpp
+++ b/src/jllvm/vm/JNIImplementation.cpp
@@ -1,6 +1,11 @@
-#include <jni.h>
+#include "JNIImplementation.hpp"
 
 #include "VirtualMachine.hpp"
+
+jllvm::VirtualMachine& jllvm::virtualMachineFromJNIEnv(JNIEnv* env)
+{
+    return *reinterpret_cast<jllvm::VirtualMachine*>(env->functions->reserved0);
+}
 
 jllvm::VirtualMachine::JNINativeInterfaceUPtr jllvm::VirtualMachine::createJNIEnvironment()
 {

--- a/src/jllvm/vm/JNIImplementation.hpp
+++ b/src/jllvm/vm/JNIImplementation.hpp
@@ -1,0 +1,12 @@
+
+#pragma once
+
+#include <jni.h>
+
+#include "VirtualMachine.hpp"
+
+namespace jllvm
+{
+/// Returns the 'VirtualMachine' instance associated with the 'JNIEnv'.
+VirtualMachine& virtualMachineFromJNIEnv(JNIEnv* env);
+} // namespace jllvm

--- a/src/jllvm/vm/NativeImplementation.hpp
+++ b/src/jllvm/vm/NativeImplementation.hpp
@@ -1,13 +1,10 @@
 #pragma once
 
-#include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/StringRef.h>
 
-#include <memory>
-#include <utility>
+#include <string_view>
 
-#include <jni.h>
-
+#include "JNIImplementation.hpp"
 #include "VirtualMachine.hpp"
 
 namespace jllvm
@@ -67,379 +64,11 @@ public:
     using ThisType = JavaObject;
 };
 
-/// Model implementation for the native methods of Javas 'Object' class.
-class ObjectModel : public ModelBase<>
-{
-public:
-    using Base::Base;
-
-    const ClassObject* getClass()
-    {
-        return javaThis->getClass();
-    }
-
-    std::int32_t hashCode()
-    {
-        std::int32_t& hashCode = javaThis->getObjectHeader().hashCode;
-        if (!hashCode)
-        {
-            hashCode = virtualMachine.createNewHashCode();
-        }
-        return hashCode;
-    }
-
-    constexpr static llvm::StringLiteral className = "java/lang/Object";
-    constexpr static auto methods = std::make_tuple(&ObjectModel::hashCode, &ObjectModel::getClass);
-};
-
-/// Model implementation for the native methods of Javas 'Class' class.
-class ClassModel : public ModelBase<ClassObject>
-{
-public:
-    using Base::Base;
-
-    static void registerNatives(VirtualMachine&, GCRootRef<ClassObject>)
-    {
-        // Noop until (if?) we need some C++ initialization code.
-    }
-
-    static const ClassObject* getPrimitiveClass(VirtualMachine& vm, GCRootRef<ClassObject>, GCRootRef<String> string)
-    {
-        static llvm::DenseMap<llvm::StringRef, char> mapping = {
-            {"boolean", 'Z'}, {"char", 'C'},  {"byte", 'B'}, {"short", 'S'}, {"int", 'I'},
-            {"double", 'D'},  {"float", 'F'}, {"void", 'V'}, {"long", 'L'},
-        };
-        std::string utf8 = string->toUTF8();
-        char c = mapping.lookup(utf8);
-        if (c == 0)
-        {
-            return nullptr;
-        }
-        return &vm.getClassLoader().forName(llvm::Twine(c));
-    }
-
-    bool isArray()
-    {
-        return javaThis->isArray();
-    }
-
-    static bool desiredAssertionStatus0(VirtualMachine&, GCRootRef<ClassObject>)
-    {
-#ifndef NDEBUG
-        return true;
-#else
-        return false;
-#endif
-    }
-
-    constexpr static llvm::StringLiteral className = "java/lang/Class";
-    constexpr static auto methods =
-        std::make_tuple(&ClassModel::registerNatives, &ClassModel::isArray, &ClassModel::desiredAssertionStatus0,
-                        &ClassModel::getPrimitiveClass);
-};
-
-class FloatModel : public ModelBase<>
-{
-public:
-    using Base::Base;
-
-    static std::uint32_t floatToRawIntBits(VirtualMachine&, GCRootRef<ClassObject>, float value)
-    {
-        // TODO: Use std::bit_cast once supported by our C++20.
-        std::uint32_t repr;
-        std::memcpy(&repr, &value, sizeof(float));
-        return repr;
-    }
-
-    static float intBitsToFloat(VirtualMachine&, GCRootRef<ClassObject>, std::uint32_t value)
-    {
-        // TODO: Use std::bit_cast once supported by our C++20.
-        float repr;
-        std::memcpy(&repr, &value, sizeof(float));
-        return repr;
-    }
-
-    constexpr static llvm::StringLiteral className = "java/lang/Float";
-    constexpr static auto methods = std::make_tuple(&floatToRawIntBits, &intBitsToFloat);
-};
-
-class DoubleModel : public ModelBase<>
-{
-public:
-    using Base::Base;
-
-    static std::uint64_t doubleToRawLongBits(VirtualMachine&, GCRootRef<ClassObject>, double value)
-    {
-        // TODO: Use std::bit_cast once supported by our C++20.
-        std::uint64_t repr;
-        std::memcpy(&repr, &value, sizeof(double));
-        return repr;
-    }
-
-    static double longBitsToDouble(VirtualMachine&, GCRootRef<ClassObject>, std::uint64_t value)
-    {
-        // TODO: Use std::bit_cast once supported by our C++20.
-        double repr;
-        std::memcpy(&repr, &value, sizeof(double));
-        return repr;
-    }
-
-    constexpr static llvm::StringLiteral className = "java/lang/Double";
-    constexpr static auto methods = std::make_tuple(&doubleToRawLongBits, &longBitsToDouble);
-};
-
-/// Model implementation for the native methods of Javas 'Thowable' class.
-class ThrowableModel : public ModelBase<Throwable>
-{
-public:
-    using Base::Base;
-
-    GCRootRef<Throwable> fillInStackTrace(int)
-    {
-        // TODO: Set backtrace and depth of 'javaThis'. See
-        // https://github.com/openjdk/jdk/blob/4f096eb7c9066e5127d9ab8c1c893e991a23d316/src/hotspot/share/classfile/javaClasses.cpp#L2491
-        return javaThis;
-    }
-
-    constexpr static llvm::StringLiteral className = "java/lang/Throwable";
-    constexpr static auto methods = std::make_tuple(&ThrowableModel::fillInStackTrace);
-};
-
-class SystemModel : public ModelBase<Object>
-{
-public:
-    using Base::Base;
-
-    static void registerNatives(VirtualMachine&, GCRootRef<ClassObject>)
-    {
-        // Noop in our implementation.
-    }
-
-    static std::int64_t nanoTime(VirtualMachine&, GCRootRef<ClassObject>)
-    {
-        auto now = std::chrono::high_resolution_clock::now();
-        return std::chrono::time_point_cast<std::chrono::nanoseconds>(now).time_since_epoch().count();
-    }
-
-    constexpr static llvm::StringLiteral className = "java/lang/System";
-    constexpr static auto methods = std::make_tuple(&SystemModel::registerNatives, &SystemModel::nanoTime);
-};
-
-class ReflectionModel : public ModelBase<>
-{
-public:
-    using Base::Base;
-
-    static const ClassObject* getCallerClass(VirtualMachine& virtualMachine, GCRootRef<ClassObject> classObject);
-
-    constexpr static llvm::StringLiteral className = "jdk/internal/reflect/Reflection";
-    constexpr static auto methods = std::make_tuple(&ReflectionModel::getCallerClass);
-};
-
-class CDSModel : public ModelBase<Object>
-{
-public:
-    using Base::Base;
-
-    static bool isDumpingClassList0(VirtualMachine&, GCRootRef<ClassObject>)
-    {
-        return false;
-    }
-
-    static bool isDumpingArchive0(VirtualMachine&, GCRootRef<ClassObject>)
-    {
-        return false;
-    }
-
-    static bool isSharingEnabled0(VirtualMachine&, GCRootRef<ClassObject>)
-    {
-        return false;
-    }
-
-    static std::int64_t getRandomSeedForDumping(VirtualMachine&, GCRootRef<ClassObject>)
-    {
-        return 0;
-    }
-
-    static void initializeFromArchive(VirtualMachine&, GCRootRef<ClassObject>, GCRootRef<ClassObject>) {}
-
-    constexpr static llvm::StringLiteral className = "jdk/internal/misc/CDS";
-    constexpr static auto methods =
-        std::make_tuple(&CDSModel::isDumpingClassList0, &CDSModel::isDumpingArchive0, &CDSModel::isSharingEnabled0,
-                        &CDSModel::getRandomSeedForDumping, &CDSModel::initializeFromArchive);
-};
-
-class UnsafeModel : public ModelBase<>
-{
-    template <class T>
-    bool compareAndSet(GCRootRef<Object> object, std::uint64_t offset, T expected, T desired)
-    {
-        // TODO: use C++20 std::atomic_ref instead of atomic builtins in the future.
-        return __atomic_compare_exchange_n(reinterpret_cast<T*>(reinterpret_cast<char*>(object.address()) + offset),
-                                           &expected, desired, false, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
-    }
-
-    template <class T>
-    T getVolatile(GCRootRef<Object> object, std::uint64_t offset)
-    {
-        // TODO: use C++20 std::atomic_ref instead of atomic builtins in the future.
-        return __atomic_load_n(reinterpret_cast<T*>(reinterpret_cast<char*>(object.address()) + offset),
-                               __ATOMIC_SEQ_CST);
-    }
-
-    template <class T>
-    void putVolatile(GCRootRef<Object> object, std::uint64_t offset, T value)
-    {
-        // TODO: use C++20 std::atomic_ref instead of atomic builtins in the future.
-        __atomic_store_n(reinterpret_cast<T*>(reinterpret_cast<char*>(object.address()) + offset), value,
-                         __ATOMIC_SEQ_CST);
-    }
-
-public:
-    using Base::Base;
-
-    static void registerNatives(VirtualMachine&, GCRootRef<ClassObject>) {}
-
-    std::uint32_t arrayBaseOffset0(GCRootRef<ClassObject> arrayClass)
-    {
-        assert(arrayClass->isArray());
-        const ClassObject* componentType = arrayClass->getComponentType();
-        if (!componentType->isPrimitive())
-        {
-            return Array<>::arrayElementsOffset();
-        }
-
-        static llvm::DenseMap<llvm::StringRef, std::uint32_t> mapping = {
-            {"Z", Array<bool>::arrayElementsOffset()},         {"C", Array<std::uint16_t>::arrayElementsOffset()},
-            {"B", Array<std::int8_t>::arrayElementsOffset()},  {"S", Array<std::int16_t>::arrayElementsOffset()},
-            {"I", Array<std::int32_t>::arrayElementsOffset()}, {"D", Array<double>::arrayElementsOffset()},
-            {"F", Array<float>::arrayElementsOffset()},        {"L", Array<std::int64_t>::arrayElementsOffset()},
-        };
-        return mapping.lookup(componentType->getClassName());
-    }
-
-    std::uint32_t arrayIndexScale0(GCRootRef<ClassObject> arrayClass)
-    {
-        assert(arrayClass->isArray());
-        const ClassObject* componentType = arrayClass->getComponentType();
-        if (!componentType->isPrimitive())
-        {
-            return sizeof(Object*);
-        }
-
-        static llvm::DenseMap<llvm::StringRef, std::uint32_t> mapping = {
-            {"Z", sizeof(bool)},         {"C", sizeof(std::uint16_t)}, {"B", sizeof(std::int8_t)},
-            {"S", sizeof(std::int16_t)}, {"I", sizeof(std::int32_t)},  {"D", sizeof(double)},
-            {"F", sizeof(float)},        {"L", sizeof(std::int64_t)},
-        };
-        return mapping.lookup(componentType->getClassName());
-    }
-
-    std::uint32_t objectFieldOffset1(GCRootRef<ClassObject> clazz, GCRootRef<String> fieldName)
-    {
-        std::string fieldNameStr = fieldName->toUTF8();
-        for (const ClassObject* curr : clazz->getSuperClasses())
-        {
-            const Field* iter = llvm::find_if(curr->getFields(), [&](const Field& field)
-                                              { return !field.isStatic() && field.getName() == fieldNameStr; });
-            if (iter != curr->getFields().end())
-            {
-                return iter->getOffset();
-            }
-        }
-
-        // TODO: throw InternalError
-        return 0;
-    }
-
-    void storeFence()
-    {
-        std::atomic_thread_fence(std::memory_order_release);
-    }
-
-    void loadFence()
-    {
-        std::atomic_thread_fence(std::memory_order_acquire);
-    }
-
-    void fullFence()
-    {
-        std::atomic_thread_fence(std::memory_order_seq_cst);
-    }
-
-    bool compareAndSetByte(GCRootRef<Object> object, std::uint64_t offset, std::int8_t expected, std::int8_t desired)
-    {
-        return compareAndSet(object, offset, expected, desired);
-    }
-
-    bool compareAndSetShort(GCRootRef<Object> object, std::uint64_t offset, std::int16_t expected, std::int16_t desired)
-    {
-        return compareAndSet(object, offset, expected, desired);
-    }
-
-    bool compareAndSetChar(GCRootRef<Object> object, std::uint64_t offset, std::uint16_t expected,
-                           std::uint16_t desired)
-    {
-        return compareAndSet(object, offset, expected, desired);
-    }
-
-    bool compareAndSetBoolean(GCRootRef<Object> object, std::uint64_t offset, bool expected, bool desired)
-    {
-        return compareAndSet(object, offset, expected, desired);
-    }
-
-    bool compareAndSetInt(GCRootRef<Object> object, std::uint64_t offset, std::int32_t expected, std::int32_t desired)
-    {
-        return compareAndSet(object, offset, expected, desired);
-    }
-
-    bool compareAndSetLong(GCRootRef<Object> object, std::uint64_t offset, std::int64_t expected, std::int64_t desired)
-    {
-        return compareAndSet(object, offset, expected, desired);
-    }
-
-    bool compareAndSetReference(GCRootRef<Object> object, std::uint64_t offset, GCRootRef<Object> expected,
-                                GCRootRef<Object> desired)
-    {
-        return compareAndSet(object, offset, expected.address(), desired.address());
-    }
-
-    Object* getReferenceVolatile(GCRootRef<Object> object, std::uint64_t offset)
-    {
-        return getVolatile<Object*>(object, offset);
-    }
-
-    std::int32_t getIntVolatile(GCRootRef<Object> object, std::uint64_t offset)
-    {
-        return getVolatile<std::int32_t>(object, offset);
-    }
-
-    void putReferenceVolatile(GCRootRef<Object> object, std::uint64_t offset, GCRootRef<Object> value)
-    {
-        putVolatile(object, offset, value.address());
-    }
-
-    void putIntVolatile(GCRootRef<Object> object, std::uint64_t offset, std::int32_t value)
-    {
-        putVolatile(object, offset, value);
-    }
-
-    constexpr static llvm::StringLiteral className = "jdk/internal/misc/Unsafe";
-    constexpr static auto methods = std::make_tuple(
-        &UnsafeModel::registerNatives, &UnsafeModel::arrayBaseOffset0, &UnsafeModel::arrayIndexScale0,
-        &UnsafeModel::objectFieldOffset1, &UnsafeModel::storeFence, &UnsafeModel::loadFence, &UnsafeModel::fullFence,
-        &UnsafeModel::compareAndSetByte, &UnsafeModel::compareAndSetShort, &UnsafeModel::compareAndSetChar,
-        &UnsafeModel::compareAndSetBoolean, &UnsafeModel::compareAndSetInt, &UnsafeModel::compareAndSetLong,
-        &UnsafeModel::compareAndSetReference, &UnsafeModel::getIntVolatile, &UnsafeModel::getReferenceVolatile,
-        &UnsafeModel::putIntVolatile, &UnsafeModel::putReferenceVolatile);
-};
-
 /// Register any models for builtin Java classes in the VM.
 void registerJavaClasses(VirtualMachine& virtualMachine);
 
 namespace detail
 {
-jllvm::VirtualMachine& virtualMachineFromJNIEnv(JNIEnv* env);
 
 auto coerceReturnType(std::derived_from<ObjectInterface> auto* object, VirtualMachine& virtualMachine)
 {
@@ -494,12 +123,6 @@ auto createMethodBridge(Ret (Model::*ptr)(Args...))
     };
 }
 
-template <class Model>
-using hasClassName = decltype(Model::className);
-
-template <class Model>
-using hasMethods = decltype(Model::methods);
-
 // WARNING: fnPtr even if unused is required to be named for clang to include it in the __PRETTY_FUNCTION__ output
 // below. Massive hack, I know.
 template <auto fnPtr>
@@ -532,10 +155,19 @@ template <class Model>
 void addModel(VirtualMachine& virtualMachine)
 {
     static_assert(
-        llvm::is_detected<detail::hasClassName, Model>{},
+        requires {
+            {
+                Model::className
+            } -> std::convertible_to<llvm::StringRef>;
+        },
         "'Model' must have a 'constexpr static llvm::StringLiteral className' field with fully qualified name of the class it is modelling");
+
     static_assert(
-        llvm::is_detected<detail::hasMethods, Model>{},
+        requires {
+            Model::methods;
+            std::tuple_size_v<decltype(Model::methods)>;
+            std::get<0>(Model::methods);
+        },
         "'Model' must have a 'constexpr static' tuple called 'methods' listing all 'native' methods implemented");
 
     constexpr auto methods = Model::methods;

--- a/src/jllvm/vm/native/JDK.cpp
+++ b/src/jllvm/vm/native/JDK.cpp
@@ -1,0 +1,28 @@
+#include "JDK.hpp"
+
+#include <jllvm/unwind/Unwinder.hpp>
+
+const jllvm::ClassObject* jllvm::jdk::ReflectionModel::getCallerClass(VirtualMachine& virtualMachine,
+                                                                      GCRootRef<ClassObject> classObject)
+{
+    const ClassObject* result = nullptr;
+    unwindStack(
+        [&](UnwindFrame frame)
+        {
+            std::uintptr_t fp = frame.getFunctionPointer();
+            std::optional<JavaMethodMetadata> data = virtualMachine.getJIT().getJavaMethodMetadata(fp);
+            if (!data)
+            {
+                return UnwindAction::ContinueUnwinding;
+            }
+
+            if (data->classObject == classObject)
+            {
+                return UnwindAction::ContinueUnwinding;
+            }
+            // TODO: If the method has the Java annotation '@CallerSensitive' it should be skipped by this method.
+            result = data->classObject;
+            return UnwindAction::StopUnwinding;
+        });
+    return result;
+}

--- a/src/jllvm/vm/native/JDK.hpp
+++ b/src/jllvm/vm/native/JDK.hpp
@@ -1,0 +1,219 @@
+
+#pragma once
+
+#include <jllvm/vm/NativeImplementation.hpp>
+
+/// Model implementations for all JDK classes in a 'jdk/internal/*' package.
+namespace jllvm::jdk
+{
+
+class ReflectionModel : public ModelBase<>
+{
+public:
+    using Base::Base;
+
+    static const ClassObject* getCallerClass(VirtualMachine& virtualMachine, GCRootRef<ClassObject> classObject);
+
+    constexpr static llvm::StringLiteral className = "jdk/internal/reflect/Reflection";
+    constexpr static auto methods = std::make_tuple(&ReflectionModel::getCallerClass);
+};
+
+class CDSModel : public ModelBase<>
+{
+public:
+    using Base::Base;
+
+    static bool isDumpingClassList0(VirtualMachine&, GCRootRef<ClassObject>)
+    {
+        return false;
+    }
+
+    static bool isDumpingArchive0(VirtualMachine&, GCRootRef<ClassObject>)
+    {
+        return false;
+    }
+
+    static bool isSharingEnabled0(VirtualMachine&, GCRootRef<ClassObject>)
+    {
+        return false;
+    }
+
+    static std::int64_t getRandomSeedForDumping(VirtualMachine&, GCRootRef<ClassObject>)
+    {
+        return 0;
+    }
+
+    static void initializeFromArchive(VirtualMachine&, GCRootRef<ClassObject>, GCRootRef<ClassObject>) {}
+
+    constexpr static llvm::StringLiteral className = "jdk/internal/misc/CDS";
+    constexpr static auto methods =
+        std::make_tuple(&CDSModel::isDumpingClassList0, &CDSModel::isDumpingArchive0, &CDSModel::isSharingEnabled0,
+                        &CDSModel::getRandomSeedForDumping, &CDSModel::initializeFromArchive);
+};
+
+class UnsafeModel : public ModelBase<>
+{
+    template <class T>
+    bool compareAndSet(GCRootRef<Object> object, std::uint64_t offset, T expected, T desired)
+    {
+        // TODO: use C++20 std::atomic_ref instead of atomic builtins in the future.
+        return __atomic_compare_exchange_n(reinterpret_cast<T*>(reinterpret_cast<char*>(object.address()) + offset),
+                                           &expected, desired, false, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+    }
+
+    template <class T>
+    T getVolatile(GCRootRef<Object> object, std::uint64_t offset)
+    {
+        // TODO: use C++20 std::atomic_ref instead of atomic builtins in the future.
+        return __atomic_load_n(reinterpret_cast<T*>(reinterpret_cast<char*>(object.address()) + offset),
+                               __ATOMIC_SEQ_CST);
+    }
+
+    template <class T>
+    void putVolatile(GCRootRef<Object> object, std::uint64_t offset, T value)
+    {
+        // TODO: use C++20 std::atomic_ref instead of atomic builtins in the future.
+        __atomic_store_n(reinterpret_cast<T*>(reinterpret_cast<char*>(object.address()) + offset), value,
+                         __ATOMIC_SEQ_CST);
+    }
+
+public:
+    using Base::Base;
+
+    static void registerNatives(VirtualMachine&, GCRootRef<ClassObject>) {}
+
+    std::uint32_t arrayBaseOffset0(GCRootRef<ClassObject> arrayClass)
+    {
+        assert(arrayClass->isArray());
+        const ClassObject* componentType = arrayClass->getComponentType();
+        if (!componentType->isPrimitive())
+        {
+            return Array<>::arrayElementsOffset();
+        }
+
+        static llvm::DenseMap<llvm::StringRef, std::uint32_t> mapping = {
+            {"Z", Array<bool>::arrayElementsOffset()},         {"C", Array<std::uint16_t>::arrayElementsOffset()},
+            {"B", Array<std::int8_t>::arrayElementsOffset()},  {"S", Array<std::int16_t>::arrayElementsOffset()},
+            {"I", Array<std::int32_t>::arrayElementsOffset()}, {"D", Array<double>::arrayElementsOffset()},
+            {"F", Array<float>::arrayElementsOffset()},        {"L", Array<std::int64_t>::arrayElementsOffset()},
+        };
+        return mapping.lookup(componentType->getClassName());
+    }
+
+    std::uint32_t arrayIndexScale0(GCRootRef<ClassObject> arrayClass)
+    {
+        assert(arrayClass->isArray());
+        const ClassObject* componentType = arrayClass->getComponentType();
+        if (!componentType->isPrimitive())
+        {
+            return sizeof(Object*);
+        }
+
+        static llvm::DenseMap<llvm::StringRef, std::uint32_t> mapping = {
+            {"Z", sizeof(bool)},         {"C", sizeof(std::uint16_t)}, {"B", sizeof(std::int8_t)},
+            {"S", sizeof(std::int16_t)}, {"I", sizeof(std::int32_t)},  {"D", sizeof(double)},
+            {"F", sizeof(float)},        {"L", sizeof(std::int64_t)},
+        };
+        return mapping.lookup(componentType->getClassName());
+    }
+
+    std::uint32_t objectFieldOffset1(GCRootRef<ClassObject> clazz, GCRootRef<String> fieldName)
+    {
+        std::string fieldNameStr = fieldName->toUTF8();
+        for (const ClassObject* curr : clazz->getSuperClasses())
+        {
+            const Field* iter = llvm::find_if(curr->getFields(), [&](const Field& field)
+                                              { return !field.isStatic() && field.getName() == fieldNameStr; });
+            if (iter != curr->getFields().end())
+            {
+                return iter->getOffset();
+            }
+        }
+
+        // TODO: throw InternalError
+        return 0;
+    }
+
+    void storeFence()
+    {
+        std::atomic_thread_fence(std::memory_order_release);
+    }
+
+    void loadFence()
+    {
+        std::atomic_thread_fence(std::memory_order_acquire);
+    }
+
+    void fullFence()
+    {
+        std::atomic_thread_fence(std::memory_order_seq_cst);
+    }
+
+    bool compareAndSetByte(GCRootRef<Object> object, std::uint64_t offset, std::int8_t expected, std::int8_t desired)
+    {
+        return compareAndSet(object, offset, expected, desired);
+    }
+
+    bool compareAndSetShort(GCRootRef<Object> object, std::uint64_t offset, std::int16_t expected, std::int16_t desired)
+    {
+        return compareAndSet(object, offset, expected, desired);
+    }
+
+    bool compareAndSetChar(GCRootRef<Object> object, std::uint64_t offset, std::uint16_t expected,
+                           std::uint16_t desired)
+    {
+        return compareAndSet(object, offset, expected, desired);
+    }
+
+    bool compareAndSetBoolean(GCRootRef<Object> object, std::uint64_t offset, bool expected, bool desired)
+    {
+        return compareAndSet(object, offset, expected, desired);
+    }
+
+    bool compareAndSetInt(GCRootRef<Object> object, std::uint64_t offset, std::int32_t expected, std::int32_t desired)
+    {
+        return compareAndSet(object, offset, expected, desired);
+    }
+
+    bool compareAndSetLong(GCRootRef<Object> object, std::uint64_t offset, std::int64_t expected, std::int64_t desired)
+    {
+        return compareAndSet(object, offset, expected, desired);
+    }
+
+    bool compareAndSetReference(GCRootRef<Object> object, std::uint64_t offset, GCRootRef<Object> expected,
+                                GCRootRef<Object> desired)
+    {
+        return compareAndSet(object, offset, expected.address(), desired.address());
+    }
+
+    Object* getReferenceVolatile(GCRootRef<Object> object, std::uint64_t offset)
+    {
+        return getVolatile<Object*>(object, offset);
+    }
+
+    std::int32_t getIntVolatile(GCRootRef<Object> object, std::uint64_t offset)
+    {
+        return getVolatile<std::int32_t>(object, offset);
+    }
+
+    void putReferenceVolatile(GCRootRef<Object> object, std::uint64_t offset, GCRootRef<Object> value)
+    {
+        putVolatile(object, offset, value.address());
+    }
+
+    void putIntVolatile(GCRootRef<Object> object, std::uint64_t offset, std::int32_t value)
+    {
+        putVolatile(object, offset, value);
+    }
+
+    constexpr static llvm::StringLiteral className = "jdk/internal/misc/Unsafe";
+    constexpr static auto methods = std::make_tuple(
+        &UnsafeModel::registerNatives, &UnsafeModel::arrayBaseOffset0, &UnsafeModel::arrayIndexScale0,
+        &UnsafeModel::objectFieldOffset1, &UnsafeModel::storeFence, &UnsafeModel::loadFence, &UnsafeModel::fullFence,
+        &UnsafeModel::compareAndSetByte, &UnsafeModel::compareAndSetShort, &UnsafeModel::compareAndSetChar,
+        &UnsafeModel::compareAndSetBoolean, &UnsafeModel::compareAndSetInt, &UnsafeModel::compareAndSetLong,
+        &UnsafeModel::compareAndSetReference, &UnsafeModel::getIntVolatile, &UnsafeModel::getReferenceVolatile,
+        &UnsafeModel::putIntVolatile, &UnsafeModel::putReferenceVolatile);
+};
+
+} // namespace jllvm::jdk

--- a/src/jllvm/vm/native/Lang.cpp
+++ b/src/jllvm/vm/native/Lang.cpp
@@ -1,0 +1,1 @@
+#include "Lang.hpp"

--- a/src/jllvm/vm/native/Lang.hpp
+++ b/src/jllvm/vm/native/Lang.hpp
@@ -1,0 +1,170 @@
+
+#pragma once
+
+#include <jllvm/vm/NativeImplementation.hpp>
+
+#include <chrono>
+
+/// Model implementations for all Java classes in a 'java/lang/*' package.
+namespace jllvm::lang
+{
+
+/// Model implementation for the native methods of Javas 'Object' class.
+class ObjectModel : public ModelBase<>
+{
+public:
+    using Base::Base;
+
+    const ClassObject* getClass()
+    {
+        return javaThis->getClass();
+    }
+
+    std::int32_t hashCode()
+    {
+        std::int32_t& hashCode = javaThis->getObjectHeader().hashCode;
+        if (!hashCode)
+        {
+            hashCode = virtualMachine.createNewHashCode();
+        }
+        return hashCode;
+    }
+
+    constexpr static llvm::StringLiteral className = "java/lang/Object";
+    constexpr static auto methods = std::make_tuple(&ObjectModel::hashCode, &ObjectModel::getClass);
+};
+
+/// Model implementation for the native methods of Javas 'Class' class.
+class ClassModel : public ModelBase<ClassObject>
+{
+public:
+    using Base::Base;
+
+    static void registerNatives(VirtualMachine&, GCRootRef<ClassObject>)
+    {
+        // Noop until (if?) we need some C++ initialization code.
+    }
+
+    static const ClassObject* getPrimitiveClass(VirtualMachine& vm, GCRootRef<ClassObject>, GCRootRef<String> string)
+    {
+        static llvm::DenseMap<llvm::StringRef, char> mapping = {
+            {"boolean", 'Z'}, {"char", 'C'},  {"byte", 'B'}, {"short", 'S'}, {"int", 'I'},
+            {"double", 'D'},  {"float", 'F'}, {"void", 'V'}, {"long", 'L'},
+        };
+        std::string utf8 = string->toUTF8();
+        char c = mapping.lookup(utf8);
+        if (c == 0)
+        {
+            return nullptr;
+        }
+        return &vm.getClassLoader().forName(llvm::Twine(c));
+    }
+
+    bool isArray()
+    {
+        return javaThis->isArray();
+    }
+
+    static bool desiredAssertionStatus0(VirtualMachine&, GCRootRef<ClassObject>)
+    {
+#ifndef NDEBUG
+        return true;
+#else
+        return false;
+#endif
+    }
+
+    constexpr static llvm::StringLiteral className = "java/lang/Class";
+    constexpr static auto methods =
+        std::make_tuple(&ClassModel::registerNatives, &ClassModel::isArray, &ClassModel::desiredAssertionStatus0,
+                        &ClassModel::getPrimitiveClass);
+};
+
+class FloatModel : public ModelBase<>
+{
+public:
+    using Base::Base;
+
+    static std::uint32_t floatToRawIntBits(VirtualMachine&, GCRootRef<ClassObject>, float value)
+    {
+        // TODO: Use std::bit_cast once supported by our C++20.
+        std::uint32_t repr;
+        std::memcpy(&repr, &value, sizeof(float));
+        return repr;
+    }
+
+    static float intBitsToFloat(VirtualMachine&, GCRootRef<ClassObject>, std::uint32_t value)
+    {
+        // TODO: Use std::bit_cast once supported by our C++20.
+        float repr;
+        std::memcpy(&repr, &value, sizeof(float));
+        return repr;
+    }
+
+    constexpr static llvm::StringLiteral className = "java/lang/Float";
+    constexpr static auto methods = std::make_tuple(&floatToRawIntBits, &intBitsToFloat);
+};
+
+class DoubleModel : public ModelBase<>
+{
+public:
+    using Base::Base;
+
+    static std::uint64_t doubleToRawLongBits(VirtualMachine&, GCRootRef<ClassObject>, double value)
+    {
+        // TODO: Use std::bit_cast once supported by our C++20.
+        std::uint64_t repr;
+        std::memcpy(&repr, &value, sizeof(double));
+        return repr;
+    }
+
+    static double longBitsToDouble(VirtualMachine&, GCRootRef<ClassObject>, std::uint64_t value)
+    {
+        // TODO: Use std::bit_cast once supported by our C++20.
+        double repr;
+        std::memcpy(&repr, &value, sizeof(double));
+        return repr;
+    }
+
+    constexpr static llvm::StringLiteral className = "java/lang/Double";
+    constexpr static auto methods = std::make_tuple(&doubleToRawLongBits, &longBitsToDouble);
+};
+
+/// Model implementation for the native methods of Javas 'Thowable' class.
+class ThrowableModel : public ModelBase<Throwable>
+{
+public:
+    using Base::Base;
+
+    GCRootRef<Throwable> fillInStackTrace(int)
+    {
+        // TODO: Set backtrace and depth of 'javaThis'. See
+        // https://github.com/openjdk/jdk/blob/4f096eb7c9066e5127d9ab8c1c893e991a23d316/src/hotspot/share/classfile/javaClasses.cpp#L2491
+        return javaThis;
+    }
+
+    constexpr static llvm::StringLiteral className = "java/lang/Throwable";
+    constexpr static auto methods = std::make_tuple(&ThrowableModel::fillInStackTrace);
+};
+
+class SystemModel : public ModelBase<>
+{
+public:
+    using Base::Base;
+
+    static void registerNatives(VirtualMachine&, GCRootRef<ClassObject>)
+    {
+        // Noop in our implementation.
+    }
+
+    static std::int64_t nanoTime(VirtualMachine&, GCRootRef<ClassObject>)
+    {
+        auto now = std::chrono::high_resolution_clock::now();
+        return std::chrono::time_point_cast<std::chrono::nanoseconds>(now).time_since_epoch().count();
+    }
+
+    constexpr static llvm::StringLiteral className = "java/lang/System";
+    constexpr static auto methods = std::make_tuple(&SystemModel::registerNatives, &SystemModel::nanoTime);
+};
+
+} // namespace jllvm::lang


### PR DESCRIPTION
For now just group them by their package. Models so far have been in 'java/lang' and 'jdk/internals' and have therefore been split into these two groups. I am expecting to add more like 'java/io' in a `IO.cpp` in the future as well however.