### PR TITLE
[codegen] Move class object loading to the new stub generator

### DIFF
--- a/src/jllvm/materialization/ClassObjectStubDefinitionsGenerator.cpp
+++ b/src/jllvm/materialization/ClassObjectStubDefinitionsGenerator.cpp
@@ -37,7 +37,12 @@ llvm::orc::ThreadSafeModule compile(const DemangledVariant& variant, ClassLoader
             ClassObject& classObject = classLoader.forName(ObjectType(fieldAccess.className));
             generateFieldAccessStub(*module, classObject, fieldAccess.fieldName, fieldAccess.descriptor);
         },
-        [](auto) { llvm_unreachable("Not yet implemented"); });
+        [&](FieldType fieldType)
+        {
+            ClassObject& classObject = classLoader.forName(fieldType);
+            generateClassObjectAccessStub(*module, classObject);
+        },
+        [](...) { llvm_unreachable("Not yet implemented"); });
     return llvm::orc::ThreadSafeModule(std::move(module), std::move(context));
 }
 

--- a/src/jllvm/materialization/CodeGeneratorUtils.hpp
+++ b/src/jllvm/materialization/CodeGeneratorUtils.hpp
@@ -164,10 +164,6 @@ class LazyClassLoaderHelper
     static void buildClassInitializerInitStub(llvm::IRBuilder<>& builder, const ClassObject& classObject);
 
     template <class F>
-    llvm::Value* returnConstantForClassObject(llvm::IRBuilder<>& builder, FieldType fieldDescriptor, llvm::Twine key,
-                                              F&& f, bool mustInitializeClassObject);
-
-    template <class F>
     llvm::Value* doCallForClassObject(llvm::IRBuilder<>& builder, llvm::StringRef className, llvm::StringRef methodName,
                                       MethodType methodType, bool isStatic, llvm::Twine key,
                                       llvm::ArrayRef<llvm::Value*> args, F&& f);
@@ -234,7 +230,6 @@ public:
                                        FieldType fieldType);
 
     /// Returns an LLVM Pointer which points to the class object of the type with the given field descriptor.
-    llvm::Value* getClassObject(llvm::IRBuilder<>& builder, FieldType fieldDescriptor,
-                                bool mustInitializeClassObject = false);
+    llvm::Value* getClassObject(llvm::IRBuilder<>& builder, FieldType fieldDescriptor);
 };
 } // namespace jllvm

--- a/src/jllvm/object/ClassLoader.cpp
+++ b/src/jllvm/object/ClassLoader.cpp
@@ -214,8 +214,7 @@ jllvm::ClassObject* jllvm::ClassLoader::forNameLoaded(FieldType fieldType)
     for (std::size_t i = 1; i <= arrayTypesCount; i++)
     {
         curr = ClassObject::createArray(m_classAllocator, m_metaClassObject, curr, m_stringSaver);
-        fieldType = ArrayType(fieldType);
-        m_mapping.insert({fieldType, curr});
+        m_mapping.insert({curr->getDescriptor(), curr});
     }
     return curr;
 }
@@ -235,7 +234,7 @@ jllvm::ClassObject& jllvm::ClassLoader::forName(FieldType fieldType)
             const ClassObject& componentType = forName(arrayTypeDesc->getComponentType());
             ClassObject* arrayType =
                 ClassObject::createArray(m_classAllocator, m_metaClassObject, &componentType, m_stringSaver);
-            m_mapping.insert({fieldType, arrayType});
+            m_mapping.insert({arrayType->getDescriptor(), arrayType});
             return *arrayType;
         }
         className = get<ObjectType>(fieldType).getClassName();

--- a/src/jllvm/object/ClassObject.cpp
+++ b/src/jllvm/object/ClassObject.cpp
@@ -118,12 +118,8 @@ jllvm::ClassObject* jllvm::ClassObject::createArray(llvm::BumpPtrAllocator& allo
         arrayFieldAreaSize = llvm::alignTo(arrayFieldAreaSize, sizeof(void*));
     }
 
-    llvm::StringRef className = componentType->getClassName();
-    auto* result =
-        create(allocator, metaClass, 0, arrayFieldAreaSize, {}, {}, {},
-               stringSaver.save(componentType->isClass() || componentType->isInterface() ? "[L" + className + ";" :
-                                                                                           "[" + className),
-               false);
+    auto* result = create(allocator, metaClass, 0, arrayFieldAreaSize, {}, {}, {},
+                          stringSaver.save(FieldType(ArrayType(componentType->getDescriptor())).textual()), false);
     result->m_componentTypeOrInterfaceId = componentType;
     result->m_initialized = true;
     return result;

--- a/src/jllvm/object/ClassObject.hpp
+++ b/src/jllvm/object/ClassObject.hpp
@@ -618,10 +618,24 @@ public:
     /// Returns a range containing all direct and indirect interfaces of this class in an unspecified order.
     auto getAllInterfaces() const;
 
-    /// Returns the name of this class as descriptor.
+    /// Returns the name of this class. This is the descriptor of the class if the class object represents an array
+    /// or primitive type.
     llvm::StringRef getClassName() const
     {
         return m_className;
+    }
+
+    /// Returns the field descriptor of this class. The lifetime of the returned 'FieldType' is equal to the class
+    /// object itself.
+    FieldType getDescriptor() const
+    {
+        // Arrays and primitives use the descriptor syntax as name already while classes and interfaces use just the
+        // name of the class.
+        if (isPrimitive() || isArray())
+        {
+            return FieldType(m_className);
+        }
+        return ObjectType(m_className);
     }
 
     /// Returns the name of the package this class is defined in.


### PR DESCRIPTION
This was the last method using `returnConstantForClassObject` from `LazyClassLoaderHelper` which could now be removed. To reduce a lot of the boilerplate required, a few methods were refactored and put into the `ByteCodeCompileUtils.hpp` header for reuse.

Depends on https://github.com/JLLVM/JLLVM/pull/199 and https://github.com/JLLVM/JLLVM/pull/202