### PR TITLE
[vm] complete `System.initPhase1`

### DIFF
--- a/src/jllvm/gc/GarbageCollector.hpp
+++ b/src/jllvm/gc/GarbageCollector.hpp
@@ -265,6 +265,12 @@ public:
     /// sweeping.
     GCRootRef<Object> allocateStatic();
 
+    /// Returns the size of the object heap in bytes.
+    std::size_t getHeapSize() const
+    {
+        return m_heapSize;
+    }
+
     void garbageCollect();
 };
 

--- a/src/jllvm/main/Main.cpp
+++ b/src/jllvm/main/Main.cpp
@@ -72,6 +72,7 @@ int jllvm::main(llvm::StringRef executablePath, llvm::ArrayRef<char*> args)
     }
 
     llvm::SmallString<64> modulesPath = llvm::sys::path::parent_path(llvm::sys::path::parent_path(executablePath));
+    llvm::SmallString<64> javaHome = modulesPath;
     llvm::sys::path::append(modulesPath, "lib");
 
     std::vector<std::string> classPath;
@@ -92,7 +93,7 @@ int jllvm::main(llvm::StringRef executablePath, llvm::ArrayRef<char*> args)
         llvm::append_range(classPath, splits);
     }
 
-    jllvm::VirtualMachine vm(std::move(classPath));
+    jllvm::VirtualMachine vm(javaHome, std::move(classPath));
 
     if (commandLine.getArgs().hasArg(OPT_Xenable_test_utils))
     {

--- a/src/jllvm/object/ClassObject.hpp
+++ b/src/jllvm/object/ClassObject.hpp
@@ -352,7 +352,7 @@ public:
 
     /// Size of an instance of this class, returning ALL bytes composing of the type including the object header
     /// IF the object is not an array object. For array objects it does NOT contain the array elements, but does contain
-    /// the length field.
+    /// the length field with any padding afterwards *if and only if required*.
     std::uint32_t getInstanceSize() const
     {
         return m_fieldAreaSize + sizeof(ObjectHeader);

--- a/src/jllvm/support/CMakeLists.txt
+++ b/src/jllvm/support/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_library(JLLVMSupport Bytes.cpp Encoding.cpp)
+add_library(JLLVMSupport Bytes.cpp Encoding.cpp FileUtils.cpp)
 target_link_libraries(JLLVMSupport PUBLIC LLVMSupport)

--- a/src/jllvm/support/FileUtils.cpp
+++ b/src/jllvm/support/FileUtils.cpp
@@ -1,6 +1,6 @@
 #include "FileUtils.hpp"
 
-#ifdef __unix__
+#if defined(__unix__) || defined(__APPLE__)
     #include <fcntl.h>
 
 bool jllvm::isAppendMode(int fd)

--- a/src/jllvm/support/FileUtils.cpp
+++ b/src/jllvm/support/FileUtils.cpp
@@ -1,0 +1,11 @@
+#include "FileUtils.hpp"
+
+#ifdef __unix__
+    #include <fcntl.h>
+
+bool jllvm::isAppendMode(int fd)
+{
+    return fcntl(fd, F_GETFL) & O_APPEND;
+}
+
+#endif

--- a/src/jllvm/support/FileUtils.hpp
+++ b/src/jllvm/support/FileUtils.hpp
@@ -1,4 +1,3 @@
-
 #pragma once
 
 namespace jllvm

--- a/src/jllvm/support/FileUtils.hpp
+++ b/src/jllvm/support/FileUtils.hpp
@@ -1,0 +1,8 @@
+
+#pragma once
+
+namespace jllvm
+{
+/// Returns true if the opened file referred to by 'fd' was opened in append mode.
+bool isAppendMode(int fd);
+} // namespace jllvm

--- a/src/jllvm/vm/CMakeLists.txt
+++ b/src/jllvm/vm/CMakeLists.txt
@@ -1,8 +1,8 @@
 llvm_map_components_to_libnames(llvm_native_libs ${LLVM_NATIVE_ARCH})
 
 add_library(JLLVMVirtualMachine VirtualMachine.cpp JIT.cpp StackMapRegistrationPlugin.cpp
-        JNIImplementation.cpp NativeImplementation.cpp StringInterner.cpp MarkSanitizersGCLeafs.cpp native/Lang.cpp
-        native/JDK.cpp native/Security.cpp)
+        JNIImplementation.cpp NativeImplementation.cpp StringInterner.cpp MarkSanitizersGCLeafs.cpp native/IO.cpp
+        native/Lang.cpp native/JDK.cpp native/Security.cpp)
 target_link_libraries(JLLVMVirtualMachine
         PRIVATE ${llvm_native_libs}
         PUBLIC JLLVMClassParser JLLVMObject JLLVMGC LLVMExecutionEngine LLVMOrcJIT LLVMJITLink JLLVMMaterialization

--- a/src/jllvm/vm/NativeImplementation.cpp
+++ b/src/jllvm/vm/NativeImplementation.cpp
@@ -1,5 +1,6 @@
 #include "NativeImplementation.hpp"
 
+#include <jllvm/vm/native/IO.hpp>
 #include <jllvm/vm/native/JDK.hpp>
 #include <jllvm/vm/native/Lang.hpp>
 #include <jllvm/vm/native/Security.hpp>
@@ -9,7 +10,9 @@ void jllvm::registerJavaClasses(VirtualMachine& virtualMachine)
     using namespace lang;
     using namespace jdk;
     using namespace security;
+    using namespace io;
 
     addModels<ObjectModel, ClassModel, ThrowableModel, FloatModel, DoubleModel, SystemModel, ReflectionModel, CDSModel,
-              UnsafeModel, ThreadModel, AccessControllerModel, VMModel, ReferenceModel>(virtualMachine);
+              UnsafeModel, VMModel, ReferenceModel, SystemPropsRawModel, RuntimeModel, FileDescriptorModel,
+              ScopedMemoryAccessModel, SignalModel, ThreadModel, AccessControllerModel>(virtualMachine);
 }

--- a/src/jllvm/vm/NativeImplementation.hpp
+++ b/src/jllvm/vm/NativeImplementation.hpp
@@ -2,6 +2,8 @@
 
 #include <llvm/ADT/StringRef.h>
 
+#include <jllvm/support/FileUtils.hpp>
+
 #include <string_view>
 
 #include "JNIImplementation.hpp"

--- a/src/jllvm/vm/native/IO.cpp
+++ b/src/jllvm/vm/native/IO.cpp
@@ -1,0 +1,14 @@
+#include "IO.hpp"
+
+#include <llvm/Support/FileSystem.h>
+
+void jllvm::io::FileDescriptorModel::close0()
+{
+    if (javaThis->fd == -1)
+    {
+        return;
+    }
+    llvm::sys::fs::file_t native = llvm::sys::fs::convertFDToNativeFile(javaThis->fd);
+    (void)llvm::sys::fs::closeFile(native);
+    javaThis->fd = -1;
+}

--- a/src/jllvm/vm/native/IO.hpp
+++ b/src/jllvm/vm/native/IO.hpp
@@ -1,4 +1,3 @@
-
 #pragma once
 
 #include <jllvm/vm/NativeImplementation.hpp>

--- a/src/jllvm/vm/native/IO.hpp
+++ b/src/jllvm/vm/native/IO.hpp
@@ -1,0 +1,49 @@
+
+#pragma once
+
+#include <jllvm/vm/NativeImplementation.hpp>
+
+namespace jllvm::io
+{
+struct FileDescriptor : ObjectInterface
+{
+    ObjectHeader header;
+
+    std::uint32_t fd{};
+    std::uint64_t handle{};
+    Object* parent{};
+    Object* otherParents{};
+    bool closed{};
+};
+
+static_assert(std::is_standard_layout_v<FileDescriptor>);
+
+class FileDescriptorModel : public ModelBase<FileDescriptor>
+{
+public:
+    using Base::Base;
+
+    static void initIDs(VirtualMachine&, GCRootRef<ClassObject>)
+    {
+        // Noop in our implementation.
+    }
+
+    static std::uint64_t getHandle(VirtualMachine&, GCRootRef<ClassObject>, std::uint32_t)
+    {
+        // Noop on Unix, would return handle on Windows.
+        return -1;
+    }
+
+    static bool getAppend(VirtualMachine&, GCRootRef<ClassObject>, std::uint32_t fd)
+    {
+        return isAppendMode(fd);
+    }
+
+    void close0();
+
+    constexpr static llvm::StringLiteral className = "java/io/FileDescriptor";
+    constexpr static auto methods = std::make_tuple(&FileDescriptorModel::initIDs, &FileDescriptorModel::getHandle,
+                                                    &FileDescriptorModel::getAppend, &FileDescriptorModel::close0);
+};
+
+} // namespace jllvm::io

--- a/src/jllvm/vm/native/JDK.hpp
+++ b/src/jllvm/vm/native/JDK.hpp
@@ -229,4 +229,107 @@ public:
     constexpr static auto methods = std::make_tuple(&VMModel::initialize);
 };
 
+class SystemPropsRawModel : public ModelBase<>
+{
+    // See
+    // https://github.com/openjdk/jdk/blob/7d4b77ad9ee803d89eab5632f5c65ac843a68b3c/src/java.base/share/classes/jdk/internal/util/SystemProps.java#L217
+    // and
+    // https://github.com/openjdk/jdk/blob/7d4b77ad9ee803d89eab5632f5c65ac843a68b3c/src/java.base/share/native/libjava/System.c#L107
+    enum PlatformPropertiesFields
+    {
+        DisplayCountryNDX = 0,
+        DisplayLanguageNDX = 1 + DisplayCountryNDX,
+        DisplayScriptNdx = 1 + DisplayLanguageNDX,
+        DisplayVariantNdx = 1 + DisplayScriptNdx,
+        FileEncodingNdx = 1 + DisplayVariantNdx,
+        FileSeparatorNdx = 1 + FileEncodingNdx,
+        FormatCountryNdx = 1 + FileSeparatorNdx,
+        FormatLanguageNdx = 1 + FormatCountryNdx,
+        FormatScriptNdx = 1 + FormatLanguageNdx,
+        FormatVariantNdx = 1 + FormatScriptNdx,
+        FtpNonProxyHostsNdx = 1 + FormatVariantNdx,
+        FtpProxyHostNdx = 1 + FtpNonProxyHostsNdx,
+        FtpProxyPortNdx = 1 + FtpProxyHostNdx,
+        HttpNonProxyHostsNdx = 1 + FtpProxyPortNdx,
+        HttpProxyHostNdx = 1 + HttpNonProxyHostsNdx,
+        HttpProxyPortNdx = 1 + HttpProxyHostNdx,
+        HttpsProxyHostNdx = 1 + HttpProxyPortNdx,
+        HttpsProxyPortNdx = 1 + HttpsProxyHostNdx,
+        JavaIoTmpdirNdx = 1 + HttpsProxyPortNdx,
+        LineSeparatorNdx = 1 + JavaIoTmpdirNdx,
+        OsArchNdx = 1 + LineSeparatorNdx,
+        OsNameNdx = 1 + OsArchNdx,
+        OsVersionNdx = 1 + OsNameNdx,
+        PathSeparatorNdx = 1 + OsVersionNdx,
+        SocksNonProxyHostsNdx = 1 + PathSeparatorNdx,
+        SocksProxyHostNdx = 1 + SocksNonProxyHostsNdx,
+        SocksProxyPortNdx = 1 + SocksProxyHostNdx,
+        SunArchAbiNdx = 1 + SocksProxyPortNdx,
+        SunArchDataModelNdx = 1 + SunArchAbiNdx,
+        SunCpuEndianNdx = 1 + SunArchDataModelNdx,
+        SunCpuIsalistNdx = 1 + SunCpuEndianNdx,
+        SunIoUnicodeEncodingNdx = 1 + SunCpuIsalistNdx,
+        SunJnuEncodingNdx = 1 + SunIoUnicodeEncodingNdx,
+        SunOsPatchLevelNdx = 1 + SunJnuEncodingNdx,
+        SunStderrEncodingNdx = 1 + SunOsPatchLevelNdx,
+        SunStdoutEncodingNdx = 1 + SunStderrEncodingNdx,
+        UserDirNdx = 1 + SunStdoutEncodingNdx,
+        UserHomeNdx = 1 + UserDirNdx,
+        UserNameNdx = 1 + UserHomeNdx,
+        FixedLength = 1 + UserNameNdx,
+    };
+
+public:
+    using Base::Base;
+
+    static Array<String*>* platformProperties(VirtualMachine& vm, GCRootRef<ClassObject>);
+
+    static Array<String*>* vmProperties(VirtualMachine& vm, GCRootRef<ClassObject>)
+    {
+        auto& array = *vm.getGC().allocate<Array<String*>>(&vm.getClassLoader().forName("[Ljava/lang/String;"), 5);
+
+        array[0] = vm.getStringInterner().intern("java.home");
+        array[1] = vm.getStringInterner().intern(vm.getJavaHome());
+        array[2] = vm.getStringInterner().intern("native.encoding");
+        array[3] = vm.getStringInterner().intern("UTF-8");
+
+        return &array;
+    }
+
+    constexpr static llvm::StringLiteral className = "jdk/internal/util/SystemProps$Raw";
+    constexpr static auto methods =
+        std::make_tuple(&SystemPropsRawModel::platformProperties, &SystemPropsRawModel::vmProperties);
+};
+
+class ScopedMemoryAccessModel : public ModelBase<>
+{
+public:
+    using Base::Base;
+
+    static void registerNatives(VirtualMachine&, GCRootRef<ClassObject>)
+    {
+        // Noop in our implementation.
+    }
+
+    constexpr static llvm::StringLiteral className = "jdk/internal/misc/ScopedMemoryAccess";
+    constexpr static auto methods = std::make_tuple(&ScopedMemoryAccessModel::registerNatives);
+};
+
+class SignalModel : public ModelBase<>
+{
+public:
+    using Base::Base;
+
+    static std::int32_t findSignal0(VirtualMachine&, GCRootRef<ClassObject>, GCRootRef<String> sigName);
+
+    static std::int64_t handle0(VirtualMachine&, GCRootRef<ClassObject>, std::int32_t, std::int64_t)
+    {
+        // TODO:
+        return 0;
+    }
+
+    constexpr static llvm::StringLiteral className = "jdk/internal/misc/Signal";
+    constexpr static auto methods = std::make_tuple(&SignalModel::findSignal0, &SignalModel::handle0);
+};
+
 } // namespace jllvm::jdk

--- a/tests/Execution/runtime.java
+++ b/tests/Execution/runtime.java
@@ -1,0 +1,25 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class | FileCheck %s
+
+class Test
+{
+    public static native void print(byte b);
+    public static native void print(char c);
+    public static native void print(double d);
+    public static native void print(float f);
+    public static native void print(int i);
+    public static native void print(long l);
+    public static native void print(short s);
+    public static native void print(boolean b);
+
+    public static void main(String[] args)
+    {
+        var n = Runtime.getRuntime().availableProcessors();
+        // CHECK: 1
+        print(n >= 1);
+
+        var memory = Runtime.getRuntime().maxMemory();
+        // CHECK: 1
+        print(memory >= 1);
+    }
+}

--- a/tests/Execution/system-properties.java
+++ b/tests/Execution/system-properties.java
@@ -1,0 +1,37 @@
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class
+
+class Test
+{
+    public static native void print(String s);
+    public static native void print(boolean b);
+
+    public static void main(String[] args)
+    {
+        // CHECK: 1
+        print(System.getProperty("java.io.tmpdir") != null);
+        // CHECK: 1
+        print(System.getProperty("java.home") != null);
+        var tmp = System.getProperty("file.separator");
+        // CHECK: 1
+        print(tmp == "/" || tmp == "\\");
+        tmp = System.getProperty("line.separator");
+        // CHECK: 1
+        print(tmp == "\n" || tmp == "\n\r");
+        tmp = System.getProperty("path.separator");
+        // CHECK: 1
+        print(tmp == ":" || tmp == ";");
+        // CHECK: 1
+        print(System.getProperty("user.dir") != null);
+        // CHECK: 1
+        print(System.getProperty("user.home") != null);
+        // CHECK: 1
+        print(System.getProperty("file.encoding") == "UTF-8");
+        // CHECK: 1
+        print(System.getProperty("native.encoding") == "UTF-8");
+
+
+        // CHECK: 1
+        print(System.getProperty("unknown that really should not exist") == null);
+    }
+}


### PR DESCRIPTION
This PR includes all native methods required for `System.initPhase1` to complete successfully. These are part of a single commit mostly because they were not able to be tested independently or are really minor implementations not worth their own PR IMO.

Note that after this patch, startup time really goes up as around 100 classes any many many methods are compiled and execute before ever reaching `main`. This is the expected disadvantage of our single-tier fully optimizing JIT. Nevertheless, at this point in time, it only takes around a second in release builds on my machine.