### PR TITLE
[object][NFC] create and use better methods for method and field lookup

### DIFF
--- a/src/jllvm/materialization/ByteCodeLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeLayer.cpp
@@ -33,6 +33,11 @@ std::string jllvm::mangleMethod(const MethodInfo& methodInfo, const ClassFile& c
     return mangleMethod(className, methodName, descriptor);
 }
 
+std::string jllvm::mangleMethod(const jllvm::Method* method)
+{
+    return mangleMethod(method->getClassObject()->getClassName(), method->getName(), method->getType());
+}
+
 llvm::Error jllvm::ByteCodeLayer::add(llvm::orc::JITDylib& dylib, const MethodInfo* methodInfo,
                                       const ClassFile* classFile, const Method* method, const ClassObject* classObject)
 {

--- a/src/jllvm/materialization/ByteCodeLayer.hpp
+++ b/src/jllvm/materialization/ByteCodeLayer.hpp
@@ -22,6 +22,8 @@ namespace jllvm
 {
 std::string mangleMethod(llvm::StringRef className, llvm::StringRef methodName, llvm::StringRef descriptor);
 
+std::string mangleMethod(const Method* method);
+
 std::string mangleMethod(const MethodInfo& methodInfo, const ClassFile& classFile);
 
 /// Base class layer for any layers operating on JVM Bytecode.

--- a/src/jllvm/materialization/CodeGeneratorUtils.hpp
+++ b/src/jllvm/materialization/CodeGeneratorUtils.hpp
@@ -173,16 +173,13 @@ class LazyClassLoaderHelper
                                       llvm::StringRef methodType, bool isStatic, llvm::Twine key,
                                       llvm::ArrayRef<llvm::Value*> args, F&& f);
 
-    static std::pair<const ClassObject*, const Method*>
-        methodResolution(const ClassObject* classObject, llvm::StringRef methodName, llvm::StringRef methodType);
+    static const Method* methodResolution(const ClassObject* classObject, llvm::StringRef methodName, llvm::StringRef methodType);
 
-    static std::pair<const ClassObject*, const Method*> interfaceMethodResolution(const ClassObject* classObject,
-                                                                                  llvm::StringRef methodName,
+    static const Method* interfaceMethodResolution(const ClassObject* classObject, llvm::StringRef methodName,
                                                                                   llvm::StringRef methodType,
                                                                                   ClassLoader& classLoader);
 
-    static std::pair<const ClassObject*, const Method*>
-        specialMethodResolution(const ClassObject* referencedClassObject, llvm::StringRef methodName,
+    static const Method* specialMethodResolution(const ClassObject* referencedClassObject, llvm::StringRef methodName,
                                 llvm::StringRef methodType, ClassLoader& classLoader, const ClassObject* currentClass,
                                 const ClassFile* currentClassFile);
 

--- a/src/jllvm/object/ClassLoader.cpp
+++ b/src/jllvm/object/ClassLoader.cpp
@@ -301,3 +301,9 @@ jllvm::ClassObject& jllvm::ClassLoader::loadBootstrapClasses()
     }
     return *m_metaClassObject;
 }
+
+jllvm::ClassLoader::~ClassLoader()
+{
+    auto range = llvm::make_second_range(m_mapping);
+    std::destroy(range.begin(), range.end());
+}

--- a/src/jllvm/object/ClassLoader.hpp
+++ b/src/jllvm/object/ClassLoader.hpp
@@ -67,6 +67,13 @@ public:
                 llvm::unique_function<void(const ClassFile*, ClassObject&)>&& prepareClassObject,
                 llvm::unique_function<void**()> allocateStatic);
 
+    ~ClassLoader();
+
+    ClassLoader(const ClassLoader&) = delete;
+    ClassLoader& operator=(const ClassLoader&) = delete;
+    ClassLoader(ClassLoader&&) noexcept = delete;
+    ClassLoader& operator=(ClassLoader&&) noexcept = delete;
+
     /// Loads the class object for the given class file. This may also load transitive dependencies
     /// of the class file. Currently aborts if a class file could not be loaded.
     ClassObject& add(std::unique_ptr<llvm::MemoryBuffer>&& memoryBuffer);

--- a/src/jllvm/support/NonOwningFrozenSet.hpp
+++ b/src/jllvm/support/NonOwningFrozenSet.hpp
@@ -1,0 +1,173 @@
+// Copyright (C) 2023 The JLLVM Contributors.
+//
+// This file is part of JLLVM.
+//
+// JLLVM is free software; you can redistribute it and/or modify it under  the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 3, or (at your option) any later version.
+//
+// JLLVM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with JLLVM; see the file LICENSE.txt.  If not
+// see <http://www.gnu.org/licenses/>.
+
+#include <llvm/ADT/ArrayRef.h>
+#include <llvm/Support/Allocator.h>
+
+namespace jllvm
+{
+
+/// Default hash and equality checked used by 'NonOwningFrozenSet'.
+template <class T>
+struct NonOwningFrozenSetDefaultInfo
+{
+    /// Method called to get a hash code from a value.
+    /// It is templated to work on a larger variety of types allowing heterogeneous lookup.
+    /// It is up to the caller to make sure two hash implementations of two types are equal.
+    template <class U>
+    static llvm::hash_code getHashCode(const U& value)
+    {
+        using namespace llvm;
+        // Make the call do a ADL lookup, but fallback to the implementations in the llvm namespace otherwise.
+        return hash_value(value);
+    }
+
+    /// Method called to compare two keys.
+    /// It is templated to work on a larger variety of types allowing heterogeneous lookup.
+    template <class U>
+    static bool isEqual(const T& lhs, const U& rhs)
+    {
+        return lhs == rhs;
+    }
+};
+
+/// Immutable hash set that does not take ownership of the keys.
+/// The use case for this hash set is for a range of 'Key's that are constructed and allocated elsewhere, do not change
+/// after construction, and require fast lookup.
+/// Additionally, the hash set preserves insertion order, is a standard layout type and allows heterogeneous lookup.
+/// The hash algorithm and equality check are controlled by the 'Info' template argument.
+template <class Key, class Info = NonOwningFrozenSetDefaultInfo<Key>>
+class NonOwningFrozenSet
+{
+    llvm::ArrayRef<std::size_t> m_indices;
+    llvm::ArrayRef<Key> m_keys;
+
+    constexpr static double LOAD_FACTOR = 0.75;
+    constexpr static std::size_t EMPTY_INDEX = static_cast<std::size_t>(-1);
+
+    template <class U>
+    std::size_t getBucket(const U& key) const
+    {
+        std::size_t mask = m_indices.size() - 1;
+        std::size_t bucket = Info::getHashCode(key) & mask;
+        for (std::size_t i = 1;; i++)
+        {
+            if (m_indices[bucket] == EMPTY_INDEX)
+            {
+                return bucket;
+            }
+
+            if (Info::isEqual(m_keys[m_indices[bucket]], key))
+            {
+                return bucket;
+            }
+
+            bucket += i;
+            bucket &= mask;
+        }
+        llvm_unreachable("Load factor should ensure termination");
+    }
+
+public:
+    using iterator = decltype(m_keys)::iterator;
+
+    NonOwningFrozenSet() = default;
+
+    /// Constructs a new 'NonOwningFrozenSet' with the given keys. The lifetime of 'keys' is managed externally.
+    /// 'allocator' is used for allocation of any internal data required to construct the set and must also outlive
+    /// the set instance.
+    ///
+    /// If 'keys' has any duplicates, latter instances will not be inserted into the set and cannot be found by 'find'.
+    /// They remain accessible through 'begin' and 'end' however.
+    explicit NonOwningFrozenSet(llvm::ArrayRef<Key> keys, llvm::BumpPtrAllocator& allocator) : m_keys(keys)
+    {
+        if (keys.empty())
+        {
+            return;
+        }
+
+        std::size_t size = llvm::PowerOf2Ceil(keys.size());
+        if (keys.size() / (double)size > LOAD_FACTOR)
+        {
+            size = llvm::NextPowerOf2(size);
+        }
+
+        llvm::MutableArrayRef<std::size_t> indices{allocator.Allocate<std::size_t>(size), size};
+        std::fill_n(indices.begin(), size, EMPTY_INDEX);
+        m_indices = indices;
+
+        for (auto&& [index, k] : llvm::enumerate(keys))
+        {
+            std::size_t bucket = getBucket(k);
+            if (indices[bucket] == EMPTY_INDEX)
+            {
+                indices[bucket] = index;
+            }
+        }
+    }
+
+    /// Returns an iterator to the element with they key 'key' or 'end()' if no such element exists.
+    /// The key must not be an instance of 'Key', but can be any type for which the hash and equal implementations
+    /// are compatible. It is up to the caller to ensure that is true.
+    template <class U>
+    iterator find(const U& key) const
+    {
+        if (empty())
+        {
+            return end();
+        }
+
+        std::size_t bucket = getBucket(key);
+        if (m_indices[bucket] == EMPTY_INDEX)
+        {
+            return end();
+        }
+        return m_keys.begin() + m_indices[bucket];
+    }
+
+    /// Returns true if 'find' can find an element.
+    template <class U>
+    bool contains(const U& key) const
+    {
+        return find(key) != end();
+    }
+
+    /// Returns true if this set is empty.
+    bool empty() const
+    {
+        return m_keys.empty();
+    }
+
+    llvm::ArrayRef<Key> keys() const
+    {
+        return m_keys;
+    }
+
+    /// Returns the begin iterator over the keys.
+    /// The iteration order is the same as given in the constructor.
+    iterator begin() const
+    {
+        return m_keys.begin();
+    }
+
+    /// Returns the end iterator over the keys.
+    iterator end() const
+    {
+        return m_keys.end();
+    }
+};
+
+template <class Range>
+NonOwningFrozenSet(const Range&, auto&) -> NonOwningFrozenSet<typename Range::value_type>;
+
+} // namespace jllvm

--- a/src/jllvm/support/NonOwningFrozenSet.hpp
+++ b/src/jllvm/support/NonOwningFrozenSet.hpp
@@ -72,6 +72,7 @@ class NonOwningFrozenSet
                 return bucket;
             }
 
+            // Do quadratic probing otherwise.
             bucket += i;
             bucket &= mask;
         }
@@ -79,7 +80,7 @@ class NonOwningFrozenSet
     }
 
 public:
-    using iterator = decltype(m_keys)::iterator;
+    using iterator = typename decltype(m_keys)::iterator;
 
     NonOwningFrozenSet() = default;
 

--- a/src/jllvm/vm/JIT.cpp
+++ b/src/jllvm/vm/JIT.cpp
@@ -178,7 +178,7 @@ void jllvm::JIT::add(const jllvm::ClassFile* classFile, const ClassObject* class
             continue;
         }
 
-        LLVM_DEBUG({ llvm::dbgs() << "Adding " << mangleMethod(info, *classFile) << " to JIT Link graph\n"; });
+        LLVM_DEBUG({ llvm::dbgs() << "Adding " << mangleMethod(&method) << " to JIT Link graph\n"; });
 
         if (info.isNative())
         {

--- a/src/jllvm/vm/native/Lang.hpp
+++ b/src/jllvm/vm/native/Lang.hpp
@@ -191,19 +191,19 @@ public:
 
     static void setIn0(VirtualMachine&, GCRootRef<ClassObject> classObject, GCRootRef<Object> stream)
     {
-        const void* addr = classObject->getField("in", "Ljava/io/InputStream;", true)->getAddressOfStatic();
+        const void* addr = classObject->getStaticField("in", "Ljava/io/InputStream;")->getAddressOfStatic();
         std::memcpy(const_cast<void*>(addr), stream.data(), sizeof(Object*));
     }
 
     static void setOut0(VirtualMachine&, GCRootRef<ClassObject> classObject, GCRootRef<Object> stream)
     {
-        const void* addr = classObject->getField("out", "Ljava/io/PrintStream;", true)->getAddressOfStatic();
+        const void* addr = classObject->getStaticField("out", "Ljava/io/PrintStream;")->getAddressOfStatic();
         std::memcpy(const_cast<void*>(addr), stream.data(), sizeof(Object*));
     }
 
     static void setErr0(VirtualMachine&, GCRootRef<ClassObject> classObject, GCRootRef<Object> stream)
     {
-        const void* addr = classObject->getField("err", "Ljava/io/PrintStream;", true)->getAddressOfStatic();
+        const void* addr = classObject->getStaticField("err", "Ljava/io/PrintStream;")->getAddressOfStatic();
         std::memcpy(const_cast<void*>(addr), stream.data(), sizeof(Object*));
     }
 

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -8,3 +8,7 @@ add_executable(GCTests RootFreeListTests.cpp
         GCRootRefTests.cpp)
 target_link_libraries(GCTests JLLVMGC Catch2::Catch2WithMain)
 catch_discover_tests(GCTests)
+
+add_executable(SupportTests NonOwningFrozenSetTests.cpp)
+target_link_libraries(SupportTests JLLVMSupport Catch2::Catch2WithMain)
+catch_discover_tests(SupportTests)

--- a/unittests/NonOwningFrozenSetTests.cpp
+++ b/unittests/NonOwningFrozenSetTests.cpp
@@ -1,0 +1,86 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_range_equals.hpp>
+
+#include <llvm/ADT/StringRef.h>
+
+#include <jllvm/support/NonOwningFrozenSet.hpp>
+
+using namespace jllvm;
+using namespace Catch::Matchers;
+
+TEST_CASE("Construction", "[NonOwningFrozenSet]")
+{
+    llvm::BumpPtrAllocator allocator;
+    std::vector<std::size_t> v = {3, 5, 7};
+
+    NonOwningFrozenSet set(v, allocator);
+
+    CHECK_THAT(set, RangeEquals(v));
+    CHECK_FALSE(set.empty());
+
+    CHECK(set.find(2) == set.end());
+    CHECK(set.find(3) != set.end());
+
+    STATIC_REQUIRE(std::is_standard_layout_v<decltype(set)>);
+}
+
+namespace
+{
+struct Thing
+{
+    llvm::StringRef name;
+    std::size_t data;
+
+    bool operator==(const Thing&) const = default;
+
+    bool operator==(llvm::StringRef other) const
+    {
+        return name == other;
+    }
+};
+
+llvm::hash_code hash_value(const Thing& thing)
+{
+    return hash_value(thing.name);
+}
+
+} // namespace
+
+TEST_CASE("Heterogeneous lookup", "[NonOwningFrozenSet]")
+{
+    llvm::BumpPtrAllocator allocator;
+    std::vector<Thing> v = {{"Hello", 3}, {"World", 5}, {"!", 7}};
+
+    NonOwningFrozenSet set(v, allocator);
+
+    CHECK_THAT(set, RangeEquals(v));
+    CHECK_FALSE(set.empty());
+
+    CHECK(set.find(llvm::StringRef{"..."}) == set.end());
+
+    const auto* lookup = set.find(llvm::StringRef{"Hello"});
+    REQUIRE(lookup != set.end());
+    CHECK(lookup->data == 3);
+
+    lookup = set.find(llvm::StringRef{"World"});
+    REQUIRE(lookup != set.end());
+    CHECK(lookup->data == 5);
+
+    lookup = set.find(llvm::StringRef{"!"});
+    REQUIRE(lookup != set.end());
+    CHECK(lookup->data == 7);
+}
+
+TEST_CASE("Empty Set", "[NonOwningFrozenSet]")
+{
+    llvm::BumpPtrAllocator allocator;
+    std::vector<std::size_t> v;
+
+    NonOwningFrozenSet set(v, allocator);
+
+    CHECK_THAT(set, RangeEquals(v));
+
+    CHECK(set.empty());
+    CHECK(set.find(2) == set.end());
+    CHECK(set.find(3) == set.end());
+}


### PR DESCRIPTION
These new methods 1) make use of the new frozen set for more convenient lookup 2) are more generic allowing arbitrary predicates to be used to search. Looking up either instance or static fields are particular often used functions and have been given their own methods.

Additionally, to make the result of these methods more useful, `Method` now has a pointer to its containing `ClassObject`.

Depends on https://github.com/JLLVM/JLLVM/pull/184