### PR TITLE
[jit][NFC] use `llvm::orc::SimpleCompiler` to preserve the `llvm::TargetMachine`

### DIFF
--- a/src/jllvm/vm/JIT.cpp
+++ b/src/jllvm/vm/JIT.cpp
@@ -88,7 +88,7 @@ jllvm::JIT::JIT(std::unique_ptr<llvm::orc::ExecutionSession>&& session,
       m_dataLayout(layout),
       m_interner(*m_session, m_dataLayout),
       m_objectLayer(*m_session),
-      m_compilerLayer(*m_session, m_objectLayer, std::make_unique<llvm::orc::ConcurrentIRCompiler>(builder)),
+      m_compilerLayer(*m_session, m_objectLayer, std::make_unique<llvm::orc::SimpleCompiler>(*m_targetMachine)),
       m_optimizeLayer(*m_session, m_compilerLayer,
                       [&](llvm::orc::ThreadSafeModule tsm, const llvm::orc::MaterializationResponsibility&)
                       {


### PR DESCRIPTION
The `llvm::orc::ConcurrentIRCompiler` wasn't properly being used anyways and always created and then destructed the `llvm::TargetMachine`. It contains rather large structures which are deallocated on destruction and would be allocated, constructed, destructed and deallocated for every compilation.

Using `SimpleCompiler` instead makes the code about 18% faster:
![image](https://github.com/JLLVM/JLLVM/assets/6625526/b5603fcd-f5c2-4986-81fc-73556d9d4672)
