### PR TITLE
[object] fix UBSAN error when doing empty array size calculation

### DIFF
--- a/src/jllvm/object/Object.hpp
+++ b/src/jllvm/object/Object.hpp
@@ -79,7 +79,7 @@ public:
     /// 'length' is the amount entries in the resulting array.
     static Array* create(llvm::BumpPtrAllocator& allocator, const ClassObject* classObject, std::uint32_t length)
     {
-        return new (allocator.Allocate(arrayElementsOffset() + sizeof(T[length]), alignof(Array)))
+        return new (allocator.Allocate(arrayElementsOffset() + sizeof(T) * length, alignof(Array)))
             Array(classObject, length);
     }
 

--- a/tests/Execution/empty-string.java
+++ b/tests/Execution/empty-string.java
@@ -1,0 +1,14 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+class Test
+{
+    public static native void print(int i);
+
+    public static void main(String[] args)
+    {
+        var s = "";
+        // CHECK: 0
+        print(s.length());
+    }
+}


### PR DESCRIPTION
We accidentally relied on a compiler extension in the code here by doing `sizeof` of a VLA. VLAs, as specified by C, have to have a size larger than 0, so UBSAN would raise an error if we effectively did `sizeof(T[0])`.

This PR just stops using VLAs.