### PR TITLE
[object][native] implement unicode output in `System.out`

### DIFF
--- a/src/jllvm/support/Encoding.cpp
+++ b/src/jllvm/support/Encoding.cpp
@@ -43,14 +43,10 @@ std::pair<std::vector<std::uint8_t>, jllvm::CompactEncoding> jllvm::toJavaCompac
     {
         std::uint8_t temp[2];
         std::memcpy(temp, &codePoint, sizeof(llvm::UTF16));
-        if constexpr (llvm::support::endianness::native != llvm::support::endianness::big)
-        {
-            std::swap(temp[0], temp[1]);
-        }
         result.push_back(temp[0]);
         result.push_back(temp[1]);
     }
-    return {std::move(result), CompactEncoding::Utf16BE};
+    return {std::move(result), CompactEncoding::Utf16};
 }
 
 std::string jllvm::fromJavaCompactEncoding(std::pair<llvm::ArrayRef<std::uint8_t>, CompactEncoding> compactEncoding)
@@ -75,15 +71,6 @@ std::string jllvm::fromJavaCompactEncoding(std::pair<llvm::ArrayRef<std::uint8_t
 
     std::vector<char> utf16{buffer.begin(), buffer.end()};
     std::string string;
-
-    if constexpr (llvm::support::endianness::native != llvm::support::endianness::big)
-    {
-        assert(utf16.size() % 2 == 0);
-        for (auto it = utf16.begin(); it != utf16.end();)
-        {
-            std::swap(*it++, *it++);
-        }
-    }
 
     bool success = llvm::convertUTF16ToUTF8String(utf16, string);
     assert(success);

--- a/src/jllvm/support/Encoding.hpp
+++ b/src/jllvm/support/Encoding.hpp
@@ -12,8 +12,8 @@ enum class CompactEncoding : uint8_t
 {
     /// LATIN1 encoding. Subset of unicode which encompasses all codepoints from 0 to 0xFF.
     Latin1 = 0,
-    /// Big Endian UTF16 without a BOM.
-    Utf16BE = 1,
+    /// UTF16 in native byte order without a BOM.
+    Utf16 = 1,
 };
 
 /// Converts a utf8 string, as we use internally the majority of the time, to a Java Strings internal encoding.

--- a/src/jllvm/vm/NativeImplementation.cpp
+++ b/src/jllvm/vm/NativeImplementation.cpp
@@ -14,5 +14,6 @@ void jllvm::registerJavaClasses(VirtualMachine& virtualMachine)
 
     addModels<ObjectModel, ClassModel, ThrowableModel, FloatModel, DoubleModel, SystemModel, ReflectionModel, CDSModel,
               UnsafeModel, VMModel, ReferenceModel, SystemPropsRawModel, RuntimeModel, FileDescriptorModel,
-              ScopedMemoryAccessModel, SignalModel, ThreadModel, AccessControllerModel, FileOutputStreamModel>(virtualMachine);
+              ScopedMemoryAccessModel, SignalModel, ThreadModel, AccessControllerModel, FileOutputStreamModel,
+              StringUTF16Model>(virtualMachine);
 }

--- a/src/jllvm/vm/native/Lang.cpp
+++ b/src/jllvm/vm/native/Lang.cpp
@@ -1,5 +1,7 @@
 #include "Lang.hpp"
 
+#include <llvm/Support/Endian.h>
+
 void jllvm::lang::SystemModel::arraycopy(jllvm::VirtualMachine&, jllvm::GCRootRef<jllvm::ClassObject>,
                                          jllvm::GCRootRef<Object> src, std::int32_t srcPos,
                                          jllvm::GCRootRef<Object> dest, std::int32_t destPos, std::int32_t length)
@@ -81,4 +83,9 @@ void jllvm::lang::SystemModel::arraycopy(jllvm::VirtualMachine&, jllvm::GCRootRe
         }
         (*destArr)[destPos++] = object;
     }
+}
+
+bool jllvm::lang::StringUTF16Model::isBigEndian(jllvm::VirtualMachine&, jllvm::GCRootRef<jllvm::ClassObject>)
+{
+    return llvm::sys::IsBigEndianHost;
 }

--- a/src/jllvm/vm/native/Lang.hpp
+++ b/src/jllvm/vm/native/Lang.hpp
@@ -260,4 +260,16 @@ public:
     constexpr static auto methods = std::make_tuple(&ReferenceModel::refersTo0);
 };
 
+class StringUTF16Model : public ModelBase<>
+{
+public:
+
+    using Base::Base;
+
+    static bool isBigEndian(VirtualMachine&, GCRootRef<ClassObject>);
+
+    constexpr static llvm::StringLiteral className = "java/lang/StringUTF16";
+    constexpr static auto methods = std::make_tuple(&StringUTF16Model::isBigEndian);
+};
+
 } // namespace jllvm::lang

--- a/tests/System/print-unicode.java
+++ b/tests/System/print-unicode.java
@@ -1,0 +1,13 @@
+// RUN: javac -encoding utf-8 %s -d %t
+// RUN: jllvm %t/Test.class | FileCheck %s
+
+class Test
+{
+    public static native void print(int i);
+
+    public static void main(String[] args)
+    {
+        // CHECK: €
+        System.out.println("€");
+    }
+}


### PR DESCRIPTION
This mainly required telling the system via a native method whether we are big endian or not. We apparently got the wrong idea that strings in Java are always big endian if UTF-16. Maybe this used to be true in older versions. Nowadays, they are apparently in native byte order and one simply has to tell the system the byte order.

With this patch we can now correctly display unicode characters in the output.