### PR TITLE
[CI] upgrade to GCC 13

### DIFF
--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -38,7 +38,7 @@ runs:
       shell: bash
       run: |
         sudo apt update
-        sudo apt install lld lld-15 clang-15 g++-13
+        sudo apt install lld lld-15 clang-15 g++-13 llvm
 
     - name: Generate compiler hash
       id: compiler-hash

--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -38,7 +38,7 @@ runs:
       shell: bash
       run: |
         sudo apt update
-        sudo apt install lld lld-15 clang-15 g++-10
+        sudo apt install lld lld-15 clang-15 g++-13
 
     - name: Generate compiler hash
       id: compiler-hash

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -19,7 +19,7 @@ jobs:
         include:
           - { os: ubuntu-22.04, cxx_compiler: clang++-15, c_compiler: clang-15, sanitizer: "address,undefined" }
           - { os: ubuntu-22.04, cxx_compiler: clang++-15, c_compiler: clang-15, shared_libs: "ON" }
-          - { os: ubuntu-22.04, cxx_compiler: g++-10, c_compiler: gcc-10 }
+          - { os: ubuntu-22.04, cxx_compiler: g++-13, c_compiler: gcc-13 }
           - { os: macos-12, cxx_compiler: clang++, c_compiler: clang }
 
     runs-on: ${{matrix.os}}

--- a/src/jllvm/class/Descriptors.hpp
+++ b/src/jllvm/class/Descriptors.hpp
@@ -482,6 +482,12 @@ constexpr bool FieldType::isReference() const
     return holds_alternative<ObjectType>(*this) || holds_alternative<ArrayType>(*this);
 }
 
+constexpr bool FieldType::isWide() const
+{
+    std::optional<BaseType> baseType = get_if<BaseType>(this);
+    return *baseType == BaseType::Long || *baseType == BaseType::Double;
+}
+
 } // namespace jllvm
 
 namespace llvm

--- a/src/jllvm/class/Descriptors.hpp
+++ b/src/jllvm/class/Descriptors.hpp
@@ -180,7 +180,7 @@ public:
         return getValue() == Char || getValue() == Boolean;
     }
 
-    constexpr bool operator==(const BaseType&) const = default;
+    bool operator==(const BaseType&) const = default;
 };
 
 /// <ObjectType> ::= 'L' <ClassName> ';'
@@ -198,7 +198,7 @@ public:
         return {m_name, m_size};
     }
 
-    constexpr bool operator==(const ObjectType&) const = default;
+    bool operator==(const ObjectType&) const = default;
 };
 
 /// <ArrayType> ::= '[' <FieldType>

--- a/src/jllvm/class/Descriptors.hpp
+++ b/src/jllvm/class/Descriptors.hpp
@@ -180,7 +180,7 @@ public:
         return getValue() == Char || getValue() == Boolean;
     }
 
-    bool operator==(const BaseType&) const = default;
+    constexpr bool operator==(const BaseType&) const = default;
 };
 
 /// <ObjectType> ::= 'L' <ClassName> ';'
@@ -198,7 +198,7 @@ public:
         return {m_name, m_size};
     }
 
-    bool operator==(const ObjectType&) const = default;
+    constexpr bool operator==(const ObjectType&) const = default;
 };
 
 /// <ArrayType> ::= '[' <FieldType>
@@ -480,12 +480,6 @@ constexpr FieldType::FieldType(std::string_view text) : m_arrayCount(text.find_f
 constexpr bool FieldType::isReference() const
 {
     return holds_alternative<ObjectType>(*this) || holds_alternative<ArrayType>(*this);
-}
-
-constexpr bool FieldType::isWide() const
-{
-    std::optional<BaseType> baseType = get_if<BaseType>(this);
-    return baseType == BaseType::Long || baseType == BaseType::Double;
 }
 
 } // namespace jllvm

--- a/src/jllvm/class/Descriptors.hpp
+++ b/src/jllvm/class/Descriptors.hpp
@@ -485,7 +485,7 @@ constexpr bool FieldType::isReference() const
 constexpr bool FieldType::isWide() const
 {
     std::optional<BaseType> baseType = get_if<BaseType>(this);
-    return *baseType == BaseType::Long || *baseType == BaseType::Double;
+    return baseType == BaseType::Long || baseType == BaseType::Double;
 }
 
 } // namespace jllvm


### PR DESCRIPTION
Reopened from #235

Since we're using C++20 it is more important to use newer compilers than usual. In particular, we've had to deal with bugs in various C++20 features such as https://godbolt.org/z/PzhMTYG3b which are difficult to workaround and very very VERY difficult to debug. This PR therefore switches our GCC version to GCC 13 which is the newest shipped on GitHub actions.