### PR TITLE
[vm] create and initialize main `Thread` object

### DIFF
--- a/src/jllvm/object/Object.hpp
+++ b/src/jllvm/object/Object.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <llvm/ADT/BitmaskEnum.h>
 #include <llvm/Support/Allocator.h>
 
 #include <cassert>
@@ -197,5 +198,57 @@ struct Throwable : ObjectInterface
 };
 
 static_assert(std::is_standard_layout_v<Throwable>);
+
+// Specified here https://docs.oracle.com/en/java/javase/17/docs/specs/jvmti.html#GetThreadState
+enum class ThreadState : std::int32_t
+{
+    Alive = 0x1,
+    Terminated = 0x2,
+    Runnable = 0x4,
+    BlockedOnMonitorEnter = 0x400,
+    Waiting = 0x80,
+    WaitingIndefinitely = 0x10,
+    WaitingWithTimeout = 0x20,
+    Sleeping = 0x40,
+    InObjectWait = 0x100,
+    Parked = 0x200,
+    Suspended = 0x100000,
+    Interrupted = 0x200000,
+    InNative = 0x400000,
+    LLVM_MARK_AS_BITMASK_ENUM(InNative)
+};
+LLVM_ENABLE_BITMASK_ENUMS_IN_NAMESPACE();
+
+struct Thread : ObjectInterface
+{
+    ObjectHeader header;
+
+    String* name{};
+    std::int32_t priority{};
+    bool daemon{};
+    bool interrupted{};
+    bool stillborn{};
+    std::int64_t eetop{};
+    Object* target{};
+    Object* group{};
+    Object* contextClassLoader{};
+    Object* inheritedAccessControlContext{};
+    Object* threadLocals{};
+    Object* inheritableThreadLocals{};
+    std::int64_t stackSize{};
+    std::int64_t tid{};
+    ThreadState threadStatus{};
+    Object* parkBlocker{};
+    Object* blocker{};
+    Object* blockerLock{};
+    Object* uncaughtExceptionHandler{};
+    std::int64_t threadLocalRandomSeed{};
+    std::int32_t threadLocalRandomProbe{};
+    std::int32_t threadLocalSecondarySeed{};
+
+    explicit Thread(const ClassObject* classObject) : header(classObject) {}
+};
+
+static_assert(std::is_standard_layout_v<Thread>);
 
 } // namespace jllvm

--- a/src/jllvm/vm/CMakeLists.txt
+++ b/src/jllvm/vm/CMakeLists.txt
@@ -2,7 +2,7 @@ llvm_map_components_to_libnames(llvm_native_libs ${LLVM_NATIVE_ARCH})
 
 add_library(JLLVMVirtualMachine VirtualMachine.cpp JIT.cpp StackMapRegistrationPlugin.cpp
         JNIImplementation.cpp NativeImplementation.cpp StringInterner.cpp MarkSanitizersGCLeafs.cpp native/Lang.cpp
-        native/JDK.cpp)
+        native/JDK.cpp native/Security.cpp)
 target_link_libraries(JLLVMVirtualMachine
         PRIVATE ${llvm_native_libs}
         PUBLIC JLLVMClassParser JLLVMObject JLLVMGC LLVMExecutionEngine LLVMOrcJIT LLVMJITLink JLLVMMaterialization

--- a/src/jllvm/vm/NativeImplementation.cpp
+++ b/src/jllvm/vm/NativeImplementation.cpp
@@ -2,12 +2,14 @@
 
 #include <jllvm/vm/native/JDK.hpp>
 #include <jllvm/vm/native/Lang.hpp>
+#include <jllvm/vm/native/Security.hpp>
 
 void jllvm::registerJavaClasses(VirtualMachine& virtualMachine)
 {
     using namespace lang;
     using namespace jdk;
+    using namespace security;
 
     addModels<ObjectModel, ClassModel, ThrowableModel, FloatModel, DoubleModel, SystemModel, ReflectionModel, CDSModel,
-              UnsafeModel>(virtualMachine);
+              UnsafeModel, ThreadModel, AccessControllerModel, VMModel>(virtualMachine);
 }

--- a/src/jllvm/vm/native/JDK.hpp
+++ b/src/jllvm/vm/native/JDK.hpp
@@ -216,4 +216,18 @@ public:
         &UnsafeModel::putIntVolatile, &UnsafeModel::putReferenceVolatile);
 };
 
+class VMModel : public ModelBase<>
+{
+public:
+    using Base::Base;
+
+    static void initialize(VirtualMachine&, GCRootRef<ClassObject>)
+    {
+        // Noop in our implementation.
+    }
+
+    constexpr static llvm::StringLiteral className = "jdk/internal/misc/VM";
+    constexpr static auto methods = std::make_tuple(&VMModel::initialize);
+};
+
 } // namespace jllvm::jdk

--- a/src/jllvm/vm/native/Lang.hpp
+++ b/src/jllvm/vm/native/Lang.hpp
@@ -167,4 +167,31 @@ public:
     constexpr static auto methods = std::make_tuple(&SystemModel::registerNatives, &SystemModel::nanoTime);
 };
 
+class ThreadModel : public ModelBase<Thread>
+{
+public:
+    using Base::Base;
+
+    static void registerNatives(VirtualMachine&, GCRootRef<ClassObject>)
+    {
+        // Noop in our implementation.
+    }
+
+    static GCRootRef<Thread> currentThread(VirtualMachine& vm, GCRootRef<ClassObject>)
+    {
+        // Once we are multi threaded, this should actually the return the corresponding Java thread
+        // this function is being called from. For now we are just returning the one and only thread for the time being.
+        return vm.getMainThread();
+    }
+
+    void setPriority0(std::int32_t priority)
+    {
+        javaThis->priority = priority;
+    }
+
+    constexpr static llvm::StringLiteral className = "java/lang/Thread";
+    constexpr static auto methods =
+        std::make_tuple(&ThreadModel::registerNatives, &ThreadModel::currentThread, &ThreadModel::setPriority0);
+};
+
 } // namespace jllvm::lang

--- a/src/jllvm/vm/native/Security.cpp
+++ b/src/jllvm/vm/native/Security.cpp
@@ -1,0 +1,1 @@
+#include "Security.hpp"

--- a/src/jllvm/vm/native/Security.hpp
+++ b/src/jllvm/vm/native/Security.hpp
@@ -1,4 +1,3 @@
-
 #pragma once
 
 #include <jllvm/vm/NativeImplementation.hpp>

--- a/src/jllvm/vm/native/Security.hpp
+++ b/src/jllvm/vm/native/Security.hpp
@@ -1,0 +1,25 @@
+
+#pragma once
+
+#include <jllvm/vm/NativeImplementation.hpp>
+
+/// Model implementations for all Java classes in a 'java/security/*' package.
+namespace jllvm::security
+{
+
+class AccessControllerModel : public ModelBase<>
+{
+public:
+    using Base::Base;
+
+    static Object* getStackAccessControlContext(VirtualMachine&, GCRootRef<ClassObject>)
+    {
+        // Null defined in the docs as "privileged code".
+        return nullptr;
+    }
+
+    constexpr static llvm::StringLiteral className = "java/security/AccessController";
+    constexpr static auto methods = std::make_tuple(&AccessControllerModel::getStackAccessControlContext);
+};
+
+} // namespace jllvm::security

--- a/tests/Execution/thread.java
+++ b/tests/Execution/thread.java
@@ -1,0 +1,18 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class
+
+class Test
+{
+    public static native void print(long l);
+    public static native void print(boolean b);
+
+    public static void main(String[] args)
+    {
+        var t = Thread.currentThread();
+        // CHECK: 1
+        print(t != null);
+
+        // CHECK: 1
+        print(t.getState() == Thread.State.RUNNABLE);
+    }
+}


### PR DESCRIPTION
Despite being single threaded, we still want a `Thread` object representing that one thread we do have :) This is required by other code, most importantly `System.initPhase1`.