### PR TITLE
[unwind] Port unwinder code to our fork

### DIFF
--- a/src/jllvm/gc/GarbageCollector.cpp
+++ b/src/jllvm/gc/GarbageCollector.cpp
@@ -107,7 +107,7 @@ void collectStackRoots(const llvm::DenseMap<std::uintptr_t, std::vector<jllvm::S
                        std::vector<ObjectRepr*>& results, ObjectRepr* from, ObjectRepr* to)
 {
     jllvm::unwindStack(
-        [&](jllvm::UnwindFrame context)
+        [&](const jllvm::UnwindFrame& context)
         {
             for (const auto& iter : map.lookup(context.getProgramCounter()))
             {
@@ -153,7 +153,7 @@ void replaceStackRoots(const llvm::DenseMap<std::uintptr_t, std::vector<jllvm::S
                        const llvm::DenseMap<ObjectRepr*, ObjectRepr*>& mapping)
 {
     jllvm::unwindStack(
-        [&](jllvm::UnwindFrame context)
+        [&](jllvm::UnwindFrame& context)
         {
             for (const auto& iter : map.lookup(context.getProgramCounter()))
             {

--- a/src/jllvm/unwind/CMakeLists.txt
+++ b/src/jllvm/unwind/CMakeLists.txt
@@ -12,4 +12,4 @@
 # see <http://www.gnu.org/licenses/>.
 
 add_library(JLLVMUnwinder Unwinder.cpp)
-target_link_libraries(JLLVMUnwinder PRIVATE LLVMSupport unwind_static unwind-headers)
+target_link_libraries(JLLVMUnwinder PUBLIC LLVMSupport unwind-headers PRIVATE unwind_static)

--- a/src/jllvm/unwind/CMakeLists.txt
+++ b/src/jllvm/unwind/CMakeLists.txt
@@ -12,4 +12,4 @@
 # see <http://www.gnu.org/licenses/>.
 
 add_library(JLLVMUnwinder Unwinder.cpp)
-target_link_libraries(JLLVMUnwinder PUBLIC LLVMSupport unwind-headers PRIVATE unwind_static)
+target_link_libraries(JLLVMUnwinder PUBLIC LLVMSupport unwind-headers unwind_static)

--- a/src/jllvm/unwind/Unwinder.cpp
+++ b/src/jllvm/unwind/Unwinder.cpp
@@ -14,11 +14,6 @@
 #include "Unwinder.hpp"
 
 #include <llvm/Support/Debug.h>
-#include <llvm/Support/ErrorHandling.h>
-#include <llvm/Support/Format.h>
-#include <llvm/Support/raw_ostream.h>
-
-#include <utility>
 
 #include <jllvm_unwind.h>
 
@@ -26,7 +21,8 @@
 
 namespace
 {
-///
+/// Assert that any use of libunwind didn't cause any errors. Errors while using libunwind are considered toolchain
+/// bugs or errors, not expected error cases.
 void cantFail([[maybe_unused]] int unwindErrorCode)
 {
     assert(unwindErrorCode == 0 && "unwinding action cannot fail");

--- a/src/jllvm/unwind/Unwinder.cpp
+++ b/src/jllvm/unwind/Unwinder.cpp
@@ -14,6 +14,8 @@
 #include "Unwinder.hpp"
 
 #include <llvm/Support/Debug.h>
+#include <llvm/Support/Format.h>
+#include <llvm/Support/raw_ostream.h>
 
 #include <jllvm_unwind.h>
 

--- a/src/jllvm/vm/native/JDK.cpp
+++ b/src/jllvm/vm/native/JDK.cpp
@@ -24,7 +24,7 @@ const jllvm::ClassObject* jllvm::jdk::ReflectionModel::getCallerClass(VirtualMac
 {
     const ClassObject* result = nullptr;
     unwindStack(
-        [&](UnwindFrame frame)
+        [&](const UnwindFrame& frame)
         {
             std::uintptr_t fp = frame.getFunctionPointer();
             std::optional<JavaMethodMetadata> data = virtualMachine.getJIT().getJavaMethodMetadata(fp);


### PR DESCRIPTION
This uses the low level API of `libunwind` rather than the Itanium ABIs as it is generally more powerful. The unwinding API gained one new function called `callerFrame` which can be used to get the caller frame. It is also used to implement `unwindStack` which remains the only function that can create frames.