### PR TITLE
[native] refactor `ModelBase` and subclasses to use `State` template

### DIFF
--- a/src/jllvm/vm/InteropHelpers.hpp
+++ b/src/jllvm/vm/InteropHelpers.hpp
@@ -42,10 +42,7 @@ using JavaConvertedType = decltype(detail::javaConvertedType(std::declval<T>()))
 
 /// Concept for any type that is known to implicitly convert to a 'JavaCompatible' type.
 template <class T>
-concept JavaConvertible = !std::is_void_v<T> && requires
-{
-    JavaCompatible<JavaConvertedType<T>>;
-};
+concept JavaConvertible = !std::is_void_v<T> && JavaCompatible<JavaConvertedType<T>>;
 
 /// Helper function to call 'fnPtr', which is known to be a Java function, with the given 'args'.
 /// Does implicit conversion of 'args' their 'JavaCompatible' type.

--- a/src/jllvm/vm/native/IO.cpp
+++ b/src/jllvm/vm/native/IO.cpp
@@ -17,7 +17,7 @@
 
 void jllvm::io::FileDescriptorModel::close0()
 {
-    std::uint32_t& fd = state().fdField(javaThis);
+    std::uint32_t& fd = state.fdField(javaThis);
     if (fd == -1)
     {
         return;

--- a/src/jllvm/vm/native/IO.hpp
+++ b/src/jllvm/vm/native/IO.hpp
@@ -18,15 +18,15 @@
 namespace jllvm::io
 {
 
-class FileDescriptorModel : public ModelBase<FileDescriptorModel>
+struct FileDescriptorModelState : ModelState
+{
+    InstanceFieldRef<std::uint32_t> fdField;
+};
+
+class FileDescriptorModel : public ModelBase<FileDescriptorModelState>
 {
 public:
     using Base::Base;
-
-    struct State
-    {
-        InstanceFieldRef<std::uint32_t> fdField;
-    };
 
     static void initIDs(State& state, GCRootRef<ClassObject> classObject)
     {
@@ -51,15 +51,15 @@ public:
                                                     &FileDescriptorModel::getAppend, &FileDescriptorModel::close0);
 };
 
-class FileOutputStreamModel : public ModelBase<FileOutputStreamModel>
+struct FileOutputStreamModelState : ModelState
+{
+    InstanceFieldRef<Object*> descriptor;
+    InstanceFieldRef<std::uint32_t> fdField;
+};
+
+class FileOutputStreamModel : public ModelBase<FileOutputStreamModelState>
 {
 public:
-    struct State
-    {
-        InstanceFieldRef<Object*> descriptor;
-        InstanceFieldRef<std::uint32_t> fdField;
-    };
-
     using Base::Base;
 
     static void initIDs(State& state, VirtualMachine& virtualMachine, GCRootRef<ClassObject> classObject)
@@ -72,7 +72,7 @@ public:
 
     void writeBytes(GCRootRef<Array<std::uint8_t>> bytes, std::int32_t offset, std::int32_t length, bool append)
     {
-        llvm::raw_fd_ostream stream(state().fdField(state().descriptor(javaThis)), /*shouldClose=*/false);
+        llvm::raw_fd_ostream stream(state.fdField(state.descriptor(javaThis)), /*shouldClose=*/false);
         if (append && stream.supportsSeeking())
         {
             // TODO:

--- a/src/jllvm/vm/native/JDK.hpp
+++ b/src/jllvm/vm/native/JDK.hpp
@@ -19,7 +19,7 @@
 namespace jllvm::jdk
 {
 
-class ReflectionModel : public ModelBase<ReflectionModel>
+class ReflectionModel : public ModelBase<>
 {
 public:
     using Base::Base;
@@ -30,7 +30,7 @@ public:
     constexpr static auto methods = std::make_tuple(&ReflectionModel::getCallerClass);
 };
 
-class CDSModel : public ModelBase<CDSModel>
+class CDSModel : public ModelBase<>
 {
 public:
     using Base::Base;
@@ -63,7 +63,7 @@ public:
                         &CDSModel::getRandomSeedForDumping, &CDSModel::initializeFromArchive);
 };
 
-class UnsafeModel : public ModelBase<UnsafeModel>
+class UnsafeModel : public ModelBase<>
 {
     template <JavaCompatible T>
     bool compareAndSet(Object* object, std::uint64_t offset, T expected, T desired)
@@ -226,7 +226,7 @@ public:
         &UnsafeModel::putIntVolatile, &UnsafeModel::putReferenceVolatile);
 };
 
-class VMModel : public ModelBase<VMModel>
+class VMModel : public ModelBase<>
 {
 public:
     using Base::Base;
@@ -240,7 +240,7 @@ public:
     constexpr static auto methods = std::make_tuple(&VMModel::initialize);
 };
 
-class SystemPropsRawModel : public ModelBase<SystemPropsRawModel>
+class SystemPropsRawModel : public ModelBase<>
 {
     // See
     // https://github.com/openjdk/jdk/blob/7d4b77ad9ee803d89eab5632f5c65ac843a68b3c/src/java.base/share/classes/jdk/internal/util/SystemProps.java#L217
@@ -312,7 +312,7 @@ public:
         std::make_tuple(&SystemPropsRawModel::platformProperties, &SystemPropsRawModel::vmProperties);
 };
 
-class ScopedMemoryAccessModel : public ModelBase<ScopedMemoryAccessModel>
+class ScopedMemoryAccessModel : public ModelBase<>
 {
 public:
     using Base::Base;
@@ -326,7 +326,7 @@ public:
     constexpr static auto methods = std::make_tuple(&ScopedMemoryAccessModel::registerNatives);
 };
 
-class SignalModel : public ModelBase<SignalModel>
+class SignalModel : public ModelBase<>
 {
 public:
     using Base::Base;

--- a/src/jllvm/vm/native/Lang.hpp
+++ b/src/jllvm/vm/native/Lang.hpp
@@ -22,7 +22,7 @@ namespace jllvm::lang
 {
 
 /// Model implementation for the native methods of Javas 'Object' class.
-class ObjectModel : public ModelBase<ObjectModel>
+class ObjectModel : public ModelBase<>
 {
 public:
     using Base::Base;
@@ -53,7 +53,7 @@ public:
 };
 
 /// Model implementation for the native methods of Javas 'Class' class.
-class ClassModel : public ModelBase<ClassModel, ClassObject>
+class ClassModel : public ModelBase<ModelState, ClassObject>
 {
 public:
     using Base::Base;
@@ -103,7 +103,7 @@ public:
                         &ClassModel::getPrimitiveClass, &ClassModel::isPrimitive);
 };
 
-class FloatModel : public ModelBase<FloatModel>
+class FloatModel : public ModelBase<>
 {
 public:
     using Base::Base;
@@ -128,7 +128,7 @@ public:
     constexpr static auto methods = std::make_tuple(&floatToRawIntBits, &intBitsToFloat);
 };
 
-class DoubleModel : public ModelBase<DoubleModel>
+class DoubleModel : public ModelBase<>
 {
 public:
     using Base::Base;
@@ -154,7 +154,7 @@ public:
 };
 
 /// Model implementation for the native methods of Javas 'Thowable' class.
-class ThrowableModel : public ModelBase<ThrowableModel, Throwable>
+class ThrowableModel : public ModelBase<ModelState, Throwable>
 {
 public:
     using Base::Base;
@@ -170,17 +170,17 @@ public:
     constexpr static auto methods = std::make_tuple(&ThrowableModel::fillInStackTrace);
 };
 
-class SystemModel : public ModelBase<SystemModel>
+struct SystemModelState : ModelState
+{
+    StaticFieldRef<Object*> in;
+    StaticFieldRef<Object*> out;
+    StaticFieldRef<Object*> err;
+};
+
+class SystemModel : public ModelBase<SystemModelState>
 {
 public:
     using Base::Base;
-
-    struct State
-    {
-        StaticFieldRef<Object*> in;
-        StaticFieldRef<Object*> out;
-        StaticFieldRef<Object*> err;
-    };
 
     static void arraycopy(GCRootRef<ClassObject>, GCRootRef<Object> src, std::int32_t srcPos, GCRootRef<Object> dest,
                           std::int32_t destPos, std::int32_t length);
@@ -219,7 +219,7 @@ public:
                         &SystemModel::setIn0, &SystemModel::setOut0, &SystemModel::setErr0);
 };
 
-class RuntimeModel : public ModelBase<RuntimeModel>
+class RuntimeModel : public ModelBase<>
 {
 public:
     using Base::Base;
@@ -238,15 +238,15 @@ public:
     constexpr static auto methods = std::make_tuple(&RuntimeModel::maxMemory, &RuntimeModel::availableProcessors);
 };
 
-class ThreadModel : public ModelBase<ThreadModel>
+struct ThreadModelState : ModelState
+{
+    InstanceFieldRef<std::int32_t> priorityField;
+};
+
+class ThreadModel : public ModelBase<ThreadModelState>
 {
 public:
     using Base::Base;
-
-    struct State
-    {
-        InstanceFieldRef<std::int32_t> priorityField;
-    };
 
     static void registerNatives(State& state, GCRootRef<ClassObject> classObject)
     {
@@ -262,7 +262,7 @@ public:
 
     void setPriority0(std::int32_t priority)
     {
-        state().priorityField(javaThis) = priority;
+        state.priorityField(javaThis) = priority;
     }
 
     constexpr static llvm::StringLiteral className = "java/lang/Thread";
@@ -270,7 +270,7 @@ public:
         std::make_tuple(&ThreadModel::registerNatives, &ThreadModel::currentThread, &ThreadModel::setPriority0);
 };
 
-class ReferenceModel : public ModelBase<ReferenceModel, Reference>
+class ReferenceModel : public ModelBase<ModelState, Reference>
 {
 public:
     using Base::Base;
@@ -284,10 +284,9 @@ public:
     constexpr static auto methods = std::make_tuple(&ReferenceModel::refersTo0);
 };
 
-class StringUTF16Model : public ModelBase<StringUTF16Model>
+class StringUTF16Model : public ModelBase<>
 {
 public:
-
     using Base::Base;
 
     static bool isBigEndian(GCRootRef<ClassObject>);

--- a/src/jllvm/vm/native/Security.hpp
+++ b/src/jllvm/vm/native/Security.hpp
@@ -19,7 +19,7 @@
 namespace jllvm::security
 {
 
-class AccessControllerModel : public ModelBase<AccessControllerModel>
+class AccessControllerModel : public ModelBase<>
 {
 public:
     using Base::Base;


### PR DESCRIPTION
Refactored the CRTP implementation for stateful `ModelBase` subclasses to use the simpler templated `State` approach.