### PR TITLE
[codegen][NFC] Refactor ABI sensitive LLVM attribute application 

### DIFF
--- a/src/jllvm/materialization/ByteCodeCompileLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeCompileLayer.cpp
@@ -36,14 +36,8 @@ void jllvm::ByteCodeCompileLayer::emit(std::unique_ptr<llvm::orc::Materializatio
     auto* function = llvm::Function::Create(descriptorToType(descriptor, methodInfo->isStatic(), module->getContext()),
                                             llvm::GlobalValue::ExternalLinkage,
                                             mangleDirectMethodCall(*methodInfo, *classFile), module.get());
-    function->setGC("coreclr");
-
-    applyJavaMethodAttributes(function, {classObject, method});
-
-    function->addFnAttr(llvm::Attribute::UWTable);
-#ifdef LLVM_ADDRESS_SANITIZER_BUILD
-    function->addFnAttr(llvm::Attribute::SanitizeAddress);
-#endif
+    addJavaMethodMetadata(function, {classObject, method});
+    applyABIAttributes(function);
 
     auto code = methodInfo->getAttributes().find<Code>();
     assert(code);

--- a/src/jllvm/materialization/ByteCodeCompileUtils.cpp
+++ b/src/jllvm/materialization/ByteCodeCompileUtils.cpp
@@ -84,7 +84,7 @@ llvm::FunctionType* jllvm::descriptorToType(MethodType type, bool isStatic, llvm
     return llvm::FunctionType::get(descriptorToType(type.returnType(), context), args, false);
 }
 
-void jllvm::applyJavaMethodAttributes(llvm::Function* function, const jllvm::JavaMethodMetadata& metadata)
+void jllvm::addJavaMethodMetadata(llvm::Function* function, const JavaMethodMetadata& metadata)
 {
     std::string sectionName = "java";
     if (llvm::Triple(LLVM_HOST_TRIPLE).isOSBinFormatMachO())
@@ -105,4 +105,77 @@ void jllvm::applyJavaMethodAttributes(llvm::Function* function, const jllvm::Jav
                                     reinterpret_cast<std::uintptr_t>(metadata.method)),
              ptrType)}));
     function->setSection(sectionName);
+}
+
+namespace
+{
+using namespace jllvm;
+
+/// X86 ABI essentially always uses the 32 bit register names for passing along integers. Using the 'signext' and
+/// 'zeroext' attribute we tell LLVM that if due to ABI, it has to extend these registers, which extension to use.
+/// This attribute list can be applied to either a call or a function itself.
+llvm::AttributeList getABIAttributes(llvm::LLVMContext& context, MethodType methodType, bool isStatic)
+{
+    llvm::SmallVector<llvm::AttributeSet> paramAttrs(methodType.size());
+    for (auto&& [param, attrs] : llvm::zip(methodType.parameters(), paramAttrs))
+    {
+        auto baseType = get_if<BaseType>(&param);
+        if (!baseType || !baseType->isIntegerType())
+        {
+            continue;
+        }
+        attrs = attrs.addAttribute(context, baseType->isUnsigned() ? llvm::Attribute::ZExt : llvm::Attribute::SExt);
+    }
+
+    llvm::AttributeSet retAttrs;
+    FieldType returnType = methodType.returnType();
+    if (auto baseType = get_if<BaseType>(&returnType); baseType && baseType->isIntegerType())
+    {
+        retAttrs =
+            retAttrs.addAttribute(context, baseType->isUnsigned() ? llvm::Attribute::ZExt : llvm::Attribute::SExt);
+    }
+    if (!isStatic)
+    {
+        paramAttrs.insert(paramAttrs.begin(), llvm::AttributeSet().addAttribute(context, llvm::Attribute::NonNull));
+    }
+    return llvm::AttributeList::get(context, llvm::AttributeSet{}, retAttrs, paramAttrs);
+}
+
+} // namespace
+
+void jllvm::applyABIAttributes(llvm::Function* function, MethodType methodType, bool isStatic)
+{
+    llvm::AttributeList attributeList = getABIAttributes(function->getContext(), methodType, isStatic);
+    // The RS4GC pass creating the `gc.statepoint` intrinsics that we currently use do not support `signext` and
+    // `zeroext` argument attributes. These are important as they lead to either zero or sign extending an integer
+    // register in the caller to 32 bit, something that is expected by basically all C ABIs.
+    // To circumvent this, be conservative and remove the attribute from all function parameters. This makes the
+    // function assume the caller did not extend the integer. This makes the function compatible with both a caller from
+    // C++ code, which does the extension properly, and a caller from Java code which does not.
+    // Calling C code only occurs in the JNI where the bridge does not need GC instrumentation and does the extension
+    // correctly.
+    // TODO: Remove this once we are using LLVM 18 where RS4GC does not discard `signext` and `zeroext`
+    //       or we use a local fork of the RS4GC pass that copies these.
+    //       See https://github.com/llvm/llvm-project/pull/68475 and https://github.com/llvm/llvm-project/pull/68439.
+    for (std::size_t i : llvm::seq<std::size_t>(0, function->arg_size()))
+    {
+        attributeList = attributeList.removeParamAttribute(function->getContext(), i, llvm::Attribute::ZExt);
+        attributeList = attributeList.removeParamAttribute(function->getContext(), i, llvm::Attribute::SExt);
+    }
+    function->setAttributes(attributeList);
+    applyABIAttributes(function);
+}
+
+void jllvm::applyABIAttributes(llvm::Function* function)
+{
+#ifdef LLVM_ADDRESS_SANITIZER_BUILD
+    function->addFnAttr(llvm::Attribute::SanitizeAddress);
+#endif
+    function->addFnAttr(llvm::Attribute::getWithUWTableKind(function->getContext(), llvm::UWTableKind::Async));
+    function->setGC("coreclr");
+}
+
+void jllvm::applyABIAttributes(llvm::CallBase* call, MethodType methodType, bool isStatic)
+{
+    call->setAttributes(getABIAttributes(call->getContext(), methodType, isStatic));
 }

--- a/src/jllvm/materialization/ByteCodeCompileUtils.hpp
+++ b/src/jllvm/materialization/ByteCodeCompileUtils.hpp
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <llvm/IR/DerivedTypes.h>
+#include <llvm/IR/InstrTypes.h>
 #include <llvm/IR/LLVMContext.h>
 
 #include <jllvm/class/Descriptors.hpp>
@@ -52,5 +53,18 @@ struct JavaMethodMetadata
     const Method* method;
 };
 
-void applyJavaMethodAttributes(llvm::Function* function, const JavaMethodMetadata& metadata);
+/// Adds the given Java method metadata to the function.
+void addJavaMethodMetadata(llvm::Function* function, const JavaMethodMetadata& metadata);
+
+/// Applies all ABI relevant attributes to the function which must have a signature matching the output of
+/// 'descriptorToType' when called with the given 'methodType' and 'isStatic'.
+void applyABIAttributes(llvm::Function* function, MethodType methodType, bool isStatic);
+
+/// Applies all ABI relevant attributes to the function that do not depend on its signature.
+/// This is e.g. used for stubs.
+void applyABIAttributes(llvm::Function* function);
+
+/// Applies all ABI relevant attributes to the call which must call a function with the signature matching the output of
+/// 'descriptorToType' when called with the given 'methodType' and 'isStatic'.
+void applyABIAttributes(llvm::CallBase* call, MethodType methodType, bool isStatic);
 } // namespace jllvm

--- a/src/jllvm/materialization/JNIImplementationLayer.cpp
+++ b/src/jllvm/materialization/JNIImplementationLayer.cpp
@@ -123,9 +123,10 @@ void jllvm::JNIImplementationLayer::emit(std::unique_ptr<llvm::orc::Materializat
                 auto* function = llvm::Function::Create(descriptorToType(methodType, methodInfo->isStatic(), *context),
                                                         llvm::GlobalValue::ExternalLinkage, bridgeName, module.get());
                 function->setSubprogram(subprogram);
-                function->addFnAttr(llvm::Attribute::UWTable);
 
-                applyJavaMethodAttributes(function, {classObject, method});
+                applyABIAttributes(function, methodType, methodInfo->isStatic());
+                function->clearGC();
+                addJavaMethodMetadata(function, {classObject, method});
 
                 llvm::IRBuilder<> builder(llvm::BasicBlock::Create(*context, "entry", function));
 

--- a/src/jllvm/materialization/LambdaMaterialization.hpp
+++ b/src/jllvm/materialization/LambdaMaterialization.hpp
@@ -186,7 +186,7 @@ public:
 
         llvm::Function* function =
             llvm::Function::Create(functionType, llvm::GlobalValue::ExternalLinkage, m_symbol, module.get());
-        function->addFnAttr(llvm::Attribute::UWTable);
+        function->addFnAttr(llvm::Attribute::getWithUWTableKind(function->getContext(), llvm::UWTableKind::Async));
 
         auto* type = llvm::ArrayType::get(llvm::Type::getInt8Ty(*context), sizeof(F));
         auto* closure = new llvm::GlobalVariable(


### PR DESCRIPTION
Code previously had a lot of code duplication which made applying changes to how ABI attributes are applied a lot more difficult as it required searching all over the codebase. This PR therefore creates new functions that are called on any call instruction and function to apply attributes important for any methods specific to implementing Java to the call or function.

Additionally, it documents and works around a bug that has in the past caused us many ABI issues with passing integers around. During investigations, I found out that the `gc.statepoint` intrinsic, which calls are converted to, to implement parseable stacks for the GC, are currently not properly created with argument attributes, erasing them all instead. A PR was posted upstream to fix it but won't be part of LLVM until at least LLVM 18.

Extracted out of https://github.com/JLLVM/JLLVM/pull/200