### PR TITLE
[compiler] Precisely track types of local variables

### DIFF
--- a/src/jllvm/class/Descriptors.hpp
+++ b/src/jllvm/class/Descriptors.hpp
@@ -180,7 +180,7 @@ public:
         return getValue() == Char || getValue() == Boolean;
     }
 
-    constexpr bool operator==(const BaseType&) const = default;
+    bool operator==(const BaseType&) const = default;
 };
 
 /// <ObjectType> ::= 'L' <ClassName> ';'
@@ -198,7 +198,7 @@ public:
         return {m_name, m_size};
     }
 
-    constexpr bool operator==(const ObjectType&) const = default;
+    bool operator==(const ObjectType&) const = default;
 };
 
 /// <ArrayType> ::= '[' <FieldType>

--- a/src/jllvm/class/Descriptors.hpp
+++ b/src/jllvm/class/Descriptors.hpp
@@ -485,10 +485,6 @@ constexpr bool FieldType::isReference() const
 constexpr bool FieldType::isWide() const
 {
     std::optional<BaseType> baseType = get_if<BaseType>(this);
-    if (!baseType)
-    {
-        return false;
-    }
     return *baseType == BaseType::Long || *baseType == BaseType::Double;
 }
 

--- a/src/jllvm/class/Descriptors.hpp
+++ b/src/jllvm/class/Descriptors.hpp
@@ -94,6 +94,9 @@ public:
     /// Returns true if this 'FieldType' is a reference type.
     constexpr bool isReference() const;
 
+    /// Returns true if this 'FieldType' is either a 'long' or 'double' type.
+    constexpr bool isWide() const;
+
     /// Returns true if the given string is a valid 'FieldType' descriptor.
     constexpr static bool verify(std::string_view text)
     {
@@ -477,6 +480,16 @@ constexpr FieldType::FieldType(std::string_view text) : m_arrayCount(text.find_f
 constexpr bool FieldType::isReference() const
 {
     return holds_alternative<ObjectType>(*this) || holds_alternative<ArrayType>(*this);
+}
+
+constexpr bool FieldType::isWide() const
+{
+    std::optional<BaseType> baseType = get_if<BaseType>(this);
+    if (!baseType)
+    {
+        return false;
+    }
+    return *baseType == BaseType::Long || *baseType == BaseType::Double;
 }
 
 } // namespace jllvm

--- a/src/jllvm/class/Descriptors.hpp
+++ b/src/jllvm/class/Descriptors.hpp
@@ -485,7 +485,7 @@ constexpr bool FieldType::isReference() const
 constexpr bool FieldType::isWide() const
 {
     std::optional<BaseType> baseType = get_if<BaseType>(this);
-    return *baseType == BaseType::Long || *baseType == BaseType::Double;
+    return baseType == BaseType::Long || baseType == BaseType::Double;
 }
 
 } // namespace jllvm

--- a/src/jllvm/compiler/ByteCodeCompileUtils.cpp
+++ b/src/jllvm/compiler/ByteCodeCompileUtils.cpp
@@ -119,6 +119,30 @@ llvm::FunctionType* jllvm::descriptorToType(MethodType type, bool isStatic, llvm
     return llvm::FunctionType::get(descriptorToType(type.returnType(), context), args, false);
 }
 
+llvm::Value* jllvm::extendToStackType(llvm::IRBuilder<>& builder, FieldType type, llvm::Value* value)
+{
+    return match(
+        type,
+        [&](BaseType baseType)
+        {
+            switch (baseType.getValue())
+            {
+                case BaseType::Boolean:
+                case BaseType::Byte:
+                case BaseType::Short:
+                {
+                    return builder.CreateSExt(value, builder.getInt32Ty());
+                }
+                case BaseType::Char:
+                {
+                    return builder.CreateZExt(value, builder.getInt32Ty());
+                }
+                default: return value;
+            }
+        },
+        [&](const auto&) { return value; });
+}
+
 void jllvm::addJavaMethodMetadata(llvm::Function* function, const JavaMethodMetadata& metadata)
 {
     std::string sectionName = "java";

--- a/src/jllvm/compiler/ByteCodeCompileUtils.hpp
+++ b/src/jllvm/compiler/ByteCodeCompileUtils.hpp
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <llvm/IR/DerivedTypes.h>
+#include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/InstrTypes.h>
 #include <llvm/IR/LLVMContext.h>
 
@@ -55,6 +56,11 @@ llvm::FunctionType* descriptorToType(MethodType type, bool isStatic, llvm::LLVMC
 /// the operand stack at entry and the second to an array as large as the local variables at entry. These are used to
 /// initialize the operand stack and local variables respectively.
 llvm::FunctionType* osrMethodSignature(MethodType methodType, llvm::LLVMContext& context);
+
+/// Generates code using 'builder' to convert 'value', which is of the corresponding LLVM type of 'type', to the
+/// corresponding LLVM type as is used on the JVM operand stack.
+/// This is essentially just signed-extending or zero-extending integers less than 'int' to 'int'.
+llvm::Value* extendToStackType(llvm::IRBuilder<>& builder, FieldType type, llvm::Value* value);
 
 /// Metadata attached to Java methods produced by any 'ByteCodeLayer' implementation.
 struct JavaMethodMetadata

--- a/src/jllvm/compiler/CodeGeneratorUtils.hpp
+++ b/src/jllvm/compiler/CodeGeneratorUtils.hpp
@@ -41,7 +41,8 @@ public:
     using RetAddrType = llvm::PointerEmbeddedInt<std::uint16_t>;
     using JVMType = llvm::PointerUnion<llvm::Type*, RetAddrType>;
     using TypeStack = std::vector<JVMType>;
-    using BasicBlockMap = llvm::DenseMap<std::uint16_t, TypeStack>;
+    using Locals = std::vector<JVMType>;
+    using BasicBlockMap = llvm::DenseMap<std::uint16_t, std::pair<TypeStack, Locals>>;
     using PossibleRetsMap = llvm::DenseMap<std::uint16_t, llvm::DenseSet<std::uint16_t>>;
 
     /// Point in the 'ByteCodeTypeChecker' where the local variable and operand stack types should be extracted.
@@ -58,7 +59,9 @@ private:
     const ClassFile& m_classFile;
     const Code& m_code;
     std::vector<std::uint16_t> m_offsetStack;
+    llvm::DenseMap<std::uint16_t, std::vector<std::uint16_t>> m_exceptionHandlerStarts;
     std::vector<JVMType> m_locals;
+    std::vector<JVMType> m_typeStack;
     llvm::DenseMap<std::uint16_t, std::uint16_t> m_returnAddressToSubroutineMap;
     llvm::DenseMap<std::uint16_t, ReturnInfo> m_subroutineToReturnInfoMap;
     BasicBlockMap m_basicBlocks;
@@ -69,10 +72,10 @@ private:
     llvm::Type* m_longType;
     TypeInfo m_byteCodeTypeInfo;
 
-    void checkBasicBlock(llvm::ArrayRef<char> block, std::uint16_t offset, TypeStack typeStack);
+    void checkBasicBlock(llvm::ArrayRef<char> block, std::uint16_t offset);
 
 public:
-    ByteCodeTypeChecker(llvm::LLVMContext& context, const ClassFile& classFile, const Code& code, MethodType methodType)
+    ByteCodeTypeChecker(llvm::LLVMContext& context, const ClassFile& classFile, const Code& code, const Method& method)
         : m_context{context},
           m_classFile{classFile},
           m_code{code},
@@ -84,9 +87,38 @@ public:
           m_longType{llvm::Type::getInt64Ty(m_context)}
     {
         // Types of local variables at method entry are the arguments of the parameters.
-        for (auto&& [paramType, local] : llvm::zip(methodType.parameters(), m_locals))
+        auto nextLocal = m_locals.begin();
+        if (!method.isStatic())
         {
-            local = descriptorToType(paramType, context);
+            // Implicit 'this' parameter.
+            *nextLocal++ = m_addressType;
+        }
+        for (FieldType paramType : method.getType().parameters())
+        {
+            match(
+                paramType,
+                [&](BaseType baseType)
+                {
+                    switch (baseType.getValue())
+                    {
+                        case BaseType::Boolean:
+                        case BaseType::Char:
+                        case BaseType::Byte:
+                        case BaseType::Short:
+                        case BaseType::Int: *nextLocal++ = m_intType; break;
+                        case BaseType::Float: *nextLocal++ = m_floatType; break;
+                        case BaseType::Double:
+                            *nextLocal++ = m_doubleType;
+                            nextLocal++;
+                            break;
+                        case BaseType::Long:
+                            *nextLocal++ = m_longType;
+                            nextLocal++;
+                            break;
+                        case BaseType::Void: llvm_unreachable("void parameter is not possible");
+                    }
+                },
+                [&](...) { *nextLocal++ = m_addressType; });
         }
     }
 
@@ -99,6 +131,15 @@ public:
     const BasicBlockMap& getBasicBlocks() const
     {
         return m_basicBlocks;
+    }
+
+    /// Maps a range of 'JVMType's to the corresponding `llvm::Type`s and outputs it to 'outIter'.
+    template <class Range, class OutIter>
+    static OutIter transformJVMToLLVMType(llvm::LLVMContext& context, Range&& range, OutIter&& outIter)
+    {
+        return llvm::transform(
+            std::forward<Range>(range), std::forward<OutIter>(outIter), [&](ByteCodeTypeChecker::JVMType type)
+            { return type.is<llvm::Type*>() ? type.get<llvm::Type*>() : llvm::PointerType::get(context, 0); });
     }
 };
 
@@ -153,6 +194,93 @@ public:
     void setBottomOfStackValue(llvm::Value* value) const
     {
         m_builder.CreateStore(value, m_values.front());
+    }
+};
+
+/// Class representing the JVM local variables while compiling a method.
+/// Its main responsibility is to track the LLVM types used to store and load from local variables to be able to read
+/// out the values of local variables at any point in time.
+class LocalVariables
+{
+    std::vector<llvm::AllocaInst*> m_locals;
+    std::vector<llvm::Type*> m_types;
+    llvm::IRBuilder<>& m_builder;
+
+    class Proxy
+    {
+        LocalVariables* m_localVariable;
+        std::uint16_t m_index;
+
+    public:
+        Proxy(LocalVariables* localVariable, std::uint16_t index) : m_localVariable(localVariable), m_index(index) {}
+
+        operator llvm::Value*() const;
+
+        const Proxy& operator=(llvm::Value* value) const;
+    };
+
+    friend struct Proxy;
+
+public:
+    using State = std::vector<llvm::Type*>;
+
+    /// Creates an instance allocating the given number of local variables.
+    /// 'builder' is used and stored for generating any required allocation, load and store instructions.
+    LocalVariables(llvm::IRBuilder<>& builder, std::uint16_t numLocals)
+        : m_locals(numLocals), m_types(numLocals, nullptr), m_builder(builder)
+    {
+        std::generate(m_locals.begin(), m_locals.end(), [&] { return builder.CreateAlloca(builder.getPtrTy()); });
+    }
+
+    /// Sets the current types of the local variables. This is used to reset the state at the beginning of compiling
+    /// a new basic block to set the initial types.
+    void setState(llvm::ArrayRef<llvm::Type*> state)
+    {
+        llvm::copy(state, m_types.begin());
+    }
+
+    class iterator : public llvm::indexed_accessor_iterator<iterator, LocalVariables*, Proxy>
+    {
+        using Base = llvm::indexed_accessor_iterator<iterator, LocalVariables*, Proxy>;
+
+    public:
+        iterator(LocalVariables* base, ptrdiff_t index) : Base(base, index) {}
+
+        Proxy operator*() const
+        {
+            return (*getBase())[getIndex()];
+        }
+    };
+
+    /// Returns the number of local variables.
+    std::uint16_t size() const
+    {
+        return m_locals.size();
+    }
+
+    /// Accesses the local variable with the given index.
+    /// This returns a private proxy variable that is capable of doing one of two operations:
+    /// * implicitly convert to a `llvm::Value*`: This causes the local variable to be read with the type that was last
+    ///   stored to it as determined by the JVM verification algorithm. If the local is uninitialized, a null pointer
+    ///   is returned.
+    /// * operator= of a `llvm::Value*`: This stores the assigned value to the local variable.
+    Proxy operator[](std::uint16_t index)
+    {
+        assert(index < size());
+        return Proxy(this, index);
+    }
+
+    /// Iterator to the first local variable.
+    /// Dereferencing the iterator is equal to calling 'operator[]' with the index corresponding to the iterator
+    /// position.
+    auto begin()
+    {
+        return iterator(this, 0);
+    }
+
+    auto end()
+    {
+        return iterator(this, m_locals.size());
     }
 };
 

--- a/tests/Compiler/locals-deopt-types.j
+++ b/tests/Compiler/locals-deopt-types.j
@@ -1,0 +1,45 @@
+; RUN: jasmin %s -d %t
+; RUN: jllvm-jvmc --method "test:()V" %t/Test.class | FileCheck %s
+
+.class public Test
+.super java/lang/Object
+
+.field public static foo Ljava/lang/Object;
+
+.method public <init>()V
+    aload_0
+    invokespecial java/lang/Object/<init>()V
+    return
+.end method
+
+.method public static native print(I)V
+.end method
+
+; CHECK-LABEL: define void @"Test.test:()V"
+.method public static test()V
+    .limit stack 2
+    .limit locals 7
+    iconst_0
+    istore_0
+    ldc2_w 3
+    lstore_1
+    fconst_2
+    fstore_3
+    aconst_null
+    astore 4
+    ldc2_w 8.5d
+    dstore 5
+
+    iconst_0
+    ; CHECK: %[[BITCAST_F32:.*]] = bitcast float %{{.*}} to i32
+    ; CHECK: %[[BITCAST_F64:.*]] = bitcast double %{{.*}} to i64
+    ; CHECK: call void @"Static Call to Test.print:(I)V"
+    ; CHECK-SAME: "deopt"(i16 {{[0-9]+}}, i16 7, i32 %{{.*}}, i64 %{{.*}}, i8 poison, i32 %[[BITCAST_F32]], ptr addrspace(1) %{{.*}}, i64 %[[BITCAST_F64]], i8 poison)
+start:
+    invokestatic Test/print(I)V
+end:
+    return
+
+.catch all from start to end using end
+
+.end method

--- a/tests/Compiler/locals-types-dataflow-merge.j
+++ b/tests/Compiler/locals-types-dataflow-merge.j
@@ -1,0 +1,54 @@
+; RUN: jasmin %s -d %t
+; RUN: jllvm-jvmc --method "test:()V" %t/Test.class | FileCheck %s
+
+.class public Test
+.super java/lang/Object
+
+.field public static foo Ljava/lang/Object;
+
+.method public <init>()V
+    aload_0
+    invokespecial java/lang/Object/<init>()V
+    return
+.end method
+
+.method public static native print(I)V
+.end method
+
+.method public static native deopt()V
+.end method
+
+.method public static native random()I
+.end method
+
+; CHECK-LABEL: define void @"Test.test:()V"
+.method public static test()V
+    .limit stack 2
+    .limit locals 2
+    iconst_0
+    istore_0
+    fconst_1
+    fstore_1
+    invokestatic Test/random()I
+    ifne handler
+start:
+    aconst_null
+    astore_1
+    invokestatic Test/random()I
+    ifne handler
+end:
+    return
+
+handler:
+    ; Dataflow algorithm should have determined that the second local has an inconsistent type.
+    ; CHECK: call void @"Static Call to Test.deopt:()V"
+    ; CHECK-SAME: "deopt"(i16 {{[0-9]+}}, i16 2, i32 {{.*}}, i8 poison)
+    invokestatic Test/deopt()V
+    return
+endHandler:
+    pop
+    return
+
+.catch all from handler to endHandler using endHandler
+
+.end method


### PR DESCRIPTION
The precise type of local variables is required to properly read them out when creating deoptimization state on calls. So far, `ptr addrspace(1)` has been used for this purpose, but this is problematic and has actually led to bugs as LLVM later thought that these were GC pointers. Not using `ptr addrspace(1)` is also incorrect as actual GC pointers still need to be tracked and kept alive by the deopt.

This PR therefore extends the `ByteCodeTypeChecker` to also calculate the local variables at the start of all basic blocks and adds a `LocalVariables` class, that similar to `OperandStack`, tracks the current type of a local variable throughout compilation. These are also used to generate appropriate loads and stores.