### PR TITLE
[vm] Implement On-Stack-Replacement on `throw`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -67,7 +67,6 @@ Checks: >
   cppcoreguidelines-prefer-member-initializer,
   cppcoreguidelines-pro-type-cstyle-cast,
   cppcoreguidelines-pro-type-member-init,
-  cppcoreguidelines-pro-type-static-cast-downcast,
   cppcoreguidelines-special-member-functions,
   cppcoreguidelines-virtual-class-destructor,
   google-default-arguments,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -71,7 +71,6 @@ Checks: >
   cppcoreguidelines-virtual-class-destructor,
   google-default-arguments,
   google-runtime-operator,
-  hicpp-exception-baseclass,
   hicpp-multiway-paths-covered,
   llvm-else-after-return,
   llvm-namespace-comment,

--- a/src/jllvm/compiler/ClassObjectStubCodeGenerator.cpp
+++ b/src/jllvm/compiler/ClassObjectStubCodeGenerator.cpp
@@ -81,7 +81,7 @@ void buildClassInitializerInitStub(llvm::IRBuilder<>& builder, const jllvm::Clas
 
     builder.CreateCall(
         module->getOrInsertFunction("jllvm_initialize_class_object", builder.getVoidTy(), classObjectLLVM->getType()),
-        classObjectLLVM);
+        classObjectLLVM, llvm::OperandBundleDef("deopt", std::nullopt));
 
     builder.CreateBr(continueBlock);
 
@@ -111,7 +111,7 @@ llvm::CallInst* buildDirectMethodCall(llvm::IRBuilder<>& builder, const jllvm::M
         mangleDirectMethodCall(method),
         jllvm::descriptorToType(method->getType(), method->isStatic(), builder.getContext()));
     applyABIAttributes(llvm::cast<llvm::Function>(callee.getCallee()), method->getType(), method->isStatic());
-    llvm::CallInst* call = builder.CreateCall(callee, args);
+    llvm::CallInst* call = builder.CreateCall(callee, args, llvm::OperandBundleDef("deopt", std::nullopt));
     applyABIAttributes(call, method->getType(), method->isStatic());
     return call;
 }
@@ -208,7 +208,7 @@ llvm::Function* jllvm::generateMethodResolutionCallStub(llvm::Module& module, jl
         llvm::Value* vtblSlot = builder.CreateGEP(builder.getInt8Ty(), thisClassObject, {totalOffset});
         llvm::Value* callee = builder.CreateLoad(builder.getPtrTy(), vtblSlot);
 
-        auto* call = builder.CreateCall(functionType, callee, args);
+        auto* call = builder.CreateCall(functionType, callee, args, llvm::OperandBundleDef("deopt", std::nullopt));
         applyABIAttributes(call, descriptor, /*isStatic=*/false);
         buildRetCall(builder, call);
         return function;
@@ -250,7 +250,7 @@ llvm::Function* jllvm::generateMethodResolutionCallStub(llvm::Module& module, jl
         builder.CreateGEP(iTableType(builder.getContext()), iTable, {builder.getInt32(0), builder.getInt32(1), slot});
     llvm::Value* callee = builder.CreateLoad(builder.getPtrTy(), iTableSlot);
 
-    auto* call = builder.CreateCall(functionType, callee, args);
+    auto* call = builder.CreateCall(functionType, callee, args, llvm::OperandBundleDef("deopt", std::nullopt));
     applyABIAttributes(call, descriptor, /*isStatic=*/false);
     buildRetCall(builder, call);
 

--- a/src/jllvm/compiler/Compiler.cpp
+++ b/src/jllvm/compiler/Compiler.cpp
@@ -100,6 +100,12 @@ llvm::Function* jllvm::compileOSRMethod(llvm::Module& module, std::uint16_t offs
                 llvm::Value* load = builder.CreateLoad(type.get<llvm::Type*>(), gep);
                 builder.CreateStore(load, local);
             }
+
+            // The OSR frame is responsible for deleting its input arrays as the frame that originally allocated the
+            // pointer is replaced.
+            builder.CreateCall(function->getParent()->getOrInsertFunction("jllvm_osr_frame_delete", builder.getVoidTy(),
+                                                                          builder.getPtrTy()),
+                               operandStackInput);
         },
         offset);
 

--- a/src/jllvm/main/Main.cpp
+++ b/src/jllvm/main/Main.cpp
@@ -61,6 +61,9 @@ int jllvm::main(llvm::StringRef executablePath, llvm::ArrayRef<char*> args)
     llvm::SmallVector<const char*> llvmArgs{"jllvm"};
     CommandLine commandLine(args);
 
+    // Deopt values are read-only and can be read from CSR registers by libunwind.
+    llvmArgs.push_back("-use-registers-for-deopt-values=1");
+
 #ifndef NDEBUG
     llvm::SmallString<64> buffer;
     llvmArgs.push_back("-jllvm-gc-every-alloc=1");

--- a/src/jllvm/materialization/JNIImplementationLayer.cpp
+++ b/src/jllvm/materialization/JNIImplementationLayer.cpp
@@ -210,7 +210,8 @@ void jllvm::JNIImplementationLayer::emit(std::unique_ptr<llvm::orc::Materializat
                                                     llvm::FunctionType::get(referenceType, {ptrType}, false)),
                         {methodPtr});
 
-                    builder.CreateStore(exception, module->getOrInsertGlobal("activeException", referenceType));
+                    builder.CreateCall(module->getOrInsertFunction("jllvm_throw", builder.getVoidTy(), referenceType),
+                                       exception);
                     returnValue = llvm::UndefValue::get(referenceType);
                 }
 

--- a/src/jllvm/unwind/Unwinder.cpp
+++ b/src/jllvm/unwind/Unwinder.cpp
@@ -103,7 +103,7 @@ void jllvm::UnwindFrame::resumeExecutionAtFunctionImpl(std::uintptr_t functionPo
         {
             // Identifier used by personality functions whether it knows the kind of exception. Mustn't match what C++
             // uses.
-            std::memcpy(&exception_class, "JLVMJAVA", sizeof(_Unwind_Exception_Class));
+            std::memcpy(&exception_class, "JLVMJAVA", sizeof(exception_class));
             exception_cleanup = +[](_Unwind_Reason_Code, _Unwind_Exception* exception)
             { delete static_cast<ForcedException*>(exception); };
         }
@@ -116,8 +116,7 @@ void jllvm::UnwindFrame::resumeExecutionAtFunctionImpl(std::uintptr_t functionPo
     // implementation.
     _Unwind_ForcedUnwind(
         exception,
-        +[](int, _Unwind_Action, _Unwind_Exception_Class, _Unwind_Exception* exception, _Unwind_Context* context,
-            void* stopPc)
+        +[](int, _Unwind_Action, std::uint64_t, _Unwind_Exception* exception, _Unwind_Context* context, void* stopPc)
         {
             auto* forcedException = static_cast<ForcedException*>(exception);
             std::uintptr_t pc = _Unwind_GetIP(context);

--- a/src/jllvm/unwind/Unwinder.cpp
+++ b/src/jllvm/unwind/Unwinder.cpp
@@ -18,6 +18,7 @@
 #include <llvm/Support/raw_ostream.h>
 
 #include <jllvm_unwind.h>
+#include <unwind.h>
 
 #define DEBUG_TYPE "unwinder"
 
@@ -53,6 +54,91 @@ std::uintptr_t jllvm::UnwindFrame::getFunctionPointer() const
 jllvm::UnwindFrame::UnwindFrame(const jllvm_unw_context_t& context) : m_cursor()
 {
     cantFail(jllvm_unw_init_local(&m_cursor, const_cast<jllvm_unw_context_t*>(&context)));
+}
+
+void jllvm::UnwindFrame::resumeExecutionAtFunctionImpl(std::uintptr_t functionPointer,
+                                                       llvm::ArrayRef<std::uint64_t> arguments) const
+{
+#if defined(__x86_64__) && !defined(_WIN32)
+    constexpr bool stackGrowsDown = true;
+    constexpr bool returnAddressOnStack = true;
+    constexpr std::array<int, argMax> argRegisterNumbers = {UNW_X86_64_RDI, UNW_X86_64_RSI, UNW_X86_64_RDX,
+                                                            UNW_X86_64_RCX, UNW_X86_64_R8,  UNW_X86_64_R9};
+
+#else
+    #error Code not ported for this architecture yet
+#endif
+
+    assert(arguments.size() <= argRegisterNumbers.size());
+
+    // Get the caller frame of this frame and set its frame values. This is required to restore all callee saved
+    // registers before entering 'fnPtr'.
+    std::optional<UnwindFrame> maybeCallerFrame = this->callerFrame();
+    assert(maybeCallerFrame && "Replacing bottom of stack is not supported");
+    UnwindFrame& nextFrame = *maybeCallerFrame;
+
+    // The stack pointer value of the caller is right before the call. If the platform also pushes a return address on
+    // the stack, adjust the stack pointer past the return address as it would be on functon entry.
+    std::uintptr_t nextStack = nextFrame.getIntegerRegister(UNW_REG_SP);
+    if constexpr (returnAddressOnStack)
+    {
+        nextStack += (stackGrowsDown ? -1 : 1) * sizeof(void (*)());
+    }
+
+    nextFrame.setIntegerRegister(UNW_REG_IP, functionPointer);
+    nextFrame.setIntegerRegister(UNW_REG_SP, nextStack);
+
+    // Set the function arguments.
+    for (std::size_t i = 0; i < arguments.size(); i++)
+    {
+        nextFrame.setIntegerRegister(argRegisterNumbers[i], arguments[i]);
+    }
+
+    // Exception object for the force unwind of the C++ stack.
+    struct ForcedException : _Unwind_Exception
+    {
+        UnwindFrame frame;
+
+        explicit ForcedException(const UnwindFrame& frame) : _Unwind_Exception{0}, frame(frame)
+        {
+            // Identifier used by personality functions whether it knows the kind of exception. Mustn't match what C++
+            // uses.
+            std::memcpy(&exception_class, "JLVMJAVA", sizeof(_Unwind_Exception_Class));
+            exception_cleanup = +[](_Unwind_Reason_Code, _Unwind_Exception* exception)
+            { delete static_cast<ForcedException*>(exception); };
+        }
+    };
+
+    // Exception object for the force unwind must be heap allocated as the stack unwinding destroys all local variables.
+    auto* exception = new ForcedException(nextFrame);
+    // Unwind the C++ stack until we have reached the Java frame we want to replace. The program counter of the frame we
+    // want to replace is passed as 'stopPc' and then always compared with the current frame being unwound by the C++
+    // implementation.
+    _Unwind_ForcedUnwind(
+        exception,
+        +[](int, _Unwind_Action, _Unwind_Exception_Class, _Unwind_Exception* exception, _Unwind_Context* context,
+            void* stopPc)
+        {
+            auto* forcedException = static_cast<ForcedException*>(exception);
+            std::uintptr_t pc = _Unwind_GetIP(context);
+            if (pc != reinterpret_cast<std::uintptr_t>(stopPc))
+            {
+                // Continue unwinding.
+                return _URC_NO_REASON;
+            }
+
+            // Reached the Java frame to replace. Get the internal cursor that all modifications have been performed on
+            // so far and apply them.
+            jllvm_unw_cursor_t cursor = forcedException->frame.m_cursor;
+            // Make sure to now erase the heap allocated exception object.
+            _Unwind_DeleteException(exception);
+            jllvm_unw_resume(&cursor);
+
+            llvm_unreachable("resume should not have returned");
+        },
+        reinterpret_cast<void*>(getProgramCounter()));
+
+    llvm_unreachable("_Unwind_ForcedUnwind should not have returned");
 }
 
 namespace

--- a/src/jllvm/unwind/Unwinder.hpp
+++ b/src/jllvm/unwind/Unwinder.hpp
@@ -89,8 +89,9 @@ public:
     }
 
     /// Replaces this frame and all its direct or indirect callees with the execution of 'fnPtr' called with 'args'.
-    /// This first performs C++ stack unwinding to run any destructors all callee frames. 'fnPtr' is required to have
-    /// the same return type or a compatible return type as determined by the platform ABI.
+    /// This first performs C++ stack unwinding to run any destructors in all callee frames. 'fnPtr' is required to have
+    /// the same return type or a compatible return type as determined by the platform ABI as the function being
+    /// executed by this frame.
     /// The argument types and count supported by 'args' is platform dependent but must currently support at least two
     /// arguments of pointer types.
     template <class Ret, typename... Args>

--- a/src/jllvm/unwind/Unwinder.hpp
+++ b/src/jllvm/unwind/Unwinder.hpp
@@ -94,7 +94,8 @@ public:
     /// The argument types and count supported by 'args' is platform dependent but must currently support at least two
     /// arguments of pointer types.
     template <class Ret, typename... Args>
-    [[noreturn]] void resumeExecutionAtFunction(Ret (*fnPtr)(Args...), std::type_identity<Args>::type... args) const
+    [[noreturn]] void resumeExecutionAtFunction(Ret (*fnPtr)(Args...),
+                                                typename std::type_identity<Args>::type... args) const
         requires((std::is_void_v<Ret> || abiSupported<Ret>)&&...&& abiSupported<Args>)
     {
         std::array<std::uint64_t, sizeof...(args)> array{llvm::bit_cast<std::uint64_t>(args)...};

--- a/src/jllvm/vm/CMakeLists.txt
+++ b/src/jllvm/vm/CMakeLists.txt
@@ -18,9 +18,9 @@ add_library(JLLVMVirtualMachine VirtualMachine.cpp JIT.cpp StackMapRegistrationP
         native/Lang.cpp native/JDK.cpp native/Security.cpp
         ClassObjectStubImportPass.cpp)
 target_link_libraries(JLLVMVirtualMachine
-        PRIVATE JLLVMUnwinder ${llvm_native_libs} LLVMTargetParser LLVMOrcTargetProcess LLVMScalarOpts LLVMAnalysis
-        PUBLIC JLLVMClassParser JLLVMObject JLLVMGC JLLVMMaterialization LLVMExecutionEngine LLVMOrcJIT LLVMJITLink
-        LLVMPasses
+        PRIVATE ${llvm_native_libs} LLVMTargetParser LLVMOrcTargetProcess LLVMScalarOpts LLVMAnalysis
+        PUBLIC JLLVMClassParser JLLVMObject JLLVMGC JLLVMMaterialization JLLVMUnwinder LLVMExecutionEngine LLVMOrcJIT
+        LLVMJITLink LLVMPasses
         )
 
 set(JAVA_INCLUDE_PATH "${JAVA_HOME}/../include")

--- a/src/jllvm/vm/JIT.cpp
+++ b/src/jllvm/vm/JIT.cpp
@@ -287,7 +287,8 @@ llvm::SmallVector<std::uint64_t> jllvm::JIT::readLocals(const UnwindFrame& frame
                 std::memcpy(&value, framePointer, indirect.size);
                 return value;
             },
-            [&](DeoptEntry::Direct direct) -> std::uint64_t { llvm_unreachable("not doing stack allocations yet"); });
+            [&](DeoptEntry::Direct /*direct*/) -> std::uint64_t
+            { llvm_unreachable("not doing stack allocations yet"); });
     }
 
     return result;

--- a/src/jllvm/vm/JIT.cpp
+++ b/src/jllvm/vm/JIT.cpp
@@ -318,7 +318,7 @@ void jllvm::JIT::doExceptionOnStackReplacement(const UnwindFrame& frame, std::ui
     llvm::cantFail(m_optimizeLayer.add(m_main, llvm::orc::ThreadSafeModule(std::move(module), std::move(context))));
 
     llvm::JITEvaluatedSymbol osrMethod =
-        llvm::cantFail(m_session->lookup({&m_main}, mangleOSRMethod(&method, byteCodeOffset)));
+        llvm::cantFail(m_session->lookup({&m_main}, m_interner(mangleOSRMethod(&method, byteCodeOffset))));
     frame.resumeExecutionAtFunction(reinterpret_cast<void (*)(std::uint64_t*, std::uint64_t*)>(osrMethod.getAddress()),
                                     operandPtr, localsPtr);
 }

--- a/src/jllvm/vm/StackMapRegistrationPlugin.hpp
+++ b/src/jllvm/vm/StackMapRegistrationPlugin.hpp
@@ -17,16 +17,25 @@
 
 #include <jllvm/gc/GarbageCollector.hpp>
 
+#include <utility>
+
+#include "JIT.hpp"
+
 namespace jllvm
 {
 /// JIT link plugin for extracting the LLVM generated stack map section out of materialized objects and notifying
 /// the GC about newly added entries.
 class StackMapRegistrationPlugin : public llvm::orc::ObjectLinkingLayer::Plugin
 {
-    jllvm::GarbageCollector& m_gc;
+    GarbageCollector& m_gc;
+    std::function<void(std::uintptr_t, JIT::DeoptEntry&&)> m_deoptEntryParsed;
 
 public:
-    explicit StackMapRegistrationPlugin(jllvm::GarbageCollector& gc) : m_gc(gc) {}
+    explicit StackMapRegistrationPlugin(GarbageCollector& gc,
+                                        std::function<void(std::uintptr_t, JIT::DeoptEntry&&)> deoptEntryParsed)
+        : m_gc(gc), m_deoptEntryParsed(std::move(deoptEntryParsed))
+    {
+    }
 
     llvm::Error notifyFailed(llvm::orc::MaterializationResponsibility&) override;
 

--- a/src/jllvm/vm/VirtualMachine.hpp
+++ b/src/jllvm/vm/VirtualMachine.hpp
@@ -50,7 +50,6 @@ class VirtualMachine
     ClassLoader m_classLoader;
     GarbageCollector m_gc;
     StringInterner m_stringInterner;
-    GCRootRef<Throwable> m_activeException = static_cast<GCRootRef<Throwable>>(m_gc.allocateStatic());
     JIT m_jit = JIT::create(m_classLoader, m_gc, m_stringInterner, m_jniEnv.get());
     std::mt19937 m_pseudoGen;
     std::uniform_int_distribution<std::uint32_t> m_hashIntDistrib;
@@ -62,6 +61,8 @@ class VirtualMachine
 
     // Instances of 'Model::State', subtypes of ModelState.
     std::vector<std::unique_ptr<ModelState>> m_modelState;
+
+    [[noreturn]] void unwindStackForExceptionHandling(Throwable* exception);
 
 public:
     explicit VirtualMachine(BootOptions&& options);

--- a/tests/Execution/deopt-smaller-than-pointer.j
+++ b/tests/Execution/deopt-smaller-than-pointer.j
@@ -1,0 +1,49 @@
+; RUN: jasmin %s -d %t
+; RUN: jllvm %t/Test.class | FileCheck %s
+
+.class public Test
+.super java/lang/Object
+
+.method public <init>()V
+    aload_0
+    invokespecial java/lang/Object/<init>()V
+    return
+.end method
+
+.method public static native print(F)V
+.end method
+
+.method public static native print(I)V
+.end method
+
+.method public static raise()V
+    .limit stack 2
+    new java/lang/RuntimeException
+    dup
+    invokespecial java/lang/RuntimeException/<init>()V
+    athrow
+.end method
+
+; Check that smaller types such as int or float can be read and restored properly as well.
+.method public static main([Ljava/lang/String;)V
+    .limit locals 2
+    .limit stack 2
+    ldc 3.25
+    fstore 0
+    iconst_5
+    istore_1
+Lstart:
+    invokestatic Test/raise()V
+    return
+Lend:
+    fload_0
+    ; CHECK: 3.25
+    invokestatic Test/print(F)V
+    iload_1
+    ; CHECK: 5
+    invokestatic Test/print(I)V
+    return
+
+.catch all from Lstart to Lend using Lend
+
+.end method


### PR DESCRIPTION
This is the very first mechanism making use of OSR. This PR completely replaces the manual checks of `activeException` entirely with a system more closely matching how exception handling works in languages like C++ with the addition of JIT and OSR.

The new exception handling now works through the use of "deoptimization" operands in LLVM. These are operands that are put into the stackmap and can be read by the unwinder, similarily to how GC pointers are currently read. When an exception is thrown, we unwind the stack and search for the frame of a Java method that contains an exception handler for the thrown exception. If found, the deoptimization operands are used to read the local variables in that frame and transfer them to a new JIT compiled OSR frame that starts at the exception handling.

The large advantage of this mechanism as opposed to the previous is that there is no longer an explicit need to check whether an exception has been thrown after a call. Futhermore, the code for exception handlers is not generated and compiled at all unless there is an `athrow` in a method making it reachable. Since exceptions are naturally "exceptional" cold code it should lead to both better compile time (and therefore VM runtime) + better code generation on the non-exceptional code path. The last point is made a bit mood by the extra code generation required to make the deopt operands readable but can potentially be improved in the future through liveness analysis checking which local variables are actually needed.