### PR TITLE
[compiler] remove redundant deopt operands

### DIFF
--- a/src/jllvm/compiler/CodeGenerator.hpp
+++ b/src/jllvm/compiler/CodeGenerator.hpp
@@ -80,6 +80,11 @@ class CodeGenerator
     /// The original call is replaced and erased.
     void addExceptionHandlingDeopts(std::uint16_t byteCodeOffset, llvm::CallBase*& callInst);
 
+    /// Creates a new call from 'callInst' which contains the deoptimization information required for generating a Java
+    /// backtrace. This is equal to using 'addExceptionHandlingDeopts' but with the number of local variables set to
+    /// zero.
+    void addBytecodeOffsetOnlyDeopts(std::uint16_t byteCodeOffset, llvm::CallBase*& callInst);
+
     void generateBuiltinExceptionThrow(llvm::Value* condition, llvm::StringRef builderName,
                                        llvm::ArrayRef<llvm::Value*> builderArgs);
 

--- a/src/jllvm/gc/CMakeLists.txt
+++ b/src/jllvm/gc/CMakeLists.txt
@@ -12,4 +12,4 @@
 # see <http://www.gnu.org/licenses/>.
 
 add_library(JLLVMGC GarbageCollector.cpp RootFreeList.cpp)
-target_link_libraries(JLLVMGC PUBLIC JLLVMObject PRIVATE JLLVMUnwinder)
+target_link_libraries(JLLVMGC PUBLIC JLLVMObject JLLVMUnwinder)

--- a/src/jllvm/gc/GarbageCollector.hpp
+++ b/src/jllvm/gc/GarbageCollector.hpp
@@ -18,6 +18,7 @@
 
 #include <jllvm/object/ClassObject.hpp>
 #include <jllvm/object/Object.hpp>
+#include <jllvm/unwind/Unwinder.hpp>
 
 #include <cstdint>
 #include <memory>
@@ -29,26 +30,12 @@ namespace jllvm
 {
 struct StackMapEntry
 {
-    enum Type : std::uint8_t
-    {
-        Register = 1,
-        Direct = 2,
-        Indirect = 3,
-    } type;
-    std::uint8_t count;
-    int registerNumber;
-    std::uint32_t offset;
-
-    bool operator==(const StackMapEntry& rhs) const
-    {
-        return type == rhs.type && count == rhs.count && registerNumber == rhs.registerNumber && offset == rhs.offset;
-    }
-
-    bool operator<(const StackMapEntry& rhs) const
-    {
-        return std::tie(type, count, registerNumber, offset)
-               < std::tie(rhs.type, rhs.count, rhs.registerNumber, rhs.offset);
-    }
+    /// Base pointer which points directly at an object.
+    WriteableFrameValue<ObjectInterface*> basePointer;
+    /// Derived pointer which may be at an offset to the base pointer and therefore possibly point into the middle of
+    /// the object. After relocation, it should have the same offset from the relocated base pointer as it did prior to
+    /// relocation.
+    WriteableFrameValue<std::byte*> derivedPointer;
 };
 
 class GarbageCollector;

--- a/src/jllvm/vm/JIT.cpp
+++ b/src/jllvm/vm/JIT.cpp
@@ -325,7 +325,7 @@ llvm::SmallVector<std::uint64_t> jllvm::JIT::readLocals(const UnwindFrame& frame
     const DeoptEntry& entry = iter->second;
 
     return llvm::to_vector(
-        llvm::map_range(entry.locals, [&](FrameValue<std::uint64_t> frameValue) { return frameValue.read(frame); }));
+        llvm::map_range(entry.locals, [&](FrameValue<std::uint64_t> frameValue) { return frameValue.readScalar(frame); }));
 }
 
 void jllvm::JIT::doExceptionOnStackReplacement(const UnwindFrame& frame, std::uint16_t byteCodeOffset,

--- a/src/jllvm/vm/StackMapRegistrationPlugin.hpp
+++ b/src/jllvm/vm/StackMapRegistrationPlugin.hpp
@@ -37,6 +37,10 @@ class StackMapRegistrationPlugin : public llvm::orc::ObjectLinkingLayer::Plugin
     template <class T>
     FrameValue<T> toFrameValue(const StackMapParser::LocationAccessor& loc, StackMapParser& parser);
 
+    /// Converts a location in the stackmap into an equivalent 'WriteableFrameValue<T>'.
+    template <class T>
+    std::optional<WriteableFrameValue<T>> toWriteableFrameValue(const StackMapParser::LocationAccessor& loc);
+
 public:
     explicit StackMapRegistrationPlugin(GarbageCollector& gc,
                                         std::function<void(std::uintptr_t, JIT::DeoptEntry&&)> deoptEntryParsed)

--- a/tests/Compiler/elide-deopt.j
+++ b/tests/Compiler/elide-deopt.j
@@ -1,0 +1,44 @@
+; RUN: jasmin %s -d %t
+; RUN: jllvm-jvmc --method "noExcept:()V" %t/Test.class | FileCheck %s --check-prefix=NO_EXCEPT
+; RUN: jllvm-jvmc --method "except:()V" %t/Test.class | FileCheck %s --check-prefix=EXCEPT
+
+.class public Test
+.super java/lang/Object
+
+.field public static foo Ljava/lang/Object;
+
+.method public <init>()V
+    aload_0
+    invokespecial java/lang/Object/<init>()V
+    return
+.end method
+
+.method public static native print(I)V
+.end method
+
+; CHECK-LABEL: define void @"Test.noExcept:()V"
+.method public static noExcept()V
+    .limit stack 2
+    .limit locals 1
+    iconst_0
+    ; NO_EXCEPT: call void @"Static Call to Test.print:(I)V"
+    ; NO_EXCEPT-SAME: "deopt"(i16 1, i16 0)
+    invokestatic Test/print(I)V
+    return
+.end method
+
+; CHECK-LABEL: define void @"Test.except:()V"
+.method public static except()V
+    .limit stack 2
+    .limit locals 1
+    iconst_0
+    ; EXCEPT: call void @"Static Call to Test.print:(I)V"
+    ; EXCEPT-SAME: "deopt"(i16 1, i16 1, {{[^,]*}})
+start:
+    invokestatic Test/print(I)V
+end:
+    return
+
+.catch all from start to end using end
+
+.end method


### PR DESCRIPTION
The local variables in the deopt operand bundle are only read out and required when the instruction is within an exception handler. In all other cases it is possible to elide these operands to improve code-generation.
