### PR TITLE
[object][NFC] make `GCRootRef` implicitly convertible to `T*`

### DIFF
--- a/src/jllvm/gc/GarbageCollector.cpp
+++ b/src/jllvm/gc/GarbageCollector.cpp
@@ -46,7 +46,7 @@ jllvm::GarbageCollector::GarbageCollector(std::size_t heapSize)
 
 namespace
 {
-class ObjectRepr
+class ObjectRepr : public jllvm::ObjectInterface
 {
     llvm::PointerIntPair<jllvm::ClassObject*, 1, bool> m_classObject;
 

--- a/src/jllvm/gc/RootFreeList.hpp
+++ b/src/jllvm/gc/RootFreeList.hpp
@@ -65,6 +65,16 @@ public:
     {
     }
 
+    /// Assignment operator required to make assignment from another 'GCRootRef' not ambiguous.
+    /// This does not copy the root, but rather assigns the object within 'rhs' to this root.
+    /// Rational for this is that null 'GCRootRef's do not exist (and 'GCRootRef' does not have a default constructor),
+    /// making a rootless 'GCRootRef' basically not a thing.
+    template <std::derived_from<T> U>
+    GCRootRef& operator=(GCRootRef<U> rhs) requires(!std::is_same_v<T, U>)
+    {
+        return *this = rhs.address();
+    }
+
     /// Explicit cast to a 'GCRootRef' of another type. This allows both up and down casting and does not perform any
     /// validity checks. It is therefore up to the user to make sure the cast is valid.
     template <class U>
@@ -75,7 +85,7 @@ public:
 
     /// Explicit cast to 'T*'. This operation should generally be avoided in favour of just using the 'GCRootRef' as
     /// intended.
-    explicit operator T*() const
+    /*implicit*/ operator T*() const
     {
         return get();
     }
@@ -92,12 +102,6 @@ public:
     friend bool operator==(GCRootRef<T> lhs, GCRootRef<U> rhs)
     {
         return lhs.get() == static_cast<U*>(rhs);
-    }
-
-    /// Returns true if 'lhs' and 'rhs' refer to the same object.
-    friend bool operator==(GCRootRef<T> lhs, const T* object)
-    {
-        return lhs.get() == object;
     }
 
     /// Returns true if this root contains a reference to an object instead of null.

--- a/src/jllvm/object/Object.hpp
+++ b/src/jllvm/object/Object.hpp
@@ -70,11 +70,27 @@ public:
     }
 };
 
-class Object;
+/// In memory representation for a general Java object.
+class Object : public ObjectInterface
+{
+    ObjectHeader m_header;
+
+public:
+    explicit Object(const ClassObject* classObject) : m_header(classObject) {}
+};
+
+static_assert(std::is_standard_layout_v<Object>);
+
+/// Concept for any type that is compatible with Java objects in their object representation.
+/// This should be used in places when doing interop that require the storage/value to be identical to the corresponding
+/// Java type.
+template <class T>
+concept JavaCompatible =
+    std::is_arithmetic_v<T> || std::is_void_v<T> || std::is_base_of_v<ObjectInterface, std::remove_pointer_t<T>>;
 
 /// In memory representation of Java array with component type 'T'.
 /// 'T' is always either a primitive or a pointer to Java objects.
-template <class T = Object*>
+template <JavaCompatible T = ObjectInterface*>
 class Array : public ObjectInterface
 {
     ObjectHeader m_header;
@@ -157,17 +173,6 @@ public:
 };
 
 static_assert(std::is_standard_layout_v<Array<>>);
-
-/// In memory representation for a general Java object.
-class Object : public ObjectInterface
-{
-    ObjectHeader m_header;
-
-public:
-    explicit Object(const ClassObject* classObject) : m_header(classObject) {}
-};
-
-static_assert(std::is_standard_layout_v<Object>);
 
 /// In memory representation for a Java String.
 class String : public ObjectInterface

--- a/src/jllvm/vm/InteropHelpers.hpp
+++ b/src/jllvm/vm/InteropHelpers.hpp
@@ -1,0 +1,58 @@
+// Copyright (C) 2023 The JLLVM Contributors.
+//
+// This file is part of JLLVM.
+//
+// JLLVM is free software; you can redistribute it and/or modify it under  the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 3, or (at your option) any later version.
+//
+// JLLVM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with JLLVM; see the file LICENSE.txt.  If not
+// see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <llvm/ExecutionEngine/JITSymbol.h>
+
+#include <jllvm/gc/RootFreeList.hpp>
+#include <jllvm/object/ClassObject.hpp>
+
+#include <concepts>
+#include <type_traits>
+
+namespace jllvm
+{
+
+namespace detail
+{
+// JavaCompatible types convert to themselves.
+template <JavaCompatible T>
+T javaConvertedType(T);
+
+// GCRootRefs convert to their contained object.
+template <class T>
+T* javaConvertedType(GCRootRef<T>);
+
+} // namespace detail
+
+/// Type alias returning the 'JavaCompatible' type a 'JavaConvertible' type implicitly converts to.
+template <class T>
+using JavaConvertedType = decltype(detail::javaConvertedType(std::declval<T>()));
+
+/// Concept for any type that is known to implicitly convert to a 'JavaCompatible' type.
+template <class T>
+concept JavaConvertible = !std::is_void_v<T> && requires
+{
+    JavaCompatible<JavaConvertedType<T>>;
+};
+
+/// Helper function to call 'fnPtr', which is known to be a Java function, with the given 'args'.
+/// Does implicit conversion of 'args' their 'JavaCompatible' type.
+template <JavaCompatible Ret, JavaConvertible... Args>
+Ret invokeJava(llvm::JITEvaluatedSymbol fnPtr, Args... args)
+{
+    return reinterpret_cast<Ret (*)(JavaConvertedType<Args>...)>(fnPtr.getAddress())(args...);
+}
+
+} // namespace jllvm

--- a/src/jllvm/vm/VirtualMachine.cpp
+++ b/src/jllvm/vm/VirtualMachine.cpp
@@ -194,7 +194,8 @@ jllvm::VirtualMachine::VirtualMachine(BootOptions&& bootOptions)
                       assert(!classObject->isInitialized());
                       initialize(*classObject);
                   }},
-        std::pair{"jllvm_build_class_cast_exception", [&](Object* object, ClassObject* classObject)
+        std::pair{"jllvm_build_class_cast_exception",
+                  [&](Object* object, ClassObject* classObject) -> Object*
                   {
                       llvm::StringRef className = object->getClass()->getClassName();
                       llvm::StringRef prefix;
@@ -213,7 +214,7 @@ jllvm::VirtualMachine::VirtualMachine(BootOptions&& bootOptions)
                       GCUniqueRoot root =
                           m_gc.root(m_gc.allocate(&m_classLoader.forName("Ljava/lang/ClassCastException;")));
                       executeObjectConstructor(root, "(Ljava/lang/String;)V", string);
-                      return static_cast<Object*>(root);
+                      return root;
                   }},
         std::pair{"jllvm_push_local_frame", [&] { m_gc.pushLocalFrame(); }},
         std::pair{"jllvm_pop_local_frame", [&] { m_gc.popLocalFrame(); }});
@@ -243,7 +244,7 @@ jllvm::VirtualMachine::VirtualMachine(BootOptions&& bootOptions)
     m_mainThread->priority = 1;
     m_mainThread->threadStatus = ThreadState::Runnable;
 
-    executeObjectConstructor(m_mainThread, "(Ljava/lang/ThreadGroup;Ljava/lang/String;)V", m_mainThreadGroup.address(),
+    executeObjectConstructor(m_mainThread, "(Ljava/lang/ThreadGroup;Ljava/lang/String;)V", m_mainThreadGroup,
                              m_stringInterner.intern("main"));
 
     initialize(m_classLoader.forName("Ljava/lang/System;"));

--- a/src/jllvm/vm/native/JDK.hpp
+++ b/src/jllvm/vm/native/JDK.hpp
@@ -65,28 +65,26 @@ public:
 
 class UnsafeModel : public ModelBase<>
 {
-    template <class T>
-    bool compareAndSet(GCRootRef<Object> object, std::uint64_t offset, T expected, T desired)
+    template <JavaCompatible T>
+    bool compareAndSet(Object* object, std::uint64_t offset, T expected, T desired)
     {
         // TODO: use C++20 std::atomic_ref instead of atomic builtins in the future.
-        return __atomic_compare_exchange_n(reinterpret_cast<T*>(reinterpret_cast<char*>(object.address()) + offset),
-                                           &expected, desired, false, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+        return __atomic_compare_exchange_n(reinterpret_cast<T*>(reinterpret_cast<char*>(object) + offset), &expected,
+                                           desired, false, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
     }
 
-    template <class T>
-    T getVolatile(GCRootRef<Object> object, std::uint64_t offset)
+    template <JavaCompatible T>
+    T getVolatile(Object* object, std::uint64_t offset)
     {
         // TODO: use C++20 std::atomic_ref instead of atomic builtins in the future.
-        return __atomic_load_n(reinterpret_cast<T*>(reinterpret_cast<char*>(object.address()) + offset),
-                               __ATOMIC_SEQ_CST);
+        return __atomic_load_n(reinterpret_cast<T*>(reinterpret_cast<char*>(object) + offset), __ATOMIC_SEQ_CST);
     }
 
-    template <class T>
-    void putVolatile(GCRootRef<Object> object, std::uint64_t offset, T value)
+    template <JavaCompatible T>
+    void putVolatile(Object* object, std::uint64_t offset, T value)
     {
         // TODO: use C++20 std::atomic_ref instead of atomic builtins in the future.
-        __atomic_store_n(reinterpret_cast<T*>(reinterpret_cast<char*>(object.address()) + offset), value,
-                         __ATOMIC_SEQ_CST);
+        __atomic_store_n(reinterpret_cast<T*>(reinterpret_cast<char*>(object) + offset), value, __ATOMIC_SEQ_CST);
     }
 
 public:

--- a/src/jllvm/vm/native/Lang.cpp
+++ b/src/jllvm/vm/native/Lang.cpp
@@ -87,7 +87,8 @@ void jllvm::lang::SystemModel::arraycopy(jllvm::VirtualMachine&, jllvm::GCRootRe
         return;
     }
 
-    for (Object* object : llvm::ArrayRef<Object*>{srcArr->begin(), srcArr->end()}.slice(srcPos, length))
+    for (ObjectInterface* object :
+         llvm::ArrayRef<ObjectInterface*>{srcArr->begin(), srcArr->end()}.slice(srcPos, length))
     {
         if (object && !object->instanceOf(destComp))
         {

--- a/unittests/GarbageCollectorTests.cpp
+++ b/unittests/GarbageCollectorTests.cpp
@@ -110,11 +110,6 @@ SCENARIO_METHOD(GarbageCollectorFixture, "GCUniqueRoot Behaviour", "[GCUniqueRoo
             STATIC_CHECK(std::is_convertible_v<GCUniqueRoot<Object>, GCRootRef<Object>>);
         }
 
-        THEN("it cannot be assigned a GCRootRef")
-        {
-            STATIC_CHECK_FALSE(std::is_assignable_v<GCUniqueRoot<Object>, GCRootRef<Object>>);
-        }
-
         AND_WHEN("reset")
         {
             root.reset();


### PR DESCRIPTION
Previously, any API taking a `T*` would require explicitly casting a `GCRootRef`, either via `static_cast` or `.address()` to get the address of the contained object. This made using `GCRootRef` less comfortable then it has to be and made its behaviour differ to `Object*` from a user perspective in a few places. Worst of all, wanting to avoid these explicit casts would often lead to APIs taking `GCRootRef<T>` parameters instead of `T*` parameters despite the latter being the better more generic choice if no GCs can occur during those function calls.

This PR therefore makes the conversion operator to 'T*' implicit. The advantages of this is the useability in all the previously mentioned scenarios. The disadvantages are that one could deem it as non-obvious "magic" and the potential for confusing behaviour in templates (where the implicit conversion would not occur). For the latter issue, the `JavaCompatible` and `JavaConvertible` concepts were added to make sure that a template type is of an expected type. `JavaConvertible` in particular can be used with the `JavaConvertedType` alias to then force required implicit conversions to `JavaCompatible` types as well.