### PR TITLE
[refactor] move `ByteCodeTypeInfo` into `ByteCodeTypeChecker`

### DIFF
--- a/src/jllvm/compiler/CodeGenerator.cpp
+++ b/src/jllvm/compiler/CodeGenerator.cpp
@@ -211,7 +211,7 @@ void CodeGenerator::generateBody(const Code& code, PrologueGenFn generatePrologu
     ByteCodeTypeChecker checker{m_builder.getContext(), m_classFile, code, m_functionMethodType};
 
     // Perform the type check as the information is potentially required in the prologue generation.
-    const auto& typeInfo = checker.checkAndGetTypeInfo(offset);
+    const ByteCodeTypeChecker::TypeInfo& typeInfo = checker.checkAndGetTypeInfo(offset);
 
     generatePrologue(m_builder, m_locals, m_operandStack, typeInfo);
 

--- a/src/jllvm/compiler/CodeGenerator.hpp
+++ b/src/jllvm/compiler/CodeGenerator.hpp
@@ -147,8 +147,9 @@ public:
     CodeGenerator(CodeGenerator&&) = delete;
     CodeGenerator& operator=(CodeGenerator&&) = delete;
 
-    using PrologueGenFn = llvm::function_ref<void(llvm::IRBuilder<>& builder, llvm::ArrayRef<llvm::AllocaInst*> locals,
-                                                  OperandStack& operandStack, const ByteCodeTypeInfo& typeInfo)>;
+    using PrologueGenFn =
+        llvm::function_ref<void(llvm::IRBuilder<>& builder, llvm::ArrayRef<llvm::AllocaInst*> locals,
+                                OperandStack& operandStack, const ByteCodeTypeChecker::ByteCodeTypeInfo& typeInfo)>;
 
     /// This function must be only called once. 'code' must have at most a maximum stack depth of 'maxStack'
     /// and have at most 'maxLocals' local variables. 'generatePrologue' is used to initialize the local variables and

--- a/src/jllvm/compiler/CodeGenerator.hpp
+++ b/src/jllvm/compiler/CodeGenerator.hpp
@@ -149,7 +149,7 @@ public:
 
     using PrologueGenFn =
         llvm::function_ref<void(llvm::IRBuilder<>& builder, llvm::ArrayRef<llvm::AllocaInst*> locals,
-                                OperandStack& operandStack, const ByteCodeTypeChecker::ByteCodeTypeInfo& typeInfo)>;
+                                OperandStack& operandStack, const ByteCodeTypeChecker::TypeInfo& typeInfo)>;
 
     /// This function must be only called once. 'code' must have at most a maximum stack depth of 'maxStack'
     /// and have at most 'maxLocals' local variables. 'generatePrologue' is used to initialize the local variables and

--- a/src/jllvm/compiler/CodeGeneratorUtils.cpp
+++ b/src/jllvm/compiler/CodeGeneratorUtils.cpp
@@ -440,7 +440,7 @@ void ByteCodeTypeChecker::checkBasicBlock(llvm::ArrayRef<char> block, std::uint1
     }
 }
 
-void ByteCodeTypeChecker::check()
+const ByteCodeTypeChecker::ByteCodeTypeInfo& ByteCodeTypeChecker::checkAndGetTypeInfo(std::uint16_t offset)
 {
     for (const auto& exception : m_code.getExceptionTable())
     {
@@ -452,6 +452,7 @@ void ByteCodeTypeChecker::check()
 
     m_basicBlocks.insert({0, {}});
     m_offsetStack.push_back(0);
+    m_byteCodeTypeInfo.offset = offset;
 
     while (!m_offsetStack.empty())
     {
@@ -460,6 +461,8 @@ void ByteCodeTypeChecker::check()
 
         checkBasicBlock(m_code.getCode().drop_front(startOffset), startOffset, m_basicBlocks[startOffset]);
     }
+
+    return m_byteCodeTypeInfo;
 }
 
 ByteCodeTypeChecker::PossibleRetsMap ByteCodeTypeChecker::makeRetToMap() const

--- a/src/jllvm/compiler/CodeGeneratorUtils.cpp
+++ b/src/jllvm/compiler/CodeGeneratorUtils.cpp
@@ -440,7 +440,7 @@ void ByteCodeTypeChecker::checkBasicBlock(llvm::ArrayRef<char> block, std::uint1
     }
 }
 
-const ByteCodeTypeChecker::ByteCodeTypeInfo& ByteCodeTypeChecker::checkAndGetTypeInfo(std::uint16_t offset)
+const ByteCodeTypeChecker::TypeInfo& ByteCodeTypeChecker::checkAndGetTypeInfo(std::uint16_t offset)
 {
     for (const auto& exception : m_code.getExceptionTable())
     {

--- a/src/jllvm/compiler/CodeGeneratorUtils.hpp
+++ b/src/jllvm/compiler/CodeGeneratorUtils.hpp
@@ -25,8 +25,6 @@
 namespace jllvm
 {
 
-struct ByteCodeTypeInfo;
-
 /// Class for Java bytecode typechecking
 /// This works by iterating over the bytecode of a Java method extracting the basic blocks
 /// and the types on the stack at the start of the block then constructing a map of basic block starting
@@ -46,6 +44,15 @@ public:
     using BasicBlockMap = llvm::DenseMap<std::uint16_t, TypeStack>;
     using PossibleRetsMap = llvm::DenseMap<std::uint16_t, llvm::DenseSet<std::uint16_t>>;
 
+    /// Point in the 'ByteCodeTypeChecker' where the local variable and operand stack types should be extracted.
+    /// A local variable may be null in which case the local variable is currently uninitialized.
+    struct ByteCodeTypeInfo
+    {
+        std::uint16_t offset{};
+        std::vector<JVMType> operandStack;
+        std::vector<JVMType> locals;
+    };
+
 private:
     llvm::LLVMContext& m_context;
     const ClassFile& m_classFile;
@@ -60,15 +67,12 @@ private:
     llvm::Type* m_floatType;
     llvm::Type* m_intType;
     llvm::Type* m_longType;
-    ByteCodeTypeInfo& m_byteCodeTypeInfo;
+    ByteCodeTypeInfo m_byteCodeTypeInfo;
 
     void checkBasicBlock(llvm::ArrayRef<char> block, std::uint16_t offset, TypeStack typeStack);
 
-    void check();
-
 public:
-    ByteCodeTypeChecker(llvm::LLVMContext& context, const ClassFile& classFile, const Code& code, MethodType methodType,
-                        ByteCodeTypeInfo& byteCodeTypeInfo)
+    ByteCodeTypeChecker(llvm::LLVMContext& context, const ClassFile& classFile, const Code& code, MethodType methodType)
         : m_context{context},
           m_classFile{classFile},
           m_code{code},
@@ -77,16 +81,17 @@ public:
           m_doubleType{llvm::Type::getDoubleTy(m_context)},
           m_floatType{llvm::Type::getFloatTy(m_context)},
           m_intType{llvm::Type::getInt32Ty(m_context)},
-          m_longType{llvm::Type::getInt64Ty(m_context)},
-          m_byteCodeTypeInfo(byteCodeTypeInfo)
+          m_longType{llvm::Type::getInt64Ty(m_context)}
     {
         // Types of local variables at method entry are the arguments of the parameters.
         for (auto&& [paramType, local] : llvm::zip(methodType.parameters(), m_locals))
         {
             local = descriptorToType(paramType, context);
         }
-        check();
     }
+
+    /// Type-checks the entire java method, returning the 'ByteCodeTypeInfo' for the instruction at 'offset'.
+    const ByteCodeTypeInfo& checkAndGetTypeInfo(std::uint16_t offset);
 
     /// Creates a mapping between each 'ret' instruction and the offsets inside the bytecode where it could return to.
     PossibleRetsMap makeRetToMap() const;
@@ -95,17 +100,6 @@ public:
     {
         return m_basicBlocks;
     }
-};
-
-/// Point in the 'ByteCodeTypeChecker' where the local variable and operand stack types should be extracted.
-/// 'offset' must be initialized to the required offset prior to passing this struct to 'ByteCodeTypeChecker'
-/// constructor. After the constructor call, 'operandStack' and 'locals' will be set with their types at a
-/// given offset. A local variable may be null in which case the local variable is currently uninitialized.
-struct ByteCodeTypeInfo
-{
-    std::uint16_t offset;
-    std::vector<ByteCodeTypeChecker::JVMType> operandStack;
-    std::vector<ByteCodeTypeChecker::JVMType> locals;
 };
 
 /// Class for JVM operand stack

--- a/src/jllvm/compiler/CodeGeneratorUtils.hpp
+++ b/src/jllvm/compiler/CodeGeneratorUtils.hpp
@@ -46,7 +46,7 @@ public:
 
     /// Point in the 'ByteCodeTypeChecker' where the local variable and operand stack types should be extracted.
     /// A local variable may be null in which case the local variable is currently uninitialized.
-    struct ByteCodeTypeInfo
+    struct TypeInfo
     {
         std::uint16_t offset{};
         std::vector<JVMType> operandStack;
@@ -67,7 +67,7 @@ private:
     llvm::Type* m_floatType;
     llvm::Type* m_intType;
     llvm::Type* m_longType;
-    ByteCodeTypeInfo m_byteCodeTypeInfo;
+    TypeInfo m_byteCodeTypeInfo;
 
     void checkBasicBlock(llvm::ArrayRef<char> block, std::uint16_t offset, TypeStack typeStack);
 
@@ -91,7 +91,7 @@ public:
     }
 
     /// Type-checks the entire java method, returning the 'ByteCodeTypeInfo' for the instruction at 'offset'.
-    const ByteCodeTypeInfo& checkAndGetTypeInfo(std::uint16_t offset);
+    const TypeInfo& checkAndGetTypeInfo(std::uint16_t offset);
 
     /// Creates a mapping between each 'ret' instruction and the offsets inside the bytecode where it could return to.
     PossibleRetsMap makeRetToMap() const;

--- a/src/jllvm/compiler/Compiler.cpp
+++ b/src/jllvm/compiler/Compiler.cpp
@@ -32,7 +32,7 @@ llvm::Function* jllvm::compileMethod(llvm::Module& module, const Method& method,
     assert(code && "method to compile must have a code attribute");
     compileMethodBody(function, *classObject, stringInterner, method.getType(), *code,
                       [&](llvm::IRBuilder<>& builder, llvm::ArrayRef<llvm::AllocaInst*> locals, OperandStack&,
-                          const ByteCodeTypeInfo&)
+                          const ByteCodeTypeChecker::ByteCodeTypeInfo&)
                       {
                           // Arguments are put into the locals. According to the specification, i64s and doubles are
                           // split into two locals. We don't actually do that, we just put them into the very first
@@ -72,7 +72,7 @@ llvm::Function* jllvm::compileOSRMethod(llvm::Module& module, std::uint16_t offs
     compileMethodBody(
         function, *classObject, stringInterner, method.getType(), *code,
         [&](llvm::IRBuilder<>& builder, llvm::ArrayRef<llvm::AllocaInst*> locals, OperandStack& operandStack,
-            const ByteCodeTypeInfo& typeInfo)
+            const ByteCodeTypeChecker::ByteCodeTypeInfo& typeInfo)
         {
             // Initialize the operand stack and the local variables from the two input arrays. Using the type info from
             // the type checker, it is possible to load the exact types required.

--- a/src/jllvm/compiler/Compiler.cpp
+++ b/src/jllvm/compiler/Compiler.cpp
@@ -32,7 +32,7 @@ llvm::Function* jllvm::compileMethod(llvm::Module& module, const Method& method,
     assert(code && "method to compile must have a code attribute");
     compileMethodBody(function, *classObject, stringInterner, method.getType(), *code,
                       [&](llvm::IRBuilder<>& builder, llvm::ArrayRef<llvm::AllocaInst*> locals, OperandStack&,
-                          const ByteCodeTypeChecker::ByteCodeTypeInfo&)
+                          const ByteCodeTypeChecker::TypeInfo&)
                       {
                           // Arguments are put into the locals. According to the specification, i64s and doubles are
                           // split into two locals. We don't actually do that, we just put them into the very first
@@ -72,7 +72,7 @@ llvm::Function* jllvm::compileOSRMethod(llvm::Module& module, std::uint16_t offs
     compileMethodBody(
         function, *classObject, stringInterner, method.getType(), *code,
         [&](llvm::IRBuilder<>& builder, llvm::ArrayRef<llvm::AllocaInst*> locals, OperandStack& operandStack,
-            const ByteCodeTypeChecker::ByteCodeTypeInfo& typeInfo)
+            const ByteCodeTypeChecker::TypeInfo& typeInfo)
         {
             // Initialize the operand stack and the local variables from the two input arrays. Using the type info from
             // the type checker, it is possible to load the exact types required.


### PR DESCRIPTION
This PR changes `ByteCodeTypeInfo` from an in-out parameter of the constructor of `ByteCodeTypeChecker` to a return value of `checkAndGetTypeInfo`.