### PR TITLE
[gc] add support for relocating derived pointers

### DIFF
--- a/src/jllvm/gc/CMakeLists.txt
+++ b/src/jllvm/gc/CMakeLists.txt
@@ -12,4 +12,4 @@
 # see <http://www.gnu.org/licenses/>.
 
 add_library(JLLVMGC GarbageCollector.cpp RootFreeList.cpp)
-target_link_libraries(JLLVMGC PUBLIC JLLVMObject PRIVATE JLLVMUnwinder)
+target_link_libraries(JLLVMGC PUBLIC JLLVMObject JLLVMUnwinder)

--- a/src/jllvm/gc/GarbageCollector.hpp
+++ b/src/jllvm/gc/GarbageCollector.hpp
@@ -18,6 +18,7 @@
 
 #include <jllvm/object/ClassObject.hpp>
 #include <jllvm/object/Object.hpp>
+#include <jllvm/unwind/Unwinder.hpp>
 
 #include <cstdint>
 #include <memory>
@@ -29,26 +30,12 @@ namespace jllvm
 {
 struct StackMapEntry
 {
-    enum Type : std::uint8_t
-    {
-        Register = 1,
-        Direct = 2,
-        Indirect = 3,
-    } type;
-    std::uint8_t count;
-    int registerNumber;
-    std::uint32_t offset;
-
-    bool operator==(const StackMapEntry& rhs) const
-    {
-        return type == rhs.type && count == rhs.count && registerNumber == rhs.registerNumber && offset == rhs.offset;
-    }
-
-    bool operator<(const StackMapEntry& rhs) const
-    {
-        return std::tie(type, count, registerNumber, offset)
-               < std::tie(rhs.type, rhs.count, rhs.registerNumber, rhs.offset);
-    }
+    /// Base pointer which points directly at an object.
+    WriteableFrameValue<ObjectInterface*> basePointer;
+    /// Derived pointer which may be at an offset to the base pointer and therefore possibly point into the middle of
+    /// the object. After relocation, it should have the same offset from the relocated base pointer as it did prior to
+    /// relocation.
+    WriteableFrameValue<std::byte*> derivedPointer;
 };
 
 class GarbageCollector;

--- a/src/jllvm/vm/JIT.cpp
+++ b/src/jllvm/vm/JIT.cpp
@@ -325,7 +325,7 @@ llvm::SmallVector<std::uint64_t> jllvm::JIT::readLocals(const UnwindFrame& frame
     const DeoptEntry& entry = iter->second;
 
     return llvm::to_vector(
-        llvm::map_range(entry.locals, [&](FrameValue<std::uint64_t> frameValue) { return frameValue.read(frame); }));
+        llvm::map_range(entry.locals, [&](FrameValue<std::uint64_t> frameValue) { return frameValue.readScalar(frame); }));
 }
 
 void jllvm::JIT::doExceptionOnStackReplacement(const UnwindFrame& frame, std::uint16_t byteCodeOffset,

--- a/src/jllvm/vm/StackMapRegistrationPlugin.hpp
+++ b/src/jllvm/vm/StackMapRegistrationPlugin.hpp
@@ -37,6 +37,10 @@ class StackMapRegistrationPlugin : public llvm::orc::ObjectLinkingLayer::Plugin
     template <class T>
     FrameValue<T> toFrameValue(const StackMapParser::LocationAccessor& loc, StackMapParser& parser);
 
+    /// Converts a location in the stackmap into an equivalent 'WriteableFrameValue<T>'.
+    template <class T>
+    std::optional<WriteableFrameValue<T>> toWriteableFrameValue(const StackMapParser::LocationAccessor& loc);
+
 public:
     explicit StackMapRegistrationPlugin(GarbageCollector& gc,
                                         std::function<void(std::uintptr_t, JIT::DeoptEntry&&)> deoptEntryParsed)


### PR DESCRIPTION
Derived pointers are pointers which are potentially offset from a pointer to an object, the base pointer, by some amount. After relocation, the offset must be preserved by relocating the derived pointer through applying the offset to the relocated base pointer.

This patch implements the required support for relocating such derived pointers within our GC. LLVMs stackmap supplies us with a pair of `(basePtr, derivedPtr)`s which can be used to calculate the offset for the relocation. A new `WriteableFrameValue` class was introduced on-top of the `FrameValue` class to support writing to frame values making the GC code simpler. Last, I had to also remove the `ObjectRepr` class as I didn't want to expose it as a public class but also wanted `WriteableFrameValue` to be strongly typed. I believe its not too great of a loss and that it violated C++s strict aliasing rules as well.

Lastly, I sadly do not have a regression in the PR as we are currently missing infrastructure to do so. See https://github.com/JLLVM/JLLVM/issues/231 I encountered this missing feature while working on a PR to reduce the amount of deoptimization state in IR.