### PR TITLE
[unwinder] Add 'FrameValue' class

### DIFF
--- a/src/jllvm/unwind/CMakeLists.txt
+++ b/src/jllvm/unwind/CMakeLists.txt
@@ -12,4 +12,4 @@
 # see <http://www.gnu.org/licenses/>.
 
 add_library(JLLVMUnwinder Unwinder.cpp)
-target_link_libraries(JLLVMUnwinder PUBLIC LLVMSupport unwind-headers unwind_static)
+target_link_libraries(JLLVMUnwinder PUBLIC JLLVMSupport unwind-headers unwind_static)

--- a/src/jllvm/unwind/Unwinder.hpp
+++ b/src/jllvm/unwind/Unwinder.hpp
@@ -15,6 +15,8 @@
 
 #include <llvm/ADT/ArrayRef.h>
 
+#include <jllvm/support/Bytes.hpp>
+
 #include <concepts>
 #include <cstdint>
 #include <type_traits>
@@ -101,6 +103,152 @@ public:
     {
         std::array<std::uint64_t, sizeof...(args)> array{llvm::bit_cast<std::uint64_t>(args)...};
         resumeExecutionAtFunctionImpl(reinterpret_cast<std::uintptr_t>(fnPtr), array);
+    }
+};
+
+/// Class representing a specific location of a value within a 'UnwindFrame'.
+/// A 'FrameValue' is only ever valid for a specific program counter within frames of a specific function.
+/// Mapping the program counter and/or function pointer to frame values is performed by the stackmap.
+/// A 'FrameValue' itself does not have any mechanism to validate reading from the correct frame.
+/// 'T' can be used to make a stronger typed 'FrameValue' which is known to contain a value of type 'T'.
+/// Note that this type is trivially copyable, a standard layout type and small enough to be passed by value rather
+/// than const reference.
+template <class T = void>
+class FrameValue
+{
+    enum class Tag : std::uint8_t
+    {
+        /// Value was constant folded.
+        Constant = 0,
+        /// Value is within a callee-saved register.
+        Register = 1,
+        /// Value is the result of an 'alloca' instruction.
+        Direct = 2,
+        /// Value is spilled on the stack.
+        Indirect = 3,
+    };
+
+    /// Type used to safely access the tag regardless of active union member.
+    /// This is legal due to the common initial sequence rule:
+    /// https://en.cppreference.com/w/cpp/language/data_members#Standard_layout.
+    /// Using an explicit tag inside of the union is beneficial as it allows reducing padding inbetween the tag and
+    /// fields after. Using a tagged union rather than a variant so that 'FrameValue' is a standard layout type that
+    /// can safely be interoperated with form LLVM.
+    struct TagOnly
+    {
+        Tag tag;
+    };
+
+    struct Constant
+    {
+        Tag tag;
+        std::uint64_t constant;
+    };
+
+    struct Register
+    {
+        Tag tag;
+        /// Dwarf register number of the register containing the value.
+        int registerNumber;
+    };
+
+    struct Direct
+    {
+        Tag tag;
+        /// Dwarf register number of the register containing the frame pointer.
+        int registerNumber;
+        std::int32_t offset;
+    };
+
+    struct Indirect
+    {
+        Tag tag;
+        std::uint8_t size;
+        /// Dwarf register number of the register containing the frame pointer.
+        int registerNumber;
+        std::int32_t offset;
+    };
+
+    union
+    {
+        // The first union member is used when default initializing. This initializes it to a constant with 0 as value.
+        Constant constant{};
+        TagOnly accessTag;
+        Register inRegister;
+        Direct direct;
+        Indirect indirect;
+    } m_union{};
+
+public:
+    FrameValue() = default;
+
+    /// Creates a 'FrameValue' with a constant value.
+    static FrameValue constant(std::uint64_t constant)
+    {
+        FrameValue result;
+        result.m_union.constant = {Tag::Constant, constant};
+        return result;
+    }
+
+    /// Creates a 'FrameValue' that is within a CSR register.
+    static FrameValue inRegister(int registerNumber)
+    {
+        FrameValue result;
+        result.m_union.inRegister = {Tag::Register, registerNumber};
+        return result;
+    }
+
+    /// Creates a 'FrameValue' that is a stack allocation.
+    static FrameValue direct(int registerNumber, std::int32_t offset)
+    {
+        FrameValue result;
+        result.m_union.direct = {Tag::Direct, registerNumber, offset};
+        return result;
+    }
+
+    /// Creates a 'FrameValue' that has been spilled into a location on the stack.
+    static FrameValue indirect(std::uint8_t size, int registerNumber, std::int32_t offset)
+    {
+        FrameValue result;
+        result.m_union.indirect = {Tag::Indirect, size, registerNumber, offset};
+        return result;
+    }
+
+    /// Read the values represented by the 'FrameValue' within 'frame'.
+    /// 'U' is the interpretation of the value and must be a type greater or equal in size than the actual value.
+    /// The resulting value is zero-extended and then bitcast to 'U'.
+    template <class U>
+    U read(const UnwindFrame& frame) const
+    {
+        static_assert(sizeof(U) <= sizeof(std::uint64_t), "cannot read values larger than 64 bit");
+        static_assert(std::is_trivially_copyable_v<U>, "bitcast is only valid for trivially copyable types");
+
+        std::uint64_t result{};
+        switch (m_union.accessTag.tag)
+        {
+            case Tag::Constant: result = m_union.constant.constant; break;
+            case Tag::Register: result = frame.getIntegerRegister(m_union.inRegister.registerNumber); break;
+            case Tag::Direct:
+                assert(sizeof(U) == sizeof(void*) && "type read must be equal to pointer size");
+                result = frame.getIntegerRegister(m_union.direct.registerNumber) + m_union.direct.offset;
+                break;
+            case Tag::Indirect:
+            {
+                assert(sizeof(U) >= m_union.indirect.size && "type read must be large enough for the value");
+                auto* ptr = reinterpret_cast<char*>(frame.getIntegerRegister(m_union.indirect.registerNumber)
+                                                    + m_union.indirect.offset);
+                std::memcpy(&result, ptr, m_union.indirect.size);
+                break;
+            }
+            default: llvm_unreachable("invalid tag");
+        }
+        return llvm::bit_cast<U>(static_cast<NextSizedUInt<U>>(result));
+    }
+
+    /// Overload of 'read' for strongly typed 'FrameValue's, interpreting the value as 'T'.
+    T read(const UnwindFrame& frame) const requires(!std::is_void_v<T>)
+    {
+        return read<T>(frame);
     }
 };
 

--- a/src/jllvm/vm/JIT.hpp
+++ b/src/jllvm/vm/JIT.hpp
@@ -78,29 +78,7 @@ public:
     {
         std::uint16_t bytecodeOffset;
 
-        struct Constant
-        {
-            std::uint64_t constant;
-        };
-        struct Register
-        {
-            int registerNumber;
-        };
-        struct Direct
-        {
-            int registerNumber;
-            std::int32_t offset;
-            unsigned size;
-        };
-        struct Indirect
-        {
-            int registerNumber;
-            std::int32_t offset;
-            unsigned size;
-        };
-        using Location = swl::variant<Constant, Register, Direct, Indirect>;
-
-        std::vector<Location> locals;
+        std::vector<FrameValue<std::uint64_t>> locals;
     };
 
 private:

--- a/src/jllvm/vm/StackMapRegistrationPlugin.hpp
+++ b/src/jllvm/vm/StackMapRegistrationPlugin.hpp
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h>
+#include <llvm/Object/StackMapParser.h>
 
 #include <jllvm/gc/GarbageCollector.hpp>
 
@@ -29,6 +30,12 @@ class StackMapRegistrationPlugin : public llvm::orc::ObjectLinkingLayer::Plugin
 {
     GarbageCollector& m_gc;
     std::function<void(std::uintptr_t, JIT::DeoptEntry&&)> m_deoptEntryParsed;
+
+    using StackMapParser = llvm::StackMapParser<llvm::support::endianness::native>;
+
+    /// Converts a location in the stackmap into an equivalent 'FrameValue<T>'.
+    template <class T>
+    FrameValue<T> toFrameValue(const StackMapParser::LocationAccessor& loc, StackMapParser& parser);
 
 public:
     explicit StackMapRegistrationPlugin(GarbageCollector& gc,


### PR DESCRIPTION
This class is used to represent the location of a value within a frame as are seen in the stackmap when using `deopt` operand bundles or using GCs. This class abstracts the precise mechanism used to read the value in the frame and simply offers a convenient 'read' API.