### PR TITLE
[codegen] implement throwing of `NullPointerException` for ops operating on reference types

### DIFF
--- a/src/jllvm/materialization/CodeGenerator.hpp
+++ b/src/jllvm/materialization/CodeGenerator.hpp
@@ -61,6 +61,8 @@ class CodeGenerator
 
     void generateEHDispatch();
 
+    void generateNullPointerCheck(llvm::Value* object);
+
     llvm::BasicBlock* generateHandlerChain(llvm::Value* exception, llvm::BasicBlock* newPred);
 
     llvm::Value* loadClassObjectFromPool(PoolIndex<ClassInfo> index);

--- a/src/jllvm/vm/VirtualMachine.cpp
+++ b/src/jllvm/vm/VirtualMachine.cpp
@@ -219,6 +219,14 @@ jllvm::VirtualMachine::VirtualMachine(BootOptions&& bootOptions)
                       executeObjectConstructor(root, "(Ljava/lang/String;)V", string);
                       return root;
                   }},
+        std::pair{"jllvm_build_null_pointer_exception",
+                  [&]() -> Object*
+                  {
+                      GCUniqueRoot root =
+                          m_gc.root(m_gc.allocate(&m_classLoader.forName("Ljava/lang/NullPointerException;")));
+                      executeObjectConstructor(root, "()V");
+                      return root;
+                  }},
         std::pair{"jllvm_push_local_frame", [&] { m_gc.pushLocalFrame(); }},
         std::pair{"jllvm_pop_local_frame", [&] { m_gc.popLocalFrame(); }});
 

--- a/tests/Execution/faload-fastore.java
+++ b/tests/Execution/faload-fastore.java
@@ -4,6 +4,7 @@
 class Test
 {
     public static native void print(float f);
+    public static native void print(String s);
 
     public static void main(String[] args)
     {
@@ -23,5 +24,37 @@ class Test
         print(arr[3]);
         // CHECK: 4
         print(arr.length);
+
+        arr = null;
+
+        try
+        {
+            var f = arr[0];
+        }
+        catch(NullPointerException e)
+        {
+            // CHECK: load null
+            print("load null");
+        }
+
+        try
+        {
+            arr[0] = 1.0f;
+        }
+        catch(NullPointerException e)
+        {
+            // CHECK: store null
+            print("store null");
+        }
+
+        try
+        {
+            var l = arr.length;
+        }
+        catch(NullPointerException e)
+        {
+            // CHECK: length null
+            print("length null");
+        }
     }
 }

--- a/tests/Execution/iaload-iastore.java
+++ b/tests/Execution/iaload-iastore.java
@@ -4,6 +4,7 @@
 class Test
 {
     public static native void print(int i);
+    public static native void print(String s);
 
     public static void main(String[] args)
     {
@@ -23,5 +24,37 @@ class Test
         print(arr[3]);
         // CHECK: 4
         print(arr.length);
+
+        arr = null;
+
+        try
+        {
+            var i = arr[0];
+        }
+        catch(NullPointerException e)
+        {
+            // CHECK: load null
+            print("load null");
+        }
+
+        try
+        {
+            arr[0] = 1;
+        }
+        catch(NullPointerException e)
+        {
+            // CHECK: store null
+            print("store null");
+        }
+
+        try
+        {
+            var l = arr.length;
+        }
+        catch(NullPointerException e)
+        {
+            // CHECK: length null
+            print("length null");
+        }
     }
 }

--- a/tests/Execution/instance-fields.java
+++ b/tests/Execution/instance-fields.java
@@ -6,6 +6,7 @@ class Test
     public int i = 5;
 
     public static native void print(int i);
+    public static native void print(String s);
 
     public static void main(String[] args)
     {
@@ -15,5 +16,27 @@ class Test
         t.i = 3;
         // CHECK: 3
         print(t.i);
+
+        t = null;
+
+        try
+        {
+            var i = t.i;
+        }
+        catch(NullPointerException e)
+        {
+            // CHECK: get null
+            print("get null");
+        }
+
+        try
+        {
+            t.i = 1;
+        }
+        catch(NullPointerException e)
+        {
+            // CHECK: put null
+            print("put null");
+        }
     }
 }

--- a/tests/Execution/interface-methods.java
+++ b/tests/Execution/interface-methods.java
@@ -7,6 +7,7 @@
 public class Test
 {
     public static native void print(int i);
+    public static native void print(String s);
 }
 
 //--- A.java
@@ -59,5 +60,17 @@ public class Other
         c.b();
         // CHECK: 6
         c.c();
+
+        c = null;
+
+        try
+        {
+            c.a();
+        }
+        catch(NullPointerException e)
+        {
+            // CHECK: interface null
+            Test.print("interface null");
+        }
     }
 }

--- a/tests/Execution/invoke-virtual.java
+++ b/tests/Execution/invoke-virtual.java
@@ -7,6 +7,7 @@
 public class Test
 {
     public static native void print(int i);
+    public static native void print(String s);
 }
 
 //--- A.java
@@ -59,5 +60,17 @@ public class Other
         c.c();
         // CHECK: 4
         ((B)c).b(); // Even when casting, the method of the dynamic type shall be used
+
+        c = null;
+
+        try
+        {
+            c.c();
+        }
+        catch(NullPointerException e)
+        {
+            // CHECK: virtual null
+            Test.print("virtual null");
+        }
     }
 }

--- a/tests/Execution/monitor-enter-exit.java
+++ b/tests/Execution/monitor-enter-exit.java
@@ -3,12 +3,29 @@
 
 class Test
 {
+    public static native void print(String s);
+
     public static void main(String[] args)
     {
         var o = new Object();
         synchronized(o)
         {
             new Object();
+        }
+
+        o = null;
+
+        try
+        {
+            synchronized(o)
+            {
+                new Object();
+            }
+        }
+        catch(NullPointerException e)
+        {
+            // CHECK: monitor null
+            print("monitor null");
         }
     }
 }

--- a/tests/Execution/object-array-ops.java
+++ b/tests/Execution/object-array-ops.java
@@ -4,6 +4,7 @@
 class Test
 {
     public static native void print(int i);
+    public static native void print(String s);
 
 	public int value;
 
@@ -22,14 +23,45 @@ class Test
 		// Something random inbetween, maybe GCs.
 		new Object();
 
+		// CHECK: 0
 		print(is[0].value);
+        // CHECK: 1
 		print(is[1].value);
+        // CHECK: 2
 		print(is[2].value);
+        // CHECK: 3
 		print(is.length);
+
+        is = null;
+
+        try
+        {
+            var o = is[0];
+        }
+        catch(NullPointerException e)
+        {
+            // CHECK: load null
+            print("load null");
+        }
+
+        try
+        {
+            is[0] = new Test(0);
+        }
+        catch(NullPointerException e)
+        {
+            // CHECK: store null
+            print("store null");
+        }
+
+        try
+        {
+            var l = is.length;
+        }
+        catch(NullPointerException e)
+        {
+            // CHECK: length null
+            print("length null");
+        }
     }
 }
-
-// CHECK: 0
-// CHECK: 1
-// CHECK: 2
-// CHECK: 3


### PR DESCRIPTION
This PR implements the proper throwing of  `NullPointerException` for JVM instructions dealing with reference types where such behavior is required.

Fixes: #154 