### PR TITLE
[codegen] implement throwing of `ArrayIndexOutOfBoundsException` for ops reading from and writing to arrays

### DIFF
--- a/src/jllvm/materialization/CodeGenerator.hpp
+++ b/src/jllvm/materialization/CodeGenerator.hpp
@@ -63,6 +63,8 @@ class CodeGenerator
 
     void generateNullPointerCheck(llvm::Value* object);
 
+    void generateArrayIndexCheck(llvm::Value* array, llvm::Value* index);
+
     llvm::BasicBlock* generateHandlerChain(llvm::Value* exception, llvm::BasicBlock* newPred);
 
     llvm::Value* loadClassObjectFromPool(PoolIndex<ClassInfo> index);

--- a/src/jllvm/vm/VirtualMachine.cpp
+++ b/src/jllvm/vm/VirtualMachine.cpp
@@ -227,6 +227,16 @@ jllvm::VirtualMachine::VirtualMachine(BootOptions&& bootOptions)
                       executeObjectConstructor(root, "()V");
                       return root;
                   }},
+        std::pair{"jllvm_build_array_index_out_of_bounds_exception",
+                  [&](int index, int size) -> Object*
+                  {
+                      String* string = m_stringInterner.intern(
+                          llvm::formatv("Index {0} out of bounds for length {1}", index, size).str());
+                      GCUniqueRoot root = m_gc.root(
+                          m_gc.allocate(&m_classLoader.forName("Ljava/lang/ArrayIndexOutOfBoundsException;")));
+                      executeObjectConstructor(root, "(Ljava/lang/String;)V", string);
+                      return root;
+                  }},
         std::pair{"jllvm_push_local_frame", [&] { m_gc.pushLocalFrame(); }},
         std::pair{"jllvm_pop_local_frame", [&] { m_gc.popLocalFrame(); }});
 

--- a/src/jllvm/vm/VirtualMachine.cpp
+++ b/src/jllvm/vm/VirtualMachine.cpp
@@ -228,7 +228,7 @@ jllvm::VirtualMachine::VirtualMachine(BootOptions&& bootOptions)
                       return root;
                   }},
         std::pair{"jllvm_build_array_index_out_of_bounds_exception",
-                  [&](int index, int size) -> Object*
+                  [&](std::int32_t index, std::int32_t size) -> Object*
                   {
                       String* string = m_stringInterner.intern(
                           llvm::formatv("Index {0} out of bounds for length {1}", index, size).str());

--- a/tests/Execution/array-index-out-of-bounds-exception-errror.java
+++ b/tests/Execution/array-index-out-of-bounds-exception-errror.java
@@ -1,0 +1,13 @@
+// RUN: javac %s -d %t
+// RUN: not jllvm %t/Test.class 2>&1 | FileCheck %s
+
+class Test
+{
+    public static void main(String[] args)
+    {
+        var arr = new Test[5];
+        var test = arr[10];
+    }
+}
+
+// CHECK: Index 10 out of bounds for length 5

--- a/tests/Execution/faload-fastore.java
+++ b/tests/Execution/faload-fastore.java
@@ -56,5 +56,27 @@ class Test
             // CHECK: length null
             print("length null");
         }
+
+        arr = new float[3];
+
+        try
+        {
+            var f = arr[4];
+        }
+        catch(ArrayIndexOutOfBoundsException e)
+        {
+            // CHECK: load over
+            print("load over");
+        }
+
+        try
+        {
+            arr[-1] = 0.0f;
+        }
+        catch(ArrayIndexOutOfBoundsException e)
+        {
+            // CHECK: store under
+            print("store under");
+        }
     }
 }

--- a/tests/Execution/iaload-iastore.java
+++ b/tests/Execution/iaload-iastore.java
@@ -56,5 +56,27 @@ class Test
             // CHECK: length null
             print("length null");
         }
+
+        arr = new int[3];
+
+        try
+        {
+            var i = arr[-30];
+        }
+        catch(ArrayIndexOutOfBoundsException e)
+        {
+            // CHECK: load under
+            print("load under");
+        }
+
+        try
+        {
+            arr[20] = 9;
+        }
+        catch(ArrayIndexOutOfBoundsException e)
+        {
+            // CHECK: store over
+            print("store over");
+        }
     }
 }

--- a/tests/Execution/llvm-miscompile.java
+++ b/tests/Execution/llvm-miscompile.java
@@ -8,7 +8,7 @@ class Test
 
     public static void main(String[] args)
     {
-        var t = new Test[0];
+        var t = new Test[1];
         // Causes garbage collection inbetween 't' and storing it. The dead store elimination
         // would previously falsely delete storing 'Test[].class' into 't'.
         new Object();


### PR DESCRIPTION
This PR implements the proper throwing of `ArrayIndexOutOfBoundsException` for JVM instructions dealing with reading from and writing to arrays.

Fixes: #155