### PR TITLE
[compiler] Add optimization for static final fields

### DIFF
--- a/src/jllvm/class/ClassFile.hpp
+++ b/src/jllvm/class/ClassFile.hpp
@@ -369,6 +369,12 @@ public:
     {
         return m_attributes;
     }
+
+    /// Returns the access flags of this field.
+    AccessFlag getAccessFlags() const
+    {
+        return m_accessFlags;
+    }
 };
 
 /// Info object of a method of the class represented by the class file.

--- a/src/jllvm/compiler/ClassObjectStubCodeGenerator.cpp
+++ b/src/jllvm/compiler/ClassObjectStubCodeGenerator.cpp
@@ -116,6 +116,48 @@ llvm::CallInst* buildDirectMethodCall(llvm::IRBuilder<>& builder, const jllvm::M
     return call;
 }
 
+/// Returns a new global constant named 'mangledName' initialized from static final contents of 'field' given by its
+/// type (only primitive JVM types are allowed)
+llvm::GlobalVariable* createGlobalConstant(llvm::Module& module, llvm::StringRef mangledName, const jllvm::Field* field)
+{
+    auto* initializer = jllvm::match(
+        field->getType(),
+        [&](jllvm::BaseType baseType) -> llvm::Constant*
+        {
+            switch (baseType.getValue())
+            {
+                case jllvm::BaseType::Void: break;
+                case jllvm::BaseType::Boolean:
+                case jllvm::BaseType::Byte:
+                    return llvm::ConstantInt::get(llvm::Type::getInt8Ty(module.getContext()),
+                                                  *static_cast<const std::int8_t*>(field->getAddressOfStatic()));
+                case jllvm::BaseType::Short:
+                    return llvm::ConstantInt::get(llvm::Type::getInt16Ty(module.getContext()),
+                                                  *static_cast<const std::int16_t*>(field->getAddressOfStatic()));
+                case jllvm::BaseType::Char:
+                    return llvm::ConstantInt::get(llvm::Type::getInt16Ty(module.getContext()),
+                                                  *static_cast<const std::uint16_t*>(field->getAddressOfStatic()));
+                case jllvm::BaseType::Double:
+                    return llvm::ConstantFP::get(llvm::Type::getDoubleTy(module.getContext()),
+                                                 *static_cast<const double*>(field->getAddressOfStatic()));
+                case jllvm::BaseType::Float:
+                    return llvm::ConstantFP::get(llvm::Type::getFloatTy(module.getContext()),
+                                                 *static_cast<const float*>(field->getAddressOfStatic()));
+                case jllvm::BaseType::Int:
+                    return llvm::ConstantInt::get(llvm::Type::getInt32Ty(module.getContext()),
+                                                  *static_cast<const std::int32_t*>(field->getAddressOfStatic()));
+                case jllvm::BaseType::Long:
+                    return llvm::ConstantInt::get(llvm::Type::getInt64Ty(module.getContext()),
+                                                  *static_cast<const std::int64_t*>(field->getAddressOfStatic()));
+            }
+            llvm_unreachable("Fields of void type are not allowed");
+        },
+        [&](auto) -> llvm::Constant* { llvm_unreachable("Reference types are not allowed to be cached"); });
+
+    return new llvm::GlobalVariable(module, initializer->getType(), true, llvm::GlobalValue::InternalLinkage,
+                                    initializer, mangledName);
+}
+
 } // namespace
 
 llvm::Function* jllvm::generateFieldAccessStub(llvm::Module& module, const ClassObject& classObject,
@@ -146,7 +188,7 @@ llvm::Function* jllvm::generateFieldAccessStub(llvm::Module& module, const Class
     llvm::IRBuilder<> builder(llvm::BasicBlock::Create(module.getContext(), "entry", function));
 
     // Static field accesses trigger class object initializations.
-    if (field->isStatic() && !classObject.isInitialized())
+    if (field->isStatic() && !classObject.markedInitialized())
     {
         buildClassInitializerInitStub(builder, classObject);
     }
@@ -154,8 +196,17 @@ llvm::Function* jllvm::generateFieldAccessStub(llvm::Module& module, const Class
     llvm::Value* returnValue;
     if (field->isStatic())
     {
-        returnValue = builder.CreateIntToPtr(
-            builder.getInt64(reinterpret_cast<std::uint64_t>(field->getAddressOfStatic())), returnType);
+        // Only sound if field is static, final, initialized and not a reference type
+        if (classObject.isInitialized() && !descriptor.isReference())
+        {
+            returnValue = createGlobalConstant(
+                module, mangleFieldAccess(classObject.getClassName(), fieldName, descriptor), field);
+        }
+        else
+        {
+            returnValue = builder.CreateIntToPtr(
+                builder.getInt64(reinterpret_cast<std::uint64_t>(field->getAddressOfStatic())), returnType);
+        }
     }
     else
     {
@@ -299,7 +350,7 @@ llvm::Function* jllvm::generateStaticCallStub(llvm::Module& module, const ClassO
     TrivialDebugInfoBuilder debugInfoBuilder(function);
     llvm::IRBuilder<> builder(llvm::BasicBlock::Create(module.getContext(), "entry", function));
 
-    if (!classObject.isInitialized())
+    if (!classObject.markedInitialized())
     {
         buildClassInitializerInitStub(builder, classObject);
     }

--- a/src/jllvm/object/ClassLoader.cpp
+++ b/src/jllvm/object/ClassLoader.cpp
@@ -122,11 +122,12 @@ jllvm::ClassObject& jllvm::ClassLoader::add(std::unique_ptr<llvm::MemoryBuffer>&
             FieldType descriptor = fieldInfo.getDescriptor(classFile);
             if (descriptor.isReference())
             {
-                fields.emplace_back(fieldInfo.getName(classFile), descriptor, m_allocateStatic());
+                fields.emplace_back(fieldInfo.getName(classFile), descriptor, m_allocateStatic(),
+                                    fieldInfo.getAccessFlags());
                 continue;
             }
 
-            fields.emplace_back(fieldInfo.getName(classFile), descriptor);
+            fields.emplace_back(fieldInfo.getName(classFile), descriptor, fieldInfo.getAccessFlags());
             continue;
         }
 
@@ -151,7 +152,7 @@ jllvm::ClassObject& jllvm::ClassLoader::add(std::unique_ptr<llvm::MemoryBuffer>&
             [](const ObjectType&) { return sizeof(void*); }, [](const ArrayType&) { return sizeof(void*); });
         instanceSize = llvm::alignTo(instanceSize, fieldSizeAndAlignment);
         fields.emplace_back(fieldInfo.getName(classFile), fieldInfo.getDescriptor(classFile),
-                            instanceSize + sizeof(ObjectHeader));
+                            instanceSize + sizeof(ObjectHeader), fieldInfo.getAccessFlags());
         instanceSize += fieldSizeAndAlignment;
     }
     instanceSize = llvm::alignTo(instanceSize, alignof(ObjectHeader));

--- a/src/jllvm/object/ClassObject.cpp
+++ b/src/jllvm/object/ClassObject.cpp
@@ -88,9 +88,9 @@ jllvm::ClassObject* jllvm::ClassObject::create(llvm::BumpPtrAllocator& allocator
     void* storage =
         allocator.Allocate(ClassObject::totalSizeToAlloc<VTableSlot>(allocatedVTableSlots), alignof(ClassObject));
     llvm::MutableArrayRef<Method> methodsAlloc = arrayRefAlloc(allocator, methods);
-    auto* result = new (storage)
-        ClassObject(metaClass, vTableSlots, fieldAreaSize, NonOwningFrozenSet(methodsAlloc, allocator),
-                    NonOwningFrozenSet(arrayRefAlloc(allocator, fields), allocator), arrayRefAlloc(allocator, bases),
+    auto* result = new (storage) ClassObject(
+        metaClass, vTableSlots, fieldAreaSize, NonOwningFrozenSet(methodsAlloc, allocator),
+        NonOwningFrozenSet(arrayRefAlloc(allocator, fields), allocator), arrayRefAlloc(allocator, bases),
         arrayRefAlloc(allocator, iTables), classFile.getThisClass(), classFile, arrayRefAlloc(allocator, gcMask));
     for (Method& method : methodsAlloc)
     {
@@ -143,7 +143,7 @@ jllvm::ClassObject* jllvm::ClassObject::createArray(llvm::BumpPtrAllocator& allo
         ClassObject(metaClass, arrayFieldAreaSize,
                     stringSaver.save(FieldType(ArrayType(componentType->getDescriptor())).textual()));
     result->m_componentTypeOrInterfaceId = componentType;
-    result->m_initialized = true;
+    result->m_initialized = InitializationStatus::Initialized;
     return result;
 }
 
@@ -152,7 +152,7 @@ jllvm::ClassObject::ClassObject(std::uint32_t instanceSize, llvm::StringRef name
 {
     // NOLINTBEGIN(*-prefer-member-initializer): https://github.com/llvm/llvm-project/issues/52818
     m_isPrimitive = true;
-    m_initialized = true;
+    m_initialized = InitializationStatus::Initialized;
     // NOLINTEND(*-prefer-member-initializer)
 }
 

--- a/src/jllvm/object/ClassObject.hpp
+++ b/src/jllvm/object/ClassObject.hpp
@@ -45,14 +45,6 @@ enum class Visibility : std::uint8_t
     Protected = 0b11
 };
 
-/// Initialization status of a class
-enum class InitializationStatus : std::uint8_t
-{
-    Uninitialized,
-    UnderInitialization,
-    Initialized,
-};
-
 /// Object for representing a classes method.
 class Method
 {
@@ -401,6 +393,14 @@ public:
     {
         return getTrailingObjects<VTableSlot>();
     }
+};
+
+/// Initialization status of a class
+enum class InitializationStatus : std::uint8_t
+{
+    Uninitialized = 0,
+    UnderInitialization = 1,
+    Initialized = 2,
 };
 
 /// Class object representing Java 'Class' objects. Class objects serve all introspections needs of Java
@@ -754,10 +754,9 @@ public:
         return offsetof(ClassObject, m_initialized);
     }
 
-    bool markedInitialized() const
+    bool isUnintialized() const
     {
-        return m_initialized == InitializationStatus::UnderInitialization
-               || m_initialized == InitializationStatus::Initialized;
+        return m_initialized == InitializationStatus::Uninitialized;
     }
 
     bool isInitialized() const
@@ -765,14 +764,9 @@ public:
         return m_initialized == InitializationStatus::Initialized;
     }
 
-    void markInitialized()
+    void setInitializationStatus(InitializationStatus status)
     {
-        m_initialized = InitializationStatus::UnderInitialization;
-    }
-
-    void setInitialized()
-    {
-        m_initialized = InitializationStatus::Initialized;
+        m_initialized = status;
     }
 
     /// Byte offset from the start of the class object to the start of the VTable.

--- a/src/jllvm/vm/VirtualMachine.cpp
+++ b/src/jllvm/vm/VirtualMachine.cpp
@@ -328,12 +328,12 @@ std::int32_t jllvm::VirtualMachine::createNewHashCode()
 
 void jllvm::VirtualMachine::initialize(ClassObject& classObject)
 {
-    if (classObject.markedInitialized())
+    if (!classObject.isUnintialized())
     {
         return;
     }
 
-    classObject.markInitialized();
+    classObject.setInitializationStatus(InitializationStatus::UnderInitialization);
 
     // 5.5 Step 7:
     // Next, if C is a class rather than an interface, then let SC be its superclass and let SI1, ..., SIn be
@@ -363,5 +363,5 @@ void jllvm::VirtualMachine::initialize(ClassObject& classObject)
                      << mangleDirectMethodCall(classObject.getClassName(), "<clinit>", "()V") << '\n';
     });
     reinterpret_cast<void (*)()>(classInitializer->getAddress())();
-    classObject.setInitialized();
+    classObject.setInitializationStatus(InitializationStatus::Initialized);
 }

--- a/src/jllvm/vm/VirtualMachine.cpp
+++ b/src/jllvm/vm/VirtualMachine.cpp
@@ -328,12 +328,12 @@ std::int32_t jllvm::VirtualMachine::createNewHashCode()
 
 void jllvm::VirtualMachine::initialize(ClassObject& classObject)
 {
-    if (classObject.isInitialized())
+    if (classObject.markedInitialized())
     {
         return;
     }
 
-    classObject.setInitialized(true);
+    classObject.markInitialized();
 
     // 5.5 Step 7:
     // Next, if C is a class rather than an interface, then let SC be its superclass and let SI1, ..., SIn be
@@ -363,4 +363,5 @@ void jllvm::VirtualMachine::initialize(ClassObject& classObject)
                      << mangleDirectMethodCall(classObject.getClassName(), "<clinit>", "()V") << '\n';
     });
     reinterpret_cast<void (*)()>(classInitializer->getAddress())();
+    classObject.setInitialized();
 }

--- a/tests/Execution/static-final-fields-optimization.java
+++ b/tests/Execution/static-final-fields-optimization.java
@@ -1,0 +1,75 @@
+// RUN: javac %s -d %t
+// RUN: jllvm %t/Test.class | FileCheck %s
+
+class Test
+{
+    public static final boolean z = getZ();
+    public static final byte b = getB();
+    public static final char c = getC();
+    public static final double d = getD();
+    public static final float f = getF();
+    public static final int i = getI();
+    public static final long l = getL();
+    public static final short s = getS();
+
+    public static native void print(boolean b);
+    public static native void print(byte b);
+    public static native void print(char c);
+    public static native void print(double f);
+    public static native void print(float f);
+    public static native void print(int i);
+    public static native void print(long l);
+    public static native void print(short s);
+
+    public static void main(String[] args)
+    {
+        // CHECK: 1
+        print(Test.z);
+        // CHECK: -42
+        print(Test.b);
+        // CHECK: 67
+        print(Test.c);
+        // CHECK: 2.71828182846
+        print(Test.d);
+        // CHECK: 3.14159
+        print(Test.f);
+        // CHECK: -123456789
+        print(Test.i);
+        // CHECK: 987654321
+        print(Test.l);
+        // CHECK: 1234
+        print(Test.s);
+    }
+
+    public static boolean getZ(){
+        return true;
+    }
+
+    public static byte getB(){
+        return -42;
+    }
+
+    public static char getC(){
+        return 'C';
+    }
+
+    public static double getD(){
+        return 2.71828182846d;
+    }
+
+    public static float getF(){
+        return 3.141592f;
+    }
+
+    public static int getI(){
+        return -123456789;
+    }
+
+    public static long getL(){
+        return 987654321;
+    }
+
+    public static short getS(){
+        return 1234;
+    }
+}


### PR DESCRIPTION
This PR adds an optimization for for accessing static final fields of non-reference types.
When generating code for every such field, if the class object is already initialized, a static constant within the LLVM IR is created with the value of the field. In all further accesses that value will be used removing the need to load from memory.

Fixes: #10 