### PR TITLE
[refactor] remove impossible optimization and refactor `ModelState`

### DIFF
--- a/src/jllvm/compiler/CodeGenerator.cpp
+++ b/src/jllvm/compiler/CodeGenerator.cpp
@@ -821,12 +821,9 @@ bool CodeGenerator::generateInstruction(ByteCodeOp operation)
             FieldType fieldType(
                 refInfo->nameAndTypeIndex.resolve(m_classFile)->descriptorIndex.resolve(m_classFile)->text);
             llvm::Value* fieldOffset = getInstanceFieldOffset(m_builder, className, fieldName, fieldType);
-            // If the class was already loaded 'callee' is optimized to a constant and no exception may occur.
-            if (!llvm::isa<llvm::Constant>(fieldOffset))
-            {
-                // Can throw class loader or linkage related errors.
-                generateEHDispatch();
-            }
+
+            // Can throw class loader or linkage related errors.
+            generateEHDispatch();
 
             llvm::Value* fieldPtr = m_builder.CreateGEP(m_builder.getInt8Ty(), objectRef, {fieldOffset});
             llvm::Value* field = m_builder.CreateLoad(type, fieldPtr);
@@ -844,12 +841,9 @@ bool CodeGenerator::generateInstruction(ByteCodeOp operation)
                 refInfo->nameAndTypeIndex.resolve(m_classFile)->descriptorIndex.resolve(m_classFile)->text);
 
             llvm::Value* fieldPtr = getStaticFieldAddress(m_builder, className, fieldName, fieldType);
-            // If the class was already loaded 'callee' is optimized to a constant and no exception may occur.
-            if (!llvm::isa<llvm::Constant>(fieldPtr))
-            {
-                // Can throw class loader or linkage related errors.
-                generateEHDispatch();
-            }
+
+            // Can throw class loader or linkage related errors.
+            generateEHDispatch();
 
             llvm::Type* type = descriptorToType(fieldType, m_builder.getContext());
             llvm::Value* field = m_builder.CreateLoad(type, fieldPtr);
@@ -1182,12 +1176,8 @@ bool CodeGenerator::generateInstruction(ByteCodeOp operation)
                               });
             }
 
-            // If the class was already loaded 'callee' is optimized to a constant and no exception may occur.
-            if (!llvm::isa<llvm::Constant>(arrayClassObjects[0]))
-            {
-                // Can throw class loader or linkage related errors.
-                generateEHDispatch();
-            }
+            // Can throw class loader or linkage related errors.
+            generateEHDispatch();
 
             llvm::for_each(loopCounts, [&](llvm::Value* count) { generateNegativeArraySizeCheck(count); });
 
@@ -1268,13 +1258,9 @@ bool CodeGenerator::generateInstruction(ByteCodeOp operation)
             llvm::Value* count = m_operandStack.pop_back();
 
             llvm::Value* classObject = getClassObject(m_builder, ArrayType(descriptor));
-            // If the class was already loaded 'callee' is optimized to a constant and no exception may
-            // occur.
-            if (!llvm::isa<llvm::Constant>(classObject))
-            {
-                // Can throw class loader or linkage related errors.
-                generateEHDispatch();
-            }
+
+            // Can throw class loader or linkage related errors.
+            generateEHDispatch();
 
             generateNegativeArraySizeCheck(count);
 
@@ -1323,12 +1309,9 @@ bool CodeGenerator::generateInstruction(ByteCodeOp operation)
             generateNullPointerCheck(objectRef);
 
             llvm::Value* fieldOffset = getInstanceFieldOffset(m_builder, className, fieldName, fieldType);
-            // If the class was already loaded 'callee' is optimized to a constant and no exception may occur.
-            if (!llvm::isa<llvm::Constant>(fieldOffset))
-            {
-                // Can throw class loader or linkage related errors.
-                generateEHDispatch();
-            }
+
+            // Can throw class loader or linkage related errors.
+            generateEHDispatch();
 
             llvm::Value* fieldPtr =
                 m_builder.CreateGEP(llvm::Type::getInt8Ty(m_builder.getContext()), objectRef, {fieldOffset});
@@ -1355,12 +1338,9 @@ bool CodeGenerator::generateInstruction(ByteCodeOp operation)
             llvm::Type* llvmFieldType = descriptorToType(fieldType, m_builder.getContext());
             llvm::Value* value = m_operandStack.pop_back();
             llvm::Value* fieldPtr = getStaticFieldAddress(m_builder, className, fieldName, fieldType);
-            // If the class was already loaded 'callee' is optimized to a constant and no exception may occur.
-            if (!llvm::isa<llvm::Constant>(fieldPtr))
-            {
-                // Can throw class loader or linkage related errors.
-                generateEHDispatch();
-            }
+
+            // Can throw class loader or linkage related errors.
+            generateEHDispatch();
 
             if (value->getType() != llvmFieldType)
             {

--- a/src/jllvm/vm/NativeImplementation.hpp
+++ b/src/jllvm/vm/NativeImplementation.hpp
@@ -25,6 +25,22 @@
 namespace jllvm
 {
 
+/// Default 'State' type of a 'ModelBase' subclass.
+struct ModelState
+{
+    ModelState() = default;
+
+    ModelState(const ModelState&) = delete;
+
+    ModelState(ModelState&&) = delete;
+
+    ModelState& operator=(const ModelState&) = delete;
+
+    ModelState& operator=(ModelState&&) = delete;
+
+    virtual ~ModelState() = default;
+};
+
 /// Base class for any Models used as our high level API for implementing native methods of Java.
 /// This high level API builds on top of the JNI and translates the JNIs general and JVM agnostic C interface to
 /// a more high level C++ API specific to our JVM implementation.
@@ -35,7 +51,7 @@ namespace jllvm
 /// 'StateType' refers to a subclass of 'ModelState', of which a per VM singleton will be default constructed
 /// when registering the model and injected into static methods when requested
 /// or can be accessed from non-static methods using the 'state' field.
-//
+///
 /// Use case for this type is the ability to persist state between function calls within a Model. This is commonly
 /// used to create and then use 'InstanceFieldRef' or 'StaticFieldRef's without having to look them up on every call.
 ///
@@ -207,8 +223,7 @@ auto createMethodBridge(typename Model::State& state, Ret (Model::*ptr)(Args...)
         VirtualMachine& virtualMachine = virtualMachineFromJNIEnv(env);
         if constexpr (!std::is_void_v<Ret>)
         {
-            return coerceReturnType((Model(javaThis, virtualMachine, state).*ptr)(args...),
-                                    virtualMachine);
+            return coerceReturnType((Model(javaThis, virtualMachine, state).*ptr)(args...), virtualMachine);
         }
         else
         {

--- a/src/jllvm/vm/VirtualMachine.cpp
+++ b/src/jllvm/vm/VirtualMachine.cpp
@@ -283,6 +283,8 @@ jllvm::VirtualMachine::VirtualMachine(BootOptions&& bootOptions)
     executeStaticMethod("java/lang/System", "initPhase1", "()V");
 }
 
+jllvm::VirtualMachine::~VirtualMachine() = default;
+
 int jllvm::VirtualMachine::executeMain(llvm::StringRef path, llvm::ArrayRef<llvm::StringRef> args)
 {
     auto buffer = llvm::MemoryBuffer::getFile(path);

--- a/src/jllvm/vm/VirtualMachine.hpp
+++ b/src/jllvm/vm/VirtualMachine.hpp
@@ -30,22 +30,6 @@
 namespace jllvm
 {
 
-/// Default 'State' type of a 'ModelBase' subclass.
-struct ModelState
-{
-    ModelState() = default;
-
-    ModelState(const ModelState&) = delete;
-
-    ModelState(ModelState&&) = delete;
-
-    ModelState& operator=(const ModelState&) = delete;
-
-    ModelState& operator=(ModelState&&) = delete;
-
-    virtual ~ModelState() = default;
-};
-
 /// Options used to boot the VM.
 struct BootOptions
 {
@@ -53,6 +37,8 @@ struct BootOptions
     std::vector<std::string> classPath;
     bool systemInitialization = true;
 };
+
+struct ModelState;
 
 class VirtualMachine
 {
@@ -74,12 +60,21 @@ class VirtualMachine
 
     void initialize(ClassObject& classObject);
 
-    // Type erased instances of 'Model::State'.
-    // The deleter casts the 'void*' back to its real type for destruction.
+    // Instances of 'Model::State', subtypes of ModelState.
     std::vector<std::unique_ptr<ModelState>> m_modelState;
 
 public:
     explicit VirtualMachine(BootOptions&& options);
+
+    VirtualMachine(const VirtualMachine&) = delete;
+
+    VirtualMachine(VirtualMachine&&) = delete;
+
+    VirtualMachine& operator=(const VirtualMachine&) = delete;
+
+    VirtualMachine& operator=(VirtualMachine&&) = delete;
+
+    ~VirtualMachine();
 
     /// Returns a new pseudo random hash code for a Java object.
     /// Since we have a relocating garbage collector we use a similar strategy to V8, where we generate pseudo random


### PR DESCRIPTION
This PR removes the optimizations in exception handling for already loaded classes made impossible by the removal of `LazyClassLoaderHelper` and moves `ModelState` next to  `ModelBase`.