### PR TITLE
[compiler] Implement compilation of OSR method

### DIFF
--- a/src/jllvm/class/ByteCodeIterator.hpp
+++ b/src/jllvm/class/ByteCodeIterator.hpp
@@ -132,7 +132,7 @@ public:
 };
 
 /// Returns an iterator range returning a 'ByteCodeOp' for every JVM instruction.
-/// Assumes that 'current' contains valid byte code contains the bytecode starting at offset 'offset'.
+/// Assumes that the beginning of 'current' is the bytecode offset 'offset' and contains valid bytecode.
 inline auto byteCodeRange(llvm::ArrayRef<char> current, std::uint16_t offset = 0)
 {
     return llvm::make_range(ByteCodeIterator(current.begin(), offset), ByteCodeIterator(current.end()));

--- a/src/jllvm/class/ByteCodeIterator.hpp
+++ b/src/jllvm/class/ByteCodeIterator.hpp
@@ -123,10 +123,16 @@ public:
     {
         return currentOp();
     }
+
+    /// Returns the current bytecode offset the iterator is at.
+    std::size_t getOffset()
+    {
+        return m_offset;
+    }
 };
 
 /// Returns an iterator range returning a 'ByteCodeOp' for every JVM instruction.
-/// Assumes that 'current' contains valid byte code.
+/// Assumes that 'current' contains valid byte code contains the bytecode starting at offset 'offset'.
 inline auto byteCodeRange(llvm::ArrayRef<char> current, std::uint16_t offset = 0)
 {
     return llvm::make_range(ByteCodeIterator(current.begin(), offset), ByteCodeIterator(current.end()));

--- a/src/jllvm/class/ClassFile.cpp
+++ b/src/jllvm/class/ClassFile.cpp
@@ -174,7 +174,7 @@ T parseFieldOrMethodInfo(llvm::ArrayRef<char>& bytes, const ClassFile& classFile
     for (std::size_t i = 0; i < attributeCount; i++)
     {
         auto [name, attrBytes] = parseAttributeInfo(bytes);
-        attributes.insert({name.resolve(classFile)->text, attrBytes});
+        attributes.insert(name.resolve(classFile)->text, attrBytes);
     }
     return T(accessFlags, nameIndex, descriptorIndex, std::move(attributes));
 }
@@ -229,7 +229,7 @@ jllvm::ClassFile jllvm::ClassFile::parseFromFile(llvm::ArrayRef<char> bytes, llv
     for (std::size_t i = 0; i < attributeCount; i++)
     {
         auto [name, attrBytes] = parseAttributeInfo(bytes);
-        result.m_attributes.insert({name.resolve(result)->text, attrBytes});
+        result.m_attributes.insert(name.resolve(result)->text, attrBytes);
     }
 
     return result;

--- a/src/jllvm/compiler/ByteCodeCompileUtils.cpp
+++ b/src/jllvm/compiler/ByteCodeCompileUtils.cpp
@@ -179,3 +179,10 @@ void jllvm::applyABIAttributes(llvm::CallBase* call, MethodType methodType, bool
 {
     call->setAttributes(getABIAttributes(call->getContext(), methodType, isStatic));
 }
+
+llvm::FunctionType* jllvm::osrMethodSignature(MethodType methodType, llvm::LLVMContext& context)
+{
+    auto* pointerType = llvm::PointerType::get(context, 0);
+    return llvm::FunctionType::get(descriptorToType(methodType.returnType(), context), {pointerType, pointerType},
+                                   /*isVarArg=*/false);
+}

--- a/src/jllvm/compiler/ByteCodeCompileUtils.hpp
+++ b/src/jllvm/compiler/ByteCodeCompileUtils.hpp
@@ -44,6 +44,12 @@ llvm::Type* descriptorToType(FieldType type, llvm::LLVMContext& context);
 /// Returns the corresponding LLVM function type for a given, possible static, Java method descriptor.
 llvm::FunctionType* descriptorToType(MethodType type, bool isStatic, llvm::LLVMContext& context);
 
+/// Returns the LLVM function type for an OSR method for a given Java method descriptor.
+/// An OSR frame currently uses as calling convention (ptr, ptr) where the first pointer refers to an array as large as
+/// the operand stack at entry and the second to an array as large as the local variables at entry. These are used to
+/// initialize the operand stack and local variables respectively.
+llvm::FunctionType* osrMethodSignature(MethodType methodType, llvm::LLVMContext& context);
+
 /// Metadata attached to Java methods produced by any 'ByteCodeLayer' implementation.
 struct JavaMethodMetadata
 {

--- a/src/jllvm/compiler/ClassObjectStubMangling.cpp
+++ b/src/jllvm/compiler/ClassObjectStubMangling.cpp
@@ -32,6 +32,11 @@ std::string jllvm::mangleDirectMethodCall(const jllvm::Method* method)
     return mangleDirectMethodCall(method->getClassObject()->getClassName(), method->getName(), method->getType());
 }
 
+std::string jllvm::mangleOSRMethod(const jllvm::Method* method, unsigned offset)
+{
+    return mangleDirectMethodCall(method) + "$" + std::to_string(offset);
+}
+
 std::string jllvm::mangleFieldAccess(llvm::StringRef className, llvm::StringRef fieldName, FieldType descriptor)
 {
     return (className + "." + fieldName + ":" + descriptor.textual()).str();

--- a/src/jllvm/compiler/ClassObjectStubMangling.hpp
+++ b/src/jllvm/compiler/ClassObjectStubMangling.hpp
@@ -43,6 +43,12 @@ std::string mangleDirectMethodCall(const Method* method);
 
 std::string mangleDirectMethodCall(const MethodInfo& methodInfo, const ClassFile& classFile);
 
+/// Mangling for a definition of an OSR frame that enters at the given bytecode offset.
+///
+/// Syntax:
+/// <osr-method> ::= <direct-call> '$' <offset>
+std::string mangleOSRMethod(const Method* method, unsigned offset);
+
 /// Mangling for calling a function returning either the address of a static field or the offset of an instance field.
 /// The caller must know whether the field is a static or an instance field and use the corresponding function
 /// signature:

--- a/src/jllvm/compiler/CodeGenerator.hpp
+++ b/src/jllvm/compiler/CodeGenerator.hpp
@@ -45,6 +45,15 @@ class CodeGenerator
     std::vector<llvm::AllocaInst*> m_locals;
     llvm::DenseMap<std::uint16_t, BasicBlockData> m_basicBlocks;
     ByteCodeTypeChecker::PossibleRetsMap m_retToMap;
+    llvm::SmallSetVector<std::uint16_t, 8> m_workList;
+
+    /// Returns the basic block corresponding to the given bytecode offset and schedules the basic block to be compiled.
+    /// The offset must point to the start of a basic block.
+    llvm::BasicBlock* getBasicBlock(std::uint16_t offset)
+    {
+        m_workList.insert(offset);
+        return m_basicBlocks.find(offset)->second.block;
+    }
 
     using HandlerInfo = std::pair<std::uint16_t, PoolIndex<ClassInfo>>;
 
@@ -53,12 +62,12 @@ class CodeGenerator
     // std::map because it is the easiest to use with std::list key.
     std::map<std::list<HandlerInfo>, llvm::BasicBlock*> m_alreadyGeneratedHandlers;
 
-    void createBasicBlocks(const Code& code);
+    void createBasicBlocks(const ByteCodeTypeChecker& checker);
 
-    void generateCodeBody(const Code& code);
+    void generateCodeBody(const Code& code, std::uint16_t startOffset);
 
-    /// Generate LLVM IR instructions for a JVM bytecode instruction, returns whether the instruction indicated the end
-    /// of a basic block
+    /// Generate LLVM IR instructions for a JVM bytecode instruction. Returns true if the instruction falls through or
+    /// more formally, whether the next instruction is an immediate successor of this instruction.
     bool generateInstruction(ByteCodeOp operation);
 
     void generateEHDispatch();
@@ -107,11 +116,10 @@ class CodeGenerator
     llvm::Value* getClassObject(llvm::IRBuilder<>& builder, FieldType fieldDescriptor);
 
 public:
-    CodeGenerator(llvm::Function* function, const ClassFile& classFile, const ClassObject& classObject,
-                  StringInterner& stringInterner, MethodType methodType, std::uint16_t maxStack,
-                  std::uint16_t maxLocals)
+    CodeGenerator(llvm::Function* function, const ClassObject& classObject, StringInterner& stringInterner,
+                  MethodType methodType, std::uint16_t maxStack, std::uint16_t maxLocals)
         : m_function{function},
-          m_classFile{classFile},
+          m_classFile{*classObject.getClassFile()},
           m_classObject(classObject),
           m_stringInterner{stringInterner},
           m_functionMethodType{methodType},
@@ -132,27 +140,29 @@ public:
     CodeGenerator& operator=(CodeGenerator&&) = delete;
 
     using PrologueGenFn = llvm::function_ref<void(llvm::IRBuilder<>& builder, llvm::ArrayRef<llvm::AllocaInst*> locals,
-                                                  OperandStack& operandStack)>;
+                                                  OperandStack& operandStack, const ByteCodeTypeInfo& typeInfo)>;
 
     /// This function must be only called once. 'code' must have at most a maximum stack depth of 'maxStack'
-    /// and have at most 'maxLocals' local variables.
-    void generateBody(const Code& code, PrologueGenFn generatePrologue);
+    /// and have at most 'maxLocals' local variables. 'generatePrologue' is used to initialize the local variables and
+    /// operand stack at the start of the method. 'offset' is the bytecode offset at which compilation should start and
+    /// must refer to a JVM instruction.
+    void generateBody(const Code& code, PrologueGenFn generatePrologue, std::uint16_t offset = 0);
 };
 
-/// Generates new LLVM code at the back of 'function' from the JVM Bytecode given by 'code'. 'classFile' is the class
-/// file containing 'code', 'classObject' the corresponding class object of the class file, 'stringInterner' the
-/// interner used to create string object instances from literals and 'methodType' the JVM Type of the method being
-/// compiled.
+/// Generates new LLVM code at the back of 'function' from the JVM Bytecode given by 'code'. 'classObject' is the class
+/// object of the class file containing 'code', 'stringInterner' the interner used to create string object instances
+/// from literals and 'methodType' the JVM Type of the method being compiled.
 /// 'generatePrologue' is called by the function to initialize the operand stack and local variables at the beginning of
-/// the newly created code.
-inline void compileMethodBody(llvm::Function* function, const ClassFile& classFile, const ClassObject& classObject,
-                              StringInterner& stringInterner, MethodType methodType, const Code& code,
-                              CodeGenerator::PrologueGenFn generatePrologue)
+/// the newly created code. 'offset' is the bytecode offset at which compilation should start and must refer to a JVM
+/// instruction.
+inline void compileMethodBody(llvm::Function* function, const ClassObject& classObject, StringInterner& stringInterner,
+                              MethodType methodType, const Code& code, CodeGenerator::PrologueGenFn generatePrologue,
+                              std::uint16_t offset = 0)
 {
-    CodeGenerator codeGenerator{function,   classFile,          classObject,        stringInterner,
+    CodeGenerator codeGenerator{function,   classObject,        stringInterner,
                                 methodType, code.getMaxStack(), code.getMaxLocals()};
 
-    codeGenerator.generateBody(code, generatePrologue);
+    codeGenerator.generateBody(code, generatePrologue, offset);
 }
 
 } // namespace jllvm

--- a/src/jllvm/compiler/CodeGenerator.hpp
+++ b/src/jllvm/compiler/CodeGenerator.hpp
@@ -47,6 +47,13 @@ class CodeGenerator
     ByteCodeTypeChecker::PossibleRetsMap m_retToMap;
     llvm::SmallSetVector<std::uint16_t, 8> m_workList;
 
+    using HandlerInfo = std::pair<std::uint16_t, PoolIndex<ClassInfo>>;
+
+    // std::list because we want the iterator stability when deleting handlers (requires random access).
+    std::list<HandlerInfo> m_activeHandlers;
+    // std::map because it is the easiest to use with std::list key.
+    std::map<std::list<HandlerInfo>, llvm::BasicBlock*> m_alreadyGeneratedHandlers;
+
     /// Returns the basic block corresponding to the given bytecode offset and schedules the basic block to be compiled.
     /// The offset must point to the start of a basic block.
     llvm::BasicBlock* getBasicBlock(std::uint16_t offset)
@@ -54,13 +61,6 @@ class CodeGenerator
         m_workList.insert(offset);
         return m_basicBlocks.find(offset)->second.block;
     }
-
-    using HandlerInfo = std::pair<std::uint16_t, PoolIndex<ClassInfo>>;
-
-    // std::list because we want the iterator stability when deleting handlers (requires random access).
-    std::list<HandlerInfo> m_activeHandlers;
-    // std::map because it is the easiest to use with std::list key.
-    std::map<std::list<HandlerInfo>, llvm::BasicBlock*> m_alreadyGeneratedHandlers;
 
     void createBasicBlocks(const ByteCodeTypeChecker& checker);
 

--- a/src/jllvm/compiler/Compiler.hpp
+++ b/src/jllvm/compiler/Compiler.hpp
@@ -24,4 +24,9 @@ namespace jllvm
 
 /// Compiles 'method' to a new LLVM function inside of 'module' and returns it.
 llvm::Function* compileMethod(llvm::Module& module, const Method& method, StringInterner& stringInterner);
+
+/// Compiles 'method' to a LLVM function suitable for OSR entry at the bytecode offset 'offset'. The function is placed
+/// into 'module' and returned.
+llvm::Function* compileOSRMethod(llvm::Module& module, std::uint16_t offset, const Method& method,
+                                 StringInterner& stringInterner);
 } // namespace jllvm

--- a/tests/Compiler/osr-frames.j
+++ b/tests/Compiler/osr-frames.j
@@ -1,0 +1,125 @@
+; RUN: jasmin %s -d %t
+; OSR into method entry.
+; RUN: jllvm-jvmc --method "test:(I)I" --osr 0 %t/Test.class | FileCheck %s --check-prefixes=CHECK,ENTRY
+; OSR into middle of the loop in catch.
+; RUN: jllvm-jvmc --method "test:(I)I" --osr 16 %t/Test.class | FileCheck %s --check-prefixes=CHECK,LOOP
+; OSR into exception handler.
+; RUN: jllvm-jvmc --method "test:(I)I" --osr 29 %t/Test.class | FileCheck %s --check-prefixes=CHECK,EXC
+
+.class public Test
+.super java/lang/Object
+
+.field public static foo Ljava/lang/Object;
+
+.method public <init>()V
+    aload_0
+    invokespecial java/lang/Object/<init>()V
+    return
+.end method
+
+.method public static native print(I)V
+.end method
+
+; CHECK-LABEL: define i32 @"Test.test:(I)I
+; ENTRY-SAME: $0"
+; LOOP-SAME: $16"
+; EXC-SAME: $29"
+; CHECK-SAME: ptr %[[OPERANDS:[[:alnum:]]+]]
+; CHECK-SAME: ptr %[[LOCALS:[[:alnum:]]+]]
+.method public static test(I)I
+; CHECK: %[[OP0:.*]] = alloca ptr
+; CHECK: %[[LOCAL0:.*]] = alloca ptr
+; CHECK: %[[LOCAL1:.*]] = alloca ptr
+    .limit stack 1
+    .limit locals 2
+
+; Loops has one operand on the stack and one local.
+; Entry has just one local.
+; Exc has two locals and no operands on the stack.
+
+; LOOP: %[[GEP:.*]] = getelementptr ptr, ptr %[[OPERANDS]], i32 0
+; LOOP: %[[LOAD:.*]] = load i32, ptr %[[GEP]]
+; LOOP: store i32 %[[LOAD]], ptr %[[OP0]]
+; CHECK: %[[GEP:.*]] = getelementptr ptr, ptr %[[LOCALS]], i32 0
+; CHECK: %[[LOAD:.*]] = load i32, ptr %[[GEP]]
+; CHECK: store i32 %[[LOAD]], ptr %[[LOCAL0]]
+; EXC: %[[GEP:.*]] = getelementptr ptr, ptr %[[LOCALS]], i32 1
+; EXC: %[[LOAD:.*]] = load ptr addrspace(1), ptr %[[GEP]]
+; EXC: store ptr addrspace(1) %[[LOAD]], ptr %[[LOCAL1]]
+
+; Entry continues to start of bytecode as usual.
+; ENTRY: br label %[[ENTRY:[[:alnum:]]+]]
+
+; ENTRY: [[ENTRY]]:
+; ENTRY-NEXT: call void @"Static Call to Test.foo:()V"()
+
+; LOOP: br label %[[LOOP_HEADER:[[:alnum:]]+]]
+
+; LOOP-NOT: call void @"Static Call to Test.foo:()V"
+
+; EXC: br label %[[THROW_CODE:[[:alnum:]]+]]
+
+    invokestatic Test/foo()V
+L3:
+    invokestatic Test/condition()Z
+    ifeq L34
+L9:
+    iinc 0 1
+L15:
+    iload_0
+; 16:
+
+; LOOP: [[LOOP_HEADER]]:
+; LOOP-NEXT: %[[ARG:.*]] = load i32, ptr %[[OP0]]
+; LOOP-NEXT: call void @"Static Call to Test.bar:(I)V"(
+; LOOP-SAME: i32{{.*}}%[[ARG]]
+; LOOP-SAME: )
+; LOOP: br i1 %{{.*}}, label %{{.*}}, label %[[EXC_HANDLER:[[:alnum:]]+]]
+
+; Check that despite OSRing into the middle of a 'try', that the exception handler after the bar call still leads to
+; calling the finally block.
+
+; LOOP: [[EXC_HANDLER]]:
+; LOOP-NEXT: %[[PHI:.*]] = phi
+; LOOP-NEXT: store ptr addrspace(1) null, ptr @activeException
+; LOOP-NEXT: store ptr addrspace(1) %[[PHI]], ptr %[[OP0]]
+; LOOP-NEXT: br label %[[L25CODE:[[:alnum:]]+]]
+
+; Check that the basic block was split correctly and that the iinc and iload_0 still lead to the OSR entry.
+
+; LOOP: %[[ADD:.*]] = add i32 %{{.*}}, 1
+; LOOP-NEXT: store i32 %[[ADD]], ptr %[[LOCAL0]]
+; LOOP-NEXT: %[[LOCAL0_LOAD:.*]] = load i32, ptr %[[LOCAL0]]
+; LOOP-NEXT: store i32 %[[LOCAL0_LOAD]], ptr %[[OP0]]
+; LOOP-NEXT: br label %[[LOOP_HEADER]]
+
+; LOOP: {{^}}[[L25CODE]]:
+; LOOP-NEXT: %[[OP0_LOAD:.*]] = load ptr addrspace(1), ptr %[[OP0]]
+; LOOP-NEXT: store ptr addrspace(1) %[[OP0_LOAD]], ptr %[[LOCAL1]]
+; LOOP-NEXT: call void @"Static Call to Test.foobar:()V"()
+
+    invokestatic Test/bar(I)V
+L19:
+    invokestatic Test/foobar()V
+    goto L31
+L25:
+    astore_1
+    invokestatic Test/foobar()V
+; 29:
+
+; EXC: [[THROW_CODE]]:
+; EXC-NEXT: %[[LOAD_LOCAL1:.*]] = load ptr addrspace(1), ptr %[[LOCAL1]]
+; EXC-NEXT: store ptr addrspace(1) %[[LOAD_LOCAL1]], ptr %[[OP0]]
+; EXC-NEXT: %[[LOAD_OP0:.*]] = load ptr addrspace(1), ptr %[[OP0]]
+
+; EXC: store ptr addrspace(1) %[[LOAD_OP0]], ptr @activeException
+    aload_1
+    athrow
+L31:
+    goto L3
+L34:
+    iload_0
+    ireturn
+
+.catch all from L15 to L19 using L25
+.end method

--- a/tests/tools/jllvm-jvmc/invalid.java
+++ b/tests/tools/jllvm-jvmc/invalid.java
@@ -5,6 +5,7 @@
 // RUN: not jllvm-jvmc --method "foo:()V" %t/Test.class %t/Test.class 2>&1 | FileCheck %s --check-prefix=TWO_INPUT
 // RUN: not jllvm-jvmc --method "foo:()V" %t/Bar.class 2>&1 | FileCheck %s --check-prefix=INVAL_INPUT
 // RUN: not jllvm-jvmc --method "bar:()V" %t/Test.class 2>&1 | FileCheck %s --check-prefix=NO_METHOD
+// RUN: not jllvm-jvmc --method "foo:()V" --osr t %t/Test.class 2>&1 | FileCheck %s --check-prefix=OSR_NUMBER
 
 // TWO_METHOD: expected exactly one occurrence of '--method'
 // INVAL_METHOD: expected method in format '<name>:<descriptor>'
@@ -13,6 +14,7 @@
 // INVAL_INPUT: failed to open
 // INVAL_INPUT-SAME: {{(/|\\\\)}}Bar.class{{[[:space:]]}}
 // NO_METHOD: failed to find method 'bar:()V' in 'Test'
+// OSR_NUMBER: invalid integer 't' as argument to '--osr'
 
 class Test
 {

--- a/tools/jllvm-jvmc/Opts.td
+++ b/tools/jllvm-jvmc/Opts.td
@@ -17,3 +17,4 @@ class F<string letter, string help> : Flag<["--"], letter>, HelpText<help>;
 
 def help : F<"help", "Displays this help text">;
 def method : Separate<["--"], "method">, MetaVarName<"<name-and-descriptor>">;
+def osr : Separate<["--"], "osr">, MetaVarName<"<byte-code-offset>">;

--- a/tools/jllvm-jvmc/main.cpp
+++ b/tools/jllvm-jvmc/main.cpp
@@ -150,7 +150,21 @@ int main(int argc, char** argv)
     llvm::LLVMContext context;
     llvm::Module module(name, context);
 
-    compileMethod(module, *method, stringInterner);
+    if (llvm::opt::Arg* arg = args.getLastArg(OPT_osr))
+    {
+        llvm::StringRef ref = arg->getValue();
+        unsigned offset;
+        if (ref.consumeInteger(0, offset))
+        {
+            llvm::errs() << "invalid integer '" << ref << "' as argument to '--osr'\n";
+            return -1;
+        }
+        compileOSRMethod(module, offset, *method, stringInterner);
+    }
+    else
+    {
+        compileMethod(module, *method, stringInterner);
+    }
     if (llvm::verifyModule(module, &llvm::dbgs()))
     {
         std::abort();


### PR DESCRIPTION
On-Stack-Replacement (OSR) methods are special versions of a method which start at a specific byte offset that possibly isn't 0. The use-case for such a method is in tiered compilation: Given an execution of a method (either JIT or Interpreter), it may wish to continue execution within the JIT. An OSR method for a requested offset where execution should continue can then be compiled and used.

To facilitate changing the frames of one execution to the new JIT compiled frame, the abstract machine state has to be transferred as well. In the case of the JVM, these are the local variables, the operand stack and the program counter. The latter is already baked into the compilation while the operand and local variables can be passed as an array of `int64_t`s as parameters respectively. The exact calling convention and parameters currently implemented are preliminary and possibly still subject to change.

Since an OSR method may start at any instruction within the Bytecode, compilation had to be restructured a bit. The compilation now does what is essentially a DFS walk that prefers straight-line code, leading to dead code elimination through reachability. This is important for OSR as large parts of the method may not be reachable and do not need to be compiled.