### PR TITLE
[compiler] add missing deoptimnization state to builtin exceptions

### DIFF
--- a/src/jllvm/compiler/CodeGenerator.hpp
+++ b/src/jllvm/compiler/CodeGenerator.hpp
@@ -85,16 +85,17 @@ class CodeGenerator
     /// zero.
     void addBytecodeOffsetOnlyDeopts(std::uint16_t byteCodeOffset, llvm::CallBase*& callInst);
 
-    void generateBuiltinExceptionThrow(llvm::Value* condition, llvm::StringRef builderName,
-                                       llvm::ArrayRef<llvm::Value*> builderArgs);
+    void generateBuiltinExceptionThrow(std::uint16_t byteCodeOffset, llvm::Value* condition,
+                                       llvm::StringRef builderName, llvm::ArrayRef<llvm::Value*> builderArgs);
 
-    void generateNullPointerCheck(llvm::Value* object);
+    void generateNullPointerCheck(std::uint16_t byteCodeOffset, llvm::Value* object);
 
-    void generateArrayIndexCheck(llvm::Value* array, llvm::Value* index);
+    void generateArrayIndexCheck(std::uint16_t byteCodeOffset, llvm::Value* array, llvm::Value* index);
 
-    void generateNegativeArraySizeCheck(llvm::Value* size);
+    void generateNegativeArraySizeCheck(std::uint16_t byteCodeOffset, llvm::Value* size);
 
-    llvm::BasicBlock* generateHandlerChain(llvm::Value* exception, llvm::BasicBlock* newPred);
+    llvm::BasicBlock* generateHandlerChain(std::uint16_t byteCodeOffset, llvm::Value* exception,
+                                           llvm::BasicBlock* newPred);
 
     llvm::Value* loadClassObjectFromPool(std::uint16_t offset, PoolIndex<ClassInfo> index);
 

--- a/tests/Compiler/exceptions-missing-deopt.j
+++ b/tests/Compiler/exceptions-missing-deopt.j
@@ -1,0 +1,37 @@
+; RUN: jasmin %s -d %t
+; RUN: jllvm-jvmc --method "test:()V" %t/Test.class | FileCheck %s
+
+.class public Test
+.super java/lang/Object
+
+.field public static foo Ljava/lang/Object;
+
+.method public <init>()V
+    aload_0
+    invokespecial java/lang/Object/<init>()V
+    return
+.end method
+
+.method public static native print(I)V
+.end method
+
+; CHECK-LABEL: define void @"Test.test:()V"
+.method public static test()V
+    .limit stack 2
+    iconst_1
+    ; CHECK: call {{.*}} @jllvm_build_negative_array_size_exception(
+    ; CHECK-SAME: "deopt"(i16 {{.*}}
+    ; CHECK: call {{.*}} @jllvm_throw(
+    ; CHECK-SAME: "deopt"(i16 {{.*}}
+    anewarray Ljava/lang/Object;
+    iconst_0
+    ; CHECK: call {{.*}} @jllvm_build_null_pointer_exception(
+    ; CHECK-SAME: "deopt"(i16 [[AALOAD_OFFSET:[0-9]+]]
+    ; CHECK: call {{.*}} @jllvm_build_array_index_out_of_bounds_exception(
+    ; CHECK-SAME: "deopt"(i16 [[AALOAD_OFFSET]]
+    aaload
+    ; CHECK: call {{.*}} @jllvm_build_class_cast_exception(
+    ; CHECK-SAME: "deopt"(i16 {{.*}}
+    checkcast Ljava/lang/Object;
+    return
+.end method


### PR DESCRIPTION
Deoptimization states should be added to every call within a java method from which the stack may be unwound. Since these methods may throw an exception (e.g. out of memory) or generate a stacktrace, deoptimization state should be added to at the very least be able to retrieve the corresponding JVM bytecode.