### PR TITLE
[object][NFC] add `InstanceFieldRef` and `StaticFieldRef` concepts

### DIFF
--- a/src/jllvm/object/Object.hpp
+++ b/src/jllvm/object/Object.hpp
@@ -237,38 +237,6 @@ enum class ThreadState : std::int32_t
 };
 LLVM_ENABLE_BITMASK_ENUMS_IN_NAMESPACE();
 
-struct Thread : ObjectInterface
-{
-    ObjectHeader header;
-
-    String* name{};
-    std::int32_t priority{};
-    bool daemon{};
-    bool interrupted{};
-    bool stillborn{};
-    std::int64_t eetop{};
-    Object* target{};
-    Object* group{};
-    Object* contextClassLoader{};
-    Object* inheritedAccessControlContext{};
-    Object* threadLocals{};
-    Object* inheritableThreadLocals{};
-    std::int64_t stackSize{};
-    std::int64_t tid{};
-    ThreadState threadStatus{};
-    Object* parkBlocker{};
-    Object* blocker{};
-    Object* blockerLock{};
-    Object* uncaughtExceptionHandler{};
-    std::int64_t threadLocalRandomSeed{};
-    std::int32_t threadLocalRandomProbe{};
-    std::int32_t threadLocalSecondarySeed{};
-
-    explicit Thread(const ClassObject* classObject) : header(classObject) {}
-};
-
-static_assert(std::is_standard_layout_v<Thread>);
-
 struct Reference : ObjectInterface
 {
     ObjectHeader header;

--- a/src/jllvm/vm/InteropHelpers.hpp
+++ b/src/jllvm/vm/InteropHelpers.hpp
@@ -42,10 +42,7 @@ using JavaConvertedType = decltype(detail::javaConvertedType(std::declval<T>()))
 
 /// Concept for any type that is known to implicitly convert to a 'JavaCompatible' type.
 template <class T>
-concept JavaConvertible = !std::is_void_v<T> && requires
-{
-    JavaCompatible<JavaConvertedType<T>>;
-};
+concept JavaConvertible = !std::is_void_v<T> && JavaCompatible<JavaConvertedType<T>>;
 
 /// Helper function to call 'fnPtr', which is known to be a Java function, with the given 'args'.
 /// Does implicit conversion of 'args' their 'JavaCompatible' type.

--- a/src/jllvm/vm/VirtualMachine.cpp
+++ b/src/jllvm/vm/VirtualMachine.cpp
@@ -238,11 +238,12 @@ jllvm::VirtualMachine::VirtualMachine(BootOptions&& bootOptions)
 
     ClassObject& thread = m_classLoader.forName("Ljava/lang/Thread;");
     initialize(thread);
-    m_mainThread = m_gc.allocate<Thread>(&thread);
+    m_mainThread = m_gc.allocate(&thread);
 
     // These have to be set prior to the constructor for the constructor not to fail.
-    m_mainThread->priority = 1;
-    m_mainThread->threadStatus = ThreadState::Runnable;
+    thread.getInstanceField<std::int32_t>("priority", "I")(m_mainThread) = 1;
+    thread.getInstanceField<std::int32_t>("threadStatus", "I")(m_mainThread) =
+        static_cast<std::int32_t>(ThreadState::Runnable);
 
     executeObjectConstructor(m_mainThread, "(Ljava/lang/ThreadGroup;Ljava/lang/String;)V", m_mainThreadGroup,
                              m_stringInterner.intern("main"));

--- a/src/jllvm/vm/VirtualMachine.hpp
+++ b/src/jllvm/vm/VirtualMachine.hpp
@@ -52,7 +52,7 @@ class VirtualMachine
     JIT m_jit = JIT::create(m_classLoader, m_gc, m_stringInterner, m_jniEnv.get());
     std::mt19937 m_pseudoGen;
     std::uniform_int_distribution<std::uint32_t> m_hashIntDistrib;
-    GCRootRef<Thread> m_mainThread = static_cast<GCRootRef<Thread>>(m_gc.allocateStatic());
+    GCRootRef<Object> m_mainThread = m_gc.allocateStatic();
     GCRootRef<Object> m_mainThreadGroup = m_gc.allocateStatic();
     std::string m_javaHome;
 
@@ -88,7 +88,7 @@ public:
     }
 
     /// Returns the main thread this VM is started on.
-    GCRootRef<Thread> getMainThread() const
+    GCRootRef<Object> getMainThread() const
     {
         return m_mainThread;
     }

--- a/src/jllvm/vm/native/Lang.hpp
+++ b/src/jllvm/vm/native/Lang.hpp
@@ -191,20 +191,20 @@ public:
 
     static void setIn0(VirtualMachine&, GCRootRef<ClassObject> classObject, GCRootRef<Object> stream)
     {
-        const void* addr = classObject->getStaticField("in", "Ljava/io/InputStream;")->getAddressOfStatic();
-        std::memcpy(const_cast<void*>(addr), stream.data(), sizeof(Object*));
+        StaticFieldRef<Object*> in = classObject->getStaticField<Object*>("in", "Ljava/io/InputStream;");
+        in() = stream;
     }
 
     static void setOut0(VirtualMachine&, GCRootRef<ClassObject> classObject, GCRootRef<Object> stream)
     {
-        const void* addr = classObject->getStaticField("out", "Ljava/io/PrintStream;")->getAddressOfStatic();
-        std::memcpy(const_cast<void*>(addr), stream.data(), sizeof(Object*));
+        StaticFieldRef<Object*> out = classObject->getStaticField<Object*>("out", "Ljava/io/PrintStream;");
+        out() = stream;
     }
 
     static void setErr0(VirtualMachine&, GCRootRef<ClassObject> classObject, GCRootRef<Object> stream)
     {
-        const void* addr = classObject->getStaticField("err", "Ljava/io/PrintStream;")->getAddressOfStatic();
-        std::memcpy(const_cast<void*>(addr), stream.data(), sizeof(Object*));
+        StaticFieldRef<Object*> err = classObject->getStaticField<Object*>("err", "Ljava/io/PrintStream;");
+        err() = stream;
     }
 
     constexpr static llvm::StringLiteral className = "java/lang/System";
@@ -232,7 +232,7 @@ public:
     constexpr static auto methods = std::make_tuple(&RuntimeModel::maxMemory, &RuntimeModel::availableProcessors);
 };
 
-class ThreadModel : public ModelBase<Thread>
+class ThreadModel : public ModelBase<>
 {
 public:
     using Base::Base;
@@ -242,7 +242,7 @@ public:
         // Noop in our implementation.
     }
 
-    static GCRootRef<Thread> currentThread(VirtualMachine& vm, GCRootRef<ClassObject>)
+    static GCRootRef<Object> currentThread(VirtualMachine& vm, GCRootRef<ClassObject>)
     {
         // Once we are multi threaded, this should actually the return the corresponding Java thread
         // this function is being called from. For now we are just returning the one and only thread for the time being.
@@ -251,7 +251,8 @@ public:
 
     void setPriority0(std::int32_t priority)
     {
-        javaThis->priority = priority;
+        auto priorityField = javaThis->getClass()->getInstanceField<std::int32_t>("priority", "I");
+        priorityField(javaThis) = priority;
     }
 
     constexpr static llvm::StringLiteral className = "java/lang/Thread";


### PR DESCRIPTION
These classes serve as strongly typed wrappers around a `Field*` allowing more convenient access to a field from C++ code. Access is modeled via the call operator, returning a reference to either the static field or the instance field of an object.

The most important use-case for these is for native interop. Previously, we were forced to create a C++ type mirroring the Java object layout to be able to access any of its fields conveniently. This creates a tight coupling between the C++ type and the corresponding class file which was very fragile as the layout can easily change.

With these new classes, we can instead search for the field in question and use it directly. The only coupling remaining are the field name and type which are less fragile than the memory layout of the containing object.

This has been done with the `Thread` class in this PR as a demonstration.

Using a mirrored C++ type is still recommended in scenarios requiring performance.

Depends on https://github.com/JLLVM/JLLVM/pull/187