### PR TITLE
[refactor][NFC] Refactor entire codebase to use new descriptor class

### DIFF
--- a/src/jllvm/class/ClassFile.cpp
+++ b/src/jllvm/class/ClassFile.cpp
@@ -272,9 +272,9 @@ llvm::StringRef FieldInfo::getName(const ClassFile& classFile) const
     return m_nameIndex.resolve(classFile)->text;
 }
 
-llvm::StringRef FieldInfo::getDescriptor(const jllvm::ClassFile& classFile) const
+FieldType FieldInfo::getDescriptor(const jllvm::ClassFile& classFile) const
 {
-    return m_descriptorIndex.resolve(classFile)->text;
+    return FieldType(m_descriptorIndex.resolve(classFile)->text);
 }
 
 llvm::StringRef MethodInfo::getName(const ClassFile& classFile) const
@@ -282,7 +282,7 @@ llvm::StringRef MethodInfo::getName(const ClassFile& classFile) const
     return m_nameIndex.resolve(classFile)->text;
 }
 
-llvm::StringRef MethodInfo::getDescriptor(const jllvm::ClassFile& classFile) const
+MethodType MethodInfo::getDescriptor(const jllvm::ClassFile& classFile) const
 {
-    return m_descriptorIndex.resolve(classFile)->text;
+    return MethodType(m_descriptorIndex.resolve(classFile)->text);
 }

--- a/src/jllvm/class/ClassFile.hpp
+++ b/src/jllvm/class/ClassFile.hpp
@@ -27,6 +27,8 @@
 
 #include <swl/variant.hpp>
 
+#include "Descriptors.hpp"
+
 namespace jllvm
 {
 struct ClassFile;
@@ -342,7 +344,7 @@ public:
     llvm::StringRef getName(const ClassFile& classFile) const;
 
     /// Returns the field descriptor of this field, indicating its type.
-    llvm::StringRef getDescriptor(const ClassFile& classFile) const;
+    FieldType getDescriptor(const ClassFile& classFile) const;
 
     /// Returns the attributes of this field.
     const AttributeMap& getAttributes() const
@@ -403,7 +405,7 @@ public:
     llvm::StringRef getName(const ClassFile& classFile) const;
 
     /// Returns the method descriptor of this method, indicating its type.
-    llvm::StringRef getDescriptor(const ClassFile& classFile) const;
+    MethodType getDescriptor(const ClassFile& classFile) const;
 
     /// Returns the attributes of this method.
     const AttributeMap& getAttributes() const

--- a/src/jllvm/class/Descriptors.hpp
+++ b/src/jllvm/class/Descriptors.hpp
@@ -218,22 +218,6 @@ public:
     constexpr bool operator==(const ArrayType&) const = default;
 };
 
-/// Parses a field descriptor string to a more convenient object representation.
-/// The lifetime of any strings (basically any contained 'ObjectType's) is equal to the lifetime of the string passed
-/// in.
-/// Note: This function does not allow error handling at this point in time and either exhibits UB or asserts
-/// on invalid strings.
-inline FieldType parseFieldType(llvm::StringRef string)
-{
-    return FieldType(string);
-}
-
-/// Returns true if the string descriptor indicates a reference type.
-inline bool isReferenceDescriptor(llvm::StringRef string)
-{
-    return string.front() == 'L' || string.front() == '[';
-}
-
 /// <MethodType> ::= '(' { <FieldType> } ')' <FieldType>
 class MethodType
 {
@@ -382,13 +366,6 @@ public:
         return m_retBegin == rhs.m_retBegin && m_parameterCount == rhs.m_parameterCount && textual() == rhs.textual();
     }
 };
-
-/// Parses a method descriptor string to a more convenient object representation.
-/// Same notes about lifetimes and error handling apply as in 'parseFieldType'.
-inline MethodType parseMethodType(llvm::StringRef string)
-{
-    return MethodType(string);
-}
 
 /// Visitor implementation for 'FieldType' analogous to 'std::visit'.
 /// Can be used together with 'match'.

--- a/src/jllvm/materialization/ByteCodeCompileLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeCompileLayer.cpp
@@ -30,7 +30,7 @@ void jllvm::ByteCodeCompileLayer::emit(std::unique_ptr<llvm::orc::Materializatio
     auto context = std::make_unique<llvm::LLVMContext>();
     auto module = std::make_unique<llvm::Module>(methodName, *context);
 
-    MethodType descriptor = parseMethodType(methodInfo->getDescriptor(*classFile));
+    MethodType descriptor = methodInfo->getDescriptor(*classFile);
 
     auto* function =
         llvm::Function::Create(descriptorToType(descriptor, methodInfo->isStatic(), module->getContext()),

--- a/src/jllvm/materialization/ByteCodeLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeLayer.cpp
@@ -19,16 +19,16 @@
 
 #include "ByteCodeMaterializationUnit.hpp"
 
-std::string jllvm::mangleMethod(llvm::StringRef className, llvm::StringRef methodName, llvm::StringRef descriptor)
+std::string jllvm::mangleMethod(llvm::StringRef className, llvm::StringRef methodName, MethodType descriptor)
 {
-    return (className + "." + methodName + ":" + descriptor).str();
+    return (className + "." + methodName + ":" + descriptor.textual()).str();
 }
 
 std::string jllvm::mangleMethod(const MethodInfo& methodInfo, const ClassFile& classFile)
 {
     llvm::StringRef className = classFile.getThisClass();
     llvm::StringRef methodName = methodInfo.getName(classFile);
-    llvm::StringRef descriptor = methodInfo.getDescriptor(classFile);
+    MethodType descriptor = methodInfo.getDescriptor(classFile);
 
     return mangleMethod(className, methodName, descriptor);
 }

--- a/src/jllvm/materialization/ByteCodeLayer.hpp
+++ b/src/jllvm/materialization/ByteCodeLayer.hpp
@@ -20,7 +20,7 @@
 
 namespace jllvm
 {
-std::string mangleMethod(llvm::StringRef className, llvm::StringRef methodName, llvm::StringRef descriptor);
+std::string mangleMethod(llvm::StringRef className, llvm::StringRef methodName, MethodType descriptor);
 
 std::string mangleMethod(const Method* method);
 

--- a/src/jllvm/materialization/CodeGenerator.hpp
+++ b/src/jllvm/materialization/CodeGenerator.hpp
@@ -36,7 +36,7 @@ class CodeGenerator
     const ClassFile& m_classFile;
     LazyClassLoaderHelper m_helper;
     StringInterner& m_stringInterner;
-    const MethodType& m_functionMethodType;
+    MethodType m_functionMethodType;
     llvm::IRBuilder<> m_builder;
     llvm::DIBuilder m_debugBuilder;
     OperandStack m_operandStack;
@@ -65,11 +65,11 @@ class CodeGenerator
 
     llvm::Value* loadClassObjectFromPool(PoolIndex<ClassInfo> index);
 
-    llvm::Value* generateAllocArray(llvm::StringRef descriptor, llvm::Value* classObject, llvm::Value* size);
+    llvm::Value* generateAllocArray(ArrayType descriptor, llvm::Value* classObject, llvm::Value* size);
 
 public:
     CodeGenerator(llvm::Function* function, const ClassFile& classFile, LazyClassLoaderHelper helper,
-                  StringInterner& stringInterner, const MethodType& methodType, std::uint16_t maxStack,
+                  StringInterner& stringInterner, MethodType methodType, std::uint16_t maxStack,
                   std::uint16_t maxLocals)
         : m_function{function},
           m_classFile{classFile},

--- a/src/jllvm/materialization/CodeGeneratorUtils.hpp
+++ b/src/jllvm/materialization/CodeGeneratorUtils.hpp
@@ -165,23 +165,23 @@ class LazyClassLoaderHelper
     static void buildClassInitializerInitStub(llvm::IRBuilder<>& builder, const ClassObject& classObject);
 
     template <class F>
-    llvm::Value* returnConstantForClassObject(llvm::IRBuilder<>& builder, llvm::Twine fieldDescriptor, llvm::Twine key,
+    llvm::Value* returnConstantForClassObject(llvm::IRBuilder<>& builder, FieldType fieldDescriptor, llvm::Twine key,
                                               F&& f, bool mustInitializeClassObject);
 
     template <class F>
     llvm::Value* doCallForClassObject(llvm::IRBuilder<>& builder, llvm::StringRef className, llvm::StringRef methodName,
-                                      llvm::StringRef methodType, bool isStatic, llvm::Twine key,
+                                      MethodType methodType, bool isStatic, llvm::Twine key,
                                       llvm::ArrayRef<llvm::Value*> args, F&& f);
 
-    static const Method* methodResolution(const ClassObject* classObject, llvm::StringRef methodName, llvm::StringRef methodType);
+    static const Method* methodResolution(const ClassObject* classObject, llvm::StringRef methodName,
+                                          MethodType methodType);
 
     static const Method* interfaceMethodResolution(const ClassObject* classObject, llvm::StringRef methodName,
-                                                                                  llvm::StringRef methodType,
-                                                                                  ClassLoader& classLoader);
+                                                   MethodType methodType, ClassLoader& classLoader);
 
     static const Method* specialMethodResolution(const ClassObject* referencedClassObject, llvm::StringRef methodName,
-                                llvm::StringRef methodType, ClassLoader& classLoader, const ClassObject* currentClass,
-                                const ClassFile* currentClassFile);
+                                                 MethodType methodType, ClassLoader& classLoader,
+                                                 const ClassObject* currentClass, const ClassFile* currentClassFile);
 
 public:
     LazyClassLoaderHelper(ClassLoader& classLoader, llvm::orc::JITDylib& mainDylib, llvm::orc::JITDylib& implDylib,
@@ -207,7 +207,7 @@ public:
     /// Creates a non-virtual call to the static function 'methodName' of the type 'methodType' within
     /// 'className' using 'args'. This is used to implement `invokestatic`.
     llvm::Value* doStaticCall(llvm::IRBuilder<>& builder, llvm::StringRef className, llvm::StringRef methodName,
-                              llvm::StringRef methodType, llvm::ArrayRef<llvm::Value*> args);
+                              MethodType methodType, llvm::ArrayRef<llvm::Value*> args);
 
     enum MethodResolution
     {
@@ -222,21 +222,20 @@ public:
     /// Creates a virtual call to the function 'methodName' of the type 'methodType' within 'className' using 'args'.
     /// 'resolution' determines how the actual method to be called is resolved using the previously mentioned strings.
     llvm::Value* doInstanceCall(llvm::IRBuilder<>& builder, llvm::StringRef className, llvm::StringRef methodName,
-                                llvm::StringRef methodType, llvm::ArrayRef<llvm::Value*> args,
-                                MethodResolution resolution);
+                                MethodType methodType, llvm::ArrayRef<llvm::Value*> args, MethodResolution resolution);
 
     /// Returns an LLVM integer constant which contains the offset of the 'fieldName' with the type 'fieldType'
     /// within the class 'className'.
     llvm::Value* getInstanceFieldOffset(llvm::IRBuilder<>& builder, llvm::StringRef className,
-                                        llvm::StringRef fieldName, llvm::StringRef fieldType);
+                                        llvm::StringRef fieldName, FieldType fieldType);
 
     /// Returns an LLVM Pointer which points to the static field 'fieldName' with the type 'fieldType'
     /// within the class 'className'.
     llvm::Value* getStaticFieldAddress(llvm::IRBuilder<>& builder, llvm::StringRef className, llvm::StringRef fieldName,
-                                       llvm::StringRef fieldType);
+                                       FieldType fieldType);
 
     /// Returns an LLVM Pointer which points to the class object of the type with the given field descriptor.
-    llvm::Value* getClassObject(llvm::IRBuilder<>& builder, llvm::Twine fieldDescriptor,
+    llvm::Value* getClassObject(llvm::IRBuilder<>& builder, FieldType fieldDescriptor,
                                 bool mustInitializeClassObject = false);
 };
 } // namespace jllvm

--- a/src/jllvm/materialization/JNIImplementationLayer.hpp
+++ b/src/jllvm/materialization/JNIImplementationLayer.hpp
@@ -25,8 +25,9 @@ namespace jllvm
 /// Applies the JNI name mangling to create the corresponding C symbol name for the given 'methodName' inside of
 /// 'className'. If 'methodDescriptor' is non empty, it must be a valid method descriptor whose parameter types are
 /// then also encoded in the symbol name (to allow overloading).
-std::string formJNIMethodName(llvm::StringRef className, llvm::StringRef methodName,
-                              llvm::StringRef methodDescriptor = {});
+std::string formJNIMethodName(llvm::StringRef className, llvm::StringRef methodName, MethodType methodType);
+
+std::string formJNIMethodName(llvm::StringRef className, llvm::StringRef methodName);
 
 /// Layer implementing all JIT functionality related to the Java Native Interface. It is also where any JNI symbols
 /// must be registered to be called at runtime. Its implementation roughly boils down to creating compile stubs for any

--- a/src/jllvm/object/ClassLoader.hpp
+++ b/src/jllvm/object/ClassLoader.hpp
@@ -33,7 +33,7 @@ namespace jllvm
 class ClassLoader
 {
     llvm::BumpPtrAllocator m_classAllocator;
-    llvm::StringMap<ClassObject*> m_mapping;
+    llvm::DenseMap<FieldType, ClassObject*> m_mapping;
 
     llvm::BumpPtrAllocator m_stringAllocator;
     llvm::StringSaver m_stringSaver{m_stringAllocator};
@@ -80,11 +80,11 @@ public:
 
     /// Returns the class object for 'fieldDescriptor', which must be a valid field descriptor, loading it and
     /// transitive dependencies if required. Currently aborts if a class file could not be loaded.
-    ClassObject& forName(llvm::Twine fieldDescriptor);
+    ClassObject& forName(FieldType fieldType);
 
     /// Returns the class object for 'fieldDescriptor', which must be a valid field descriptor,
     /// if it has been loaded previously. Null otherwise.
-    ClassObject* forNameLoaded(llvm::Twine fieldDescriptor);
+    ClassObject* forNameLoaded(FieldType fieldType);
 
     /// Loads java classes required to boot up the VM. This a separate method and not executed as part of the
     /// constructor as it requires the VM to already be ready to execute JVM Bytecode (one that does not depend on the

--- a/src/jllvm/object/ClassObject.cpp
+++ b/src/jllvm/object/ClassObject.cpp
@@ -58,7 +58,7 @@ jllvm::ClassObject* jllvm::ClassObject::create(llvm::BumpPtrAllocator& allocator
 
     for (const Field& iter : fields)
     {
-        if (iter.isStatic() || !isReferenceDescriptor(iter.getType()))
+        if (iter.isStatic() || !iter.getType().isReference())
         {
             continue;
         }

--- a/src/jllvm/vm/JIT.hpp
+++ b/src/jllvm/vm/JIT.hpp
@@ -159,7 +159,7 @@ public:
     /// Looks up the method 'methodName' within the class 'className' with the type given by 'methodDescriptor'
     /// returning a pointer to the function if successful or an error otherwise.
     llvm::Expected<llvm::JITEvaluatedSymbol> lookup(llvm::StringRef className, llvm::StringRef methodName,
-                                                    llvm::StringRef methodDescriptor)
+                                                    MethodType methodDescriptor)
     {
         return m_session->lookup({&m_main}, m_interner(mangleMethod(className, methodName, methodDescriptor)));
     }

--- a/src/jllvm/vm/StringInterner.hpp
+++ b/src/jllvm/vm/StringInterner.hpp
@@ -22,8 +22,8 @@ namespace jllvm
 {
 class StringInterner
 {
-    static constexpr auto stringDescriptor = "Ljava/lang/String;";
-    static constexpr auto byteArrayDescriptor = "[B";
+    static constexpr FieldType stringDescriptor = "Ljava/lang/String;";
+    static constexpr FieldType byteArrayDescriptor = "[B";
 
     llvm::DenseMap<std::pair<llvm::ArrayRef<std::uint8_t>, std::uint8_t>, String*> m_contentToStringMap;
     llvm::BumpPtrAllocator m_allocator;

--- a/src/jllvm/vm/VirtualMachine.cpp
+++ b/src/jllvm/vm/VirtualMachine.cpp
@@ -182,7 +182,8 @@ jllvm::VirtualMachine::VirtualMachine(BootOptions&& bootOptions)
     m_jit.addImplementationSymbols(
         std::pair{"fmodf", &fmodf},
         std::pair{"jllvm_gc_alloc", [&](std::uint32_t size) { return m_gc.allocate(size); }},
-        std::pair{"jllvm_for_name_loaded", [&](const char* name) { return m_classLoader.forNameLoaded(name); }},
+        std::pair{"jllvm_for_name_loaded",
+                  [&](const char* name) { return m_classLoader.forNameLoaded(FieldType(name)); }},
         std::pair{"jllvm_instance_of",
                   [](const Object* object, const ClassObject* classObject) -> std::int32_t
                   { return object->instanceOf(classObject); }},

--- a/src/jllvm/vm/VirtualMachine.hpp
+++ b/src/jllvm/vm/VirtualMachine.hpp
@@ -129,7 +129,7 @@ public:
 
     /// Calls the constructor of 'object' with the types described by 'methodDescriptor' using 'args'.
     template <JavaConvertible... Args>
-    void executeObjectConstructor(ObjectInterface* object, llvm::StringRef methodDescriptor, Args... args)
+    void executeObjectConstructor(ObjectInterface* object, MethodType methodDescriptor, Args... args)
     {
         auto addr = llvm::cantFail(m_jit.lookup(object->getClass()->getClassName(), "<init>", methodDescriptor));
         invokeJava<void>(addr, object, args...);
@@ -137,7 +137,7 @@ public:
 
     /// Calls the static method 'methodName' with types 'methodDescriptor' within 'className' using 'args'.
     template <JavaCompatible Ret = void, JavaConvertible... Args>
-    Ret executeStaticMethod(llvm::StringRef className, llvm::StringRef methodName, llvm::StringRef methodDescriptor,
+    Ret executeStaticMethod(llvm::StringRef className, llvm::StringRef methodName, MethodType methodDescriptor,
                             Args... args)
     {
         auto addr = llvm::cantFail(m_jit.lookup(className, methodName, methodDescriptor));

--- a/src/jllvm/vm/native/Lang.hpp
+++ b/src/jllvm/vm/native/Lang.hpp
@@ -65,17 +65,18 @@ public:
 
     static const ClassObject* getPrimitiveClass(VirtualMachine& vm, GCRootRef<ClassObject>, GCRootRef<String> string)
     {
-        static llvm::DenseMap<llvm::StringRef, char> mapping = {
-            {"boolean", 'Z'}, {"char", 'C'},  {"byte", 'B'}, {"short", 'S'}, {"int", 'I'},
-            {"double", 'D'},  {"float", 'F'}, {"void", 'V'}, {"long", 'J'},
+        static llvm::DenseMap<llvm::StringRef, BaseType> mapping = {
+            {"boolean", BaseType::Boolean}, {"char", BaseType::Char}, {"byte", BaseType::Byte},
+            {"short", BaseType::Short},     {"int", BaseType::Int},   {"double", BaseType::Double},
+            {"float", BaseType::Float},     {"void", BaseType::Void}, {"long", BaseType::Long},
         };
         std::string utf8 = string->toUTF8();
-        char c = mapping.lookup(utf8);
-        if (c == 0)
+        auto result = mapping.find(utf8);
+        if (result == mapping.end())
         {
             return nullptr;
         }
-        return &vm.getClassLoader().forName(llvm::Twine(c));
+        return &vm.getClassLoader().forName(result->second);
     }
 
     bool isArray()


### PR DESCRIPTION
The new classes have the large advantage of being strongly typed and giving us a lot of correctness by construction. There is also no longer a need for an explicit parsing step and it is possible to nicely compose constructors from parameters, forming the exact descriptor without the need for string manipulation.

Depends on https://github.com/JLLVM/JLLVM/pull/190