### PR TITLE
[compiler] Refactor Java method metadata

### DIFF
--- a/src/jllvm/compiler/CMakeLists.txt
+++ b/src/jllvm/compiler/CMakeLists.txt
@@ -17,7 +17,6 @@ add_library(JLLVMCompiler
         CodeGeneratorUtils.cpp
         ClassObjectStubCodeGenerator.cpp
         ClassObjectStubMangling.cpp
-        Compiler.cpp
-        Compiler.hpp)
-target_link_libraries(JLLVMCompiler PUBLIC JLLVMObject LLVMCore PRIVATE LLVMTargetParser)
+        Compiler.cpp)
+target_link_libraries(JLLVMCompiler PUBLIC JLLVMObject JLLVMUnwinder LLVMCore PRIVATE LLVMTargetParser)
 

--- a/src/jllvm/materialization/JNIImplementationLayer.cpp
+++ b/src/jllvm/materialization/JNIImplementationLayer.cpp
@@ -118,7 +118,7 @@ void jllvm::JNIImplementationLayer::emit(std::unique_ptr<llvm::orc::Materializat
 
     applyABIAttributes(function, methodType, method->isStatic());
     function->clearGC();
-    addJavaMethodMetadata(function, {method->getClassObject(), method});
+    addJavaMethodMetadata(function, method, JavaMethodMetadata::Kind::Native);
 
     llvm::IRBuilder<> builder(llvm::BasicBlock::Create(*context, "entry", function));
 

--- a/src/jllvm/vm/StackMapRegistrationPlugin.hpp
+++ b/src/jllvm/vm/StackMapRegistrationPlugin.hpp
@@ -44,7 +44,7 @@ class StackMapRegistrationPlugin : public llvm::orc::ObjectLinkingLayer::Plugin
     template <class T>
     std::optional<WriteableFrameValue<T>> toWriteableFrameValue(const StackMapParser::LocationAccessor& loc);
 
-    void parseJITEntry(JavaMethodMetadata::JITData& metadata, StackMapParser::RecordAccessor& record,
+    void parseJITEntry(JavaMethodMetadata::JITData& jitData, StackMapParser::RecordAccessor& record,
                        StackMapParser& parser, std::uint64_t functionAddress);
 
 public:

--- a/src/jllvm/vm/native/JDK.cpp
+++ b/src/jllvm/vm/native/JDK.cpp
@@ -27,18 +27,18 @@ const jllvm::ClassObject* jllvm::jdk::ReflectionModel::getCallerClass(VirtualMac
         [&](const UnwindFrame& frame)
         {
             std::uintptr_t fp = frame.getFunctionPointer();
-            std::optional<JavaMethodMetadata> data = virtualMachine.getJIT().getJavaMethodMetadata(fp);
+            const JavaMethodMetadata* data = virtualMachine.getJIT().getJavaMethodMetadata(fp);
             if (!data)
             {
                 return UnwindAction::ContinueUnwinding;
             }
 
-            if (data->classObject == classObject)
+            if (data->getClassObject() == classObject)
             {
                 return UnwindAction::ContinueUnwinding;
             }
             // TODO: If the method has the Java annotation '@CallerSensitive' it should be skipped by this method.
-            result = data->classObject;
+            result = data->getClassObject();
             return UnwindAction::StopUnwinding;
         });
     return result;

--- a/tests/Compiler/method-metadata.j
+++ b/tests/Compiler/method-metadata.j
@@ -16,7 +16,8 @@
 .end method
 
 ; CHECK-LABEL: define void @"Test.test:()V"
-; CHECK-SAME: prefix { ptr addrspace(1), ptr } { ptr addrspace(1) @"LTest;", ptr @"&Test.test:()V" }
+; CHECK-SAME: prefix
+; CHECK-SAME: ptr @"&Test.test:()V"
 .method public static test()V
     .limit stack 1
     return


### PR DESCRIPTION
Metadata associated with Java code has gotten scattered over time: We currently have the `JavaMethodMetadata` for class objects and methods, `DeoptEntry`s for reading local variables and the bytecode offset.

This PR consolidates all metadata into one datastructure again and creates the following distinction:
* `JavaMethodMetadata` is now used for all metadata that is relevant for the whole method. It additionally contains extra metadata that can be specialized for JITted methods, native methods and in the future interpreter methods.
* Per-PC metadata such as the Java bytecode offset, or the `FrameValue`s for local variables at a given callsite. This mapping is part of a mapping contained within the JIT data of `JavaMethodMetadata`.

All low-level metadata access one would ever require should therefore now be possible with just the `JavaMethodMetadata` (with the exception of GC pointers which are left as a future task).