### PR TITLE
[codegen] Fix operand stack type mismatch after exception handling code

### DIFF
--- a/src/jllvm/materialization/CodeGenerator.cpp
+++ b/src/jllvm/materialization/CodeGenerator.cpp
@@ -1480,7 +1480,7 @@ llvm::BasicBlock* CodeGenerator::generateHandlerChain(llvm::Value* exception, ll
             // Catch all used to implement 'finally'.
             // Set exception object as only object on the stack and clear the active exception.
             m_builder.CreateStore(llvm::ConstantPointerNull::get(ty), activeException(m_function->getParent()));
-            m_operandStack.setHandlerStack(phi);
+            m_builder.CreateStore(phi, m_operandStack.getBottomOfStack());
             m_builder.CreateBr(handlerBB);
             return ehHandler;
         }
@@ -1508,7 +1508,7 @@ llvm::BasicBlock* CodeGenerator::generateHandlerChain(llvm::Value* exception, ll
 
         m_builder.SetInsertPoint(jumpToHandler);
         // Set exception object as only object on the stack and clear the active exception.
-        m_operandStack.setHandlerStack(phi);
+        m_builder.CreateStore(phi, m_operandStack.getBottomOfStack());
         m_builder.CreateStore(llvm::ConstantPointerNull::get(ty), activeException(m_function->getParent()));
         m_builder.CreateBr(handlerBB);
 

--- a/src/jllvm/materialization/CodeGenerator.cpp
+++ b/src/jllvm/materialization/CodeGenerator.cpp
@@ -1480,7 +1480,7 @@ llvm::BasicBlock* CodeGenerator::generateHandlerChain(llvm::Value* exception, ll
             // Catch all used to implement 'finally'.
             // Set exception object as only object on the stack and clear the active exception.
             m_builder.CreateStore(llvm::ConstantPointerNull::get(ty), activeException(m_function->getParent()));
-            m_builder.CreateStore(phi, m_operandStack.getBottomOfStack());
+            m_operandStack.setBottomOfStackValue(phi);
             m_builder.CreateBr(handlerBB);
             return ehHandler;
         }
@@ -1508,7 +1508,7 @@ llvm::BasicBlock* CodeGenerator::generateHandlerChain(llvm::Value* exception, ll
 
         m_builder.SetInsertPoint(jumpToHandler);
         // Set exception object as only object on the stack and clear the active exception.
-        m_builder.CreateStore(phi, m_operandStack.getBottomOfStack());
+        m_operandStack.setBottomOfStackValue(phi);
         m_builder.CreateStore(llvm::ConstantPointerNull::get(ty), activeException(m_function->getParent()));
         m_builder.CreateBr(handlerBB);
 

--- a/src/jllvm/materialization/CodeGeneratorUtils.hpp
+++ b/src/jllvm/materialization/CodeGeneratorUtils.hpp
@@ -135,10 +135,10 @@ public:
         m_topOfStack = state.size();
     }
 
-    /// Returns the bottom-most stack slot of the operand stack.
-    llvm::AllocaInst* getBottomOfStack() const
+    /// Sets the value of the bottom-most stack slot of the operand stack.
+    void setBottomOfStackValue(llvm::Value* value) const
     {
-        return m_values.front();
+        m_builder.CreateStore(value, m_values.front());
     }
 };
 

--- a/src/jllvm/materialization/CodeGeneratorUtils.hpp
+++ b/src/jllvm/materialization/CodeGeneratorUtils.hpp
@@ -135,11 +135,10 @@ public:
         m_topOfStack = state.size();
     }
 
-    void setHandlerStack(llvm::Value* value)
+    /// Returns the bottom-most stack slot of the operand stack.
+    llvm::AllocaInst* getBottomOfStack() const
     {
-        llvm::AllocaInst* alloc = m_values.front();
-        m_types.front() = value->getType();
-        m_builder.CreateStore(value, alloc);
+        return m_values.front();
     }
 };
 

--- a/tests/Execution/exception-handling-stack-type-mismatch.j
+++ b/tests/Execution/exception-handling-stack-type-mismatch.j
@@ -1,0 +1,41 @@
+; RUN: rm -rf %t && split-file %s %t
+; RUN: cd %t && jasmin %t/Test.j -d %t && jasmin %t/A.j
+; RUN: jllvm %t/Test.class
+
+;--- A.j
+
+.class public A
+.super java/lang/Object
+
+.field public static a I = 0
+
+.method public <init>()V
+    .limit stack 1
+    aload_0
+    invokenonvirtual java/lang/Object/<init>()V
+    return
+.end method
+
+;--- Test.j
+
+.class public Test
+.super java/lang/Object
+
+.method public <init>()V
+    .limit stack 1
+    aload_0
+    invokespecial java/lang/Object/<init>()V
+    return
+.end method
+
+.method public static native print(Ljava/lang/String;)V
+.end method
+
+.method public static main([Ljava/lang/String;)V
+   .limit stack 2
+   iconst_0
+   getstatic A/a I
+   iadd
+   pop
+   return
+.end method


### PR DESCRIPTION
The code in the `OperandStack` incorrectly set the LLVM type of the bottom most operand as well when calling `setHandlerStack`. The method was only used during generation of the exception handling chain which shouldn't affect the operand stack at all as compilation continues afterward as usual.

This PR fixes that issue by removing the `setHandlerStack` method, as it in my opinion is oddly named, and not storing an LLVM type to the operand stack.