### PR TITLE
[CI] Add shared builds builder

### DIFF
--- a/.github/actions/llvm-build/action.yml
+++ b/.github/actions/llvm-build/action.yml
@@ -15,6 +15,10 @@ inputs:
   cache-key:
     description: 'Key to use to cache LLVM compilation. Should encode build config details'
     required: true
+  shared_libs:
+    description: 'Whether to build shared libraries. Probably only works on Linux'
+    required: false
+    default: 'OFF'
 
 outputs:
   install-dir:
@@ -96,6 +100,7 @@ runs:
         -DCMAKE_BUILD_TYPE=Release `
         -DCMAKE_CXX_COMPILER=${{inputs.cpp-compiler}} `
         -DCMAKE_C_COMPILER=${{inputs.c-compiler}} `
+        -DBUILD_SHARED_LIBS=${{inputs.shared_libs || 'OFF'}} `
         $assertions `
         -DLLVM_BUILD_TOOLS=OFF `
         -DLLVM_BUILD_UTILS=ON `

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         include:
           - { os: ubuntu-22.04, cxx_compiler: clang++, c_compiler: clang, sanitizer: "address,undefined" }
+          - { os: ubuntu-22.04, cxx_compiler: clang++, c_compiler: clang, shared_libs: "ON" }
           - { os: ubuntu-22.04, cxx_compiler: g++-10, c_compiler: gcc-10 }
           - { os: macos-12, cxx_compiler: clang++, c_compiler: clang }
 
@@ -41,6 +42,10 @@ jobs:
           if ('${{matrix.sanitizer}}') {
             $key += '-${{matrix.sanitizer}}'.Replace(',', '_and_')
           }
+          
+          if ('${{matrix.shared_libs}}' -eq 'ON') {
+            $key += '-shared'
+          }
 
           "key=$key" >> $Env:GITHUB_OUTPUT
 
@@ -63,6 +68,7 @@ jobs:
           cpp-compiler: ${{matrix.cxx_compiler}}
           sanitizers: ${{matrix.sanitizer}}
           cache-key: LLVM-${{steps.dep-install.outputs.key}}
+          shared_libs: ${{matrix.shared_libs}}
 
       - name: Configure JLLVM
         run: |
@@ -76,6 +82,11 @@ jobs:
             $use_lld = '-DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld"'
           }
           
+          $shared_libs = ''
+          if ('${{matrix.shared_libs}}' -eq 'ON') {
+            $shared_libs = '-DBUILD_SHARED_LIBS=ON'
+          }
+          
           cmake -GNinja -Bjllvm-build `
             -DCMAKE_BUILD_TYPE=Release `
             -DCMAKE_CXX_COMPILER=${{matrix.cxx_compiler}} `
@@ -83,6 +94,7 @@ jobs:
             -DCMAKE_CXX_FLAGS="-g1" `
             -DJLLVM_ENABLE_ASSERTIONS=ON `
             $sanitizer_arg `
+            $shared_libs `
             -DPython3_ROOT_DIR="$Env:pythonLocation" -DPython3_FIND_STRATEGY=LOCATION `
             -DCMAKE_C_COMPILER_LAUNCHER=ccache `
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache `

--- a/.github/workflows/llvm-cache.yml
+++ b/.github/workflows/llvm-cache.yml
@@ -16,6 +16,7 @@ jobs:
       matrix:
         include:
           - { os: ubuntu-22.04, cxx_compiler: clang++, c_compiler: clang, sanitizer: "address,undefined" }
+          - { os: ubuntu-22.04, cxx_compiler: clang++, c_compiler: clang, shared_libs: "ON" }
           - { os: ubuntu-22.04, cxx_compiler: g++-10, c_compiler: gcc-10 }
           - { os: macos-12, cxx_compiler: clang++, c_compiler: clang }
 
@@ -39,6 +40,10 @@ jobs:
           if ('${{matrix.sanitizer}}') {
             $key += '-${{matrix.sanitizer}}'.Replace(',', '_and_')
           }
+          
+          if ('${{matrix.shared_libs}}' -eq 'ON') {
+            $key += '-shared'
+          }
 
           "key=$key" >> $Env:GITHUB_OUTPUT
 
@@ -57,3 +62,4 @@ jobs:
           cpp-compiler: ${{matrix.cxx_compiler}}
           sanitizers: ${{matrix.sanitizer}}
           cache-key: LLVM-${{steps.dep-install.outputs.key}}
+          shared_libs: ${{matrix.shared_libs}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,14 @@ if ((NOT (${CMAKE_SYSTEM_NAME} MATCHES "AIX")) AND
     endif ()
 endif ()
 
+string(FIND "${CMAKE_CXX_FLAGS}" "-fsanitize=" SAN_INDEX)
+# Pass -Wl,-z,defs. This makes sure all symbols are defined. Otherwise a DSO build might work on ELF but fail on
+# MachO/COFF. Sanitizers are generally incompatible with this option.
+if (NOT (CMAKE_SYSTEM_NAME MATCHES "Darwin|FreeBSD|OpenBSD|DragonFly|AIX|OS390" OR
+        WIN32 OR CYGWIN) AND SAN_INDEX EQUAL -1)
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,defs")
+endif ()
+
 add_subdirectory(src)
 add_subdirectory(tools)
 

--- a/src/jllvm/materialization/CMakeLists.txt
+++ b/src/jllvm/materialization/CMakeLists.txt
@@ -23,4 +23,4 @@ add_library(JLLVMMaterialization
         ClassObjectStubDefinitionsGenerator.cpp
         ClassObjectStubCodeGenerator.cpp
         ClassObjectStubMangling.cpp)
-target_link_libraries(JLLVMMaterialization PUBLIC JLLVMVirtualMachine JLLVMObject LLVMCore LLVMOrcJIT)
+target_link_libraries(JLLVMMaterialization PUBLIC JLLVMObject LLVMCore LLVMOrcJIT)

--- a/src/jllvm/materialization/CMakeLists.txt
+++ b/src/jllvm/materialization/CMakeLists.txt
@@ -23,4 +23,4 @@ add_library(JLLVMMaterialization
         ClassObjectStubDefinitionsGenerator.cpp
         ClassObjectStubCodeGenerator.cpp
         ClassObjectStubMangling.cpp)
-target_link_libraries(JLLVMMaterialization PUBLIC JLLVMObject LLVMCore LLVMOrcJIT)
+target_link_libraries(JLLVMMaterialization PUBLIC JLLVMObject LLVMCore LLVMOrcJIT PRIVATE LLVMTargetParser)

--- a/src/jllvm/unwind/CMakeLists.txt
+++ b/src/jllvm/unwind/CMakeLists.txt
@@ -12,3 +12,4 @@
 # see <http://www.gnu.org/licenses/>.
 
 add_library(JLLVMUnwinder Unwinder.cpp)
+target_link_libraries(JLLVMUnwinder PRIVATE LLVMSupport)

--- a/src/jllvm/vm/CMakeLists.txt
+++ b/src/jllvm/vm/CMakeLists.txt
@@ -18,8 +18,9 @@ add_library(JLLVMVirtualMachine VirtualMachine.cpp JIT.cpp StackMapRegistrationP
         native/Lang.cpp native/JDK.cpp native/Security.cpp
         ClassObjectStubImportPass.cpp)
 target_link_libraries(JLLVMVirtualMachine
-        PRIVATE ${llvm_native_libs}
-        PUBLIC JLLVMClassParser JLLVMObject JLLVMGC LLVMExecutionEngine LLVMOrcJIT LLVMJITLink JLLVMMaterialization
+        PRIVATE JLLVMUnwinder ${llvm_native_libs} LLVMTargetParser LLVMOrcTargetProcess LLVMScalarOpts LLVMAnalysis
+        PUBLIC JLLVMClassParser JLLVMObject JLLVMGC JLLVMMaterialization LLVMExecutionEngine LLVMOrcJIT LLVMJITLink
+        LLVMPasses
         )
 
 set(JAVA_INCLUDE_PATH "${JAVA_HOME}/../include")


### PR DESCRIPTION
A shared library build has the advantage that they are linked and that one is able to tell the linker that undefined references are not allowed. Unlike the static build this ensures that we have clean modules that do not depend on any other modules, forcing us to have a cleaner non-monolithic design with less coupling.

Fixes https://github.com/JLLVM/JLLVM/issues/203