### PR TITLE
[CI] upgrade to GCC 13

### DIFF
--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -38,7 +38,7 @@ runs:
       shell: bash
       run: |
         sudo apt update
-        sudo apt install lld lld-15 clang-15 g++-10
+        sudo apt install lld lld-15 clang-15 g++-13
 
     - name: Generate compiler hash
       id: compiler-hash

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -19,7 +19,7 @@ jobs:
         include:
           - { os: ubuntu-22.04, cxx_compiler: clang++-15, c_compiler: clang-15, sanitizer: "address,undefined" }
           - { os: ubuntu-22.04, cxx_compiler: clang++-15, c_compiler: clang-15, shared_libs: "ON" }
-          - { os: ubuntu-22.04, cxx_compiler: g++-10, c_compiler: gcc-10 }
+          - { os: ubuntu-22.04, cxx_compiler: g++-13, c_compiler: gcc-13 }
           - { os: macos-12, cxx_compiler: clang++, c_compiler: clang }
 
     runs-on: ${{matrix.os}}


### PR DESCRIPTION
Since we're using C++20 it is more important to use newer compilers than usual. In particular, we've had to deal with bugs in various C++20 features such as https://godbolt.org/z/PzhMTYG3b which are difficult to workaround and very very VERY difficult to debug. This PR therefore switches our GCC version to GCC 13 which is the newest shipped on GitHub actions.