### PR TITLE
[vm][compiler] Introduce globals for class objects and methods

### DIFF
--- a/src/jllvm/compiler/ByteCodeCompileUtils.hpp
+++ b/src/jllvm/compiler/ByteCodeCompileUtils.hpp
@@ -38,6 +38,12 @@ llvm::Type* objectHeaderType(llvm::LLVMContext& context);
 /// This is a pointer tagged with an address space for the sake of the GC.
 llvm::PointerType* referenceType(llvm::LLVMContext& context);
 
+/// Returns the global variable importing the class object of the given descriptor.
+llvm::GlobalVariable* classObjectGlobal(llvm::Module& module, FieldType classObject);
+
+/// Returns the global variable importing the given method.
+llvm::GlobalVariable* methodGlobal(llvm::Module& module, const Method* method);
+
 /// Returns the corresponding LLVM type for a given Java field descriptor.
 llvm::Type* descriptorToType(FieldType type, llvm::LLVMContext& context);
 

--- a/src/jllvm/compiler/ClassObjectStubCodeGenerator.hpp
+++ b/src/jllvm/compiler/ClassObjectStubCodeGenerator.hpp
@@ -57,6 +57,6 @@ llvm::Function* generateSpecialMethodCallStub(llvm::Module& module, const ClassO
 llvm::Function* generateStaticCallStub(llvm::Module& module, const ClassObject& classObject, llvm::StringRef methodName,
                                        MethodType descriptor, const ClassObject& objectClass);
 
-llvm::Function* generateClassObjectAccessStub(llvm::Module& module, const ClassObject& classObject);
+llvm::Function* generateClassObjectAccessStub(llvm::Module& module, FieldType classObject);
 
 } // namespace jllvm

--- a/src/jllvm/compiler/ClassObjectStubMangling.hpp
+++ b/src/jllvm/compiler/ClassObjectStubMangling.hpp
@@ -100,6 +100,18 @@ std::string mangleStaticCall(llvm::StringRef className, llvm::StringRef methodNa
 /// <class-object-access> ::= 'Load ' <descriptor>
 std::string mangleClassObjectAccess(FieldType descriptor);
 
+/// Mangling for a global importing a class object.
+///
+/// Syntax:
+/// <class-object-global> ::= <descriptor>
+std::string mangleClassObjectGlobal(FieldType descriptor);
+
+/// Mangling for a global importing a method.
+///
+/// Syntax:
+/// <method-global> ::= '&' <direct-call>
+std::string mangleMethodGlobal(const Method* method);
+
 /// A call produced via 'mangleFieldAccess'.
 struct DemangledFieldAccess
 {
@@ -134,8 +146,21 @@ struct DemangledSpecialCall
     std::optional<FieldType> callerClass;
 };
 
-using DemangledVariant = swl::variant<std::monostate, DemangledFieldAccess, DemangledMethodResolutionCall,
-                                      DemangledStaticCall, FieldType, DemangledSpecialCall>;
+/// A call produced via 'mangleClassObjectAccess'.
+struct DemangledLoadClassObject
+{
+    FieldType classObject;
+};
+
+/// A global produced via 'mangleClassObjectGlobal'.
+struct DemangledClassObjectGlobal
+{
+    FieldType classObject;
+};
+
+using DemangledVariant =
+    swl::variant<std::monostate, DemangledFieldAccess, DemangledMethodResolutionCall, DemangledStaticCall,
+                 DemangledLoadClassObject, DemangledSpecialCall, DemangledClassObjectGlobal>;
 
 /// Attempts to demangle a symbol produced by any of the 'mangle*' functions above with the exception of
 /// 'mangleDirectMethodCall'.

--- a/src/jllvm/llvm/ClassObjectStubImportPass.cpp
+++ b/src/jllvm/llvm/ClassObjectStubImportPass.cpp
@@ -49,14 +49,13 @@ llvm::PreservedAnalyses jllvm::ClassObjectStubImportPass::run(llvm::Module& modu
                 }
                 return generateFieldAccessStub(module, *classObject, fieldAccess.fieldName, fieldAccess.descriptor);
             },
-            [&](FieldType fieldType) -> llvm::Function*
+            [&](DemangledLoadClassObject loadClassObject) -> llvm::Function*
             {
-                ClassObject* classObject = m_classLoader.forNameLoaded(fieldType);
-                if (!classObject)
+                if (!m_classLoader.forNameLoaded(loadClassObject.classObject))
                 {
                     return nullptr;
                 }
-                return generateClassObjectAccessStub(module, *classObject);
+                return generateClassObjectAccessStub(module, loadClassObject.classObject);
             },
             [&](const DemangledStaticCall& staticCall) -> llvm::Function*
             {
@@ -98,7 +97,7 @@ llvm::PreservedAnalyses jllvm::ClassObjectStubImportPass::run(llvm::Module& modu
                 return generateSpecialMethodCallStub(module, *classObject, specialCall.methodName,
                                                      specialCall.descriptor, callerClass, *objectClass);
             },
-            [](std::monostate) -> llvm::Function* { return nullptr; });
+            [](...) -> llvm::Function* { return nullptr; });
         if (!definition)
         {
             continue;

--- a/src/jllvm/materialization/ClassObjectStubDefinitionsGenerator.cpp
+++ b/src/jllvm/materialization/ClassObjectStubDefinitionsGenerator.cpp
@@ -37,11 +37,8 @@ llvm::orc::ThreadSafeModule compile(const DemangledVariant& variant, ClassLoader
             ClassObject& classObject = classLoader.forName(ObjectType(fieldAccess.className));
             generateFieldAccessStub(*module, classObject, fieldAccess.fieldName, fieldAccess.descriptor);
         },
-        [&](FieldType fieldType)
-        {
-            ClassObject& classObject = classLoader.forName(fieldType);
-            generateClassObjectAccessStub(*module, classObject);
-        },
+        [&](DemangledLoadClassObject demangledLoadClassObject)
+        { generateClassObjectAccessStub(*module, demangledLoadClassObject.classObject); },
         [&](const DemangledStaticCall& staticCall)
         {
             ClassObject& classObject = classLoader.forName(ObjectType(staticCall.className));
@@ -65,7 +62,7 @@ llvm::orc::ThreadSafeModule compile(const DemangledVariant& variant, ClassLoader
             generateSpecialMethodCallStub(*module, classObject, specialCall.methodName, specialCall.descriptor,
                                           callerClass, *objectClass);
         },
-        [](std::monostate) { llvm_unreachable("not possible"); });
+        [](...) {});
     return llvm::orc::ThreadSafeModule(std::move(module), std::move(context));
 }
 
@@ -97,6 +94,14 @@ llvm::Error jllvm::ClassObjectStubDefinitionsGenerator::tryToGenerate(llvm::orc:
         DemangledVariant demangleVariant = demangleStubSymbolName(name);
         if (holds_alternative<std::monostate>(demangleVariant))
         {
+            continue;
+        }
+
+        // Globals are resolved immediately. Its not possible to use a compile stub or the like.
+        if (auto* classObjectGlobal = get_if<DemangledClassObjectGlobal>(&demangleVariant))
+        {
+            generated[symbol] =
+                llvm::JITEvaluatedSymbol::fromPointer(&m_classLoader.forName(classObjectGlobal->classObject));
             continue;
         }
 

--- a/src/jllvm/materialization/ClassObjectStubDefinitionsGenerator.cpp
+++ b/src/jllvm/materialization/ClassObjectStubDefinitionsGenerator.cpp
@@ -62,7 +62,7 @@ llvm::orc::ThreadSafeModule compile(const DemangledVariant& variant, ClassLoader
             generateSpecialMethodCallStub(*module, classObject, specialCall.methodName, specialCall.descriptor,
                                           callerClass, *objectClass);
         },
-        [](...) {});
+        [](...) { llvm_unreachable("not possible"); });
     return llvm::orc::ThreadSafeModule(std::move(module), std::move(context));
 }
 

--- a/src/jllvm/materialization/JNIImplementationLayer.cpp
+++ b/src/jllvm/materialization/JNIImplementationLayer.cpp
@@ -138,8 +138,7 @@ void jllvm::JNIImplementationLayer::emit(std::unique_ptr<llvm::orc::Materializat
         llvm::SmallVector<llvm::Value*> args{environment};
         if (method->isStatic())
         {
-            args.push_back(builder.CreateIntToPtr(
-                builder.getInt64(reinterpret_cast<std::uintptr_t>(method->getClassObject())), referenceType));
+            args.push_back(classObjectGlobal(*module, method->getClassObject()->getDescriptor()));
         }
 
         for (llvm::Argument& arg : function->args())
@@ -199,8 +198,7 @@ void jllvm::JNIImplementationLayer::emit(std::unique_ptr<llvm::orc::Materializat
         llvm::consumeError(lookup.takeError());
         llvm::Type* ptrType = builder.getPtrTy();
 
-        llvm::Value* methodPtr =
-            builder.CreateIntToPtr(builder.getInt64(reinterpret_cast<std::uintptr_t>(method)), ptrType);
+        llvm::Value* methodPtr = methodGlobal(*module, method);
 
         llvm::Value* exception =
             builder.CreateCall(module->getOrInsertFunction("jllvm_build_unsatisfied_link_error",

--- a/tests/Compiler/method-metadata.j
+++ b/tests/Compiler/method-metadata.j
@@ -1,0 +1,23 @@
+; RUN: jasmin %s -d %t
+; RUN: jllvm-jvmc --method "test:()V" %t/Test.class | FileCheck %s
+
+.class public Test
+.super java/lang/Object
+
+.field public static foo Ljava/lang/Object;
+
+.method public <init>()V
+    aload_0
+    invokespecial java/lang/Object/<init>()V
+    return
+.end method
+
+.method public static native print(I)V
+.end method
+
+; CHECK-LABEL: define void @"Test.test:()V"
+; CHECK-SAME: prefix { ptr addrspace(1), ptr } { ptr addrspace(1) @"LTest;", ptr @"&Test.test:()V" }
+.method public static test()V
+    .limit stack 1
+    return
+.end method


### PR DESCRIPTION
Class objects and pointers to globals have so far been embedded in IR with their address. This is undesirable for many reasons, some described in https://github.com/JLLVM/JLLVM/issues/196. This PR replaces the pointer embedding with proper external global variables which the JIT linker later resolves to the actual class object and method.

Depends on https://github.com/JLLVM/JLLVM/pull/224