### PR TITLE
[vm][NFC] Introduce `JavaFrame` class

### DIFF
--- a/src/jllvm/vm/CMakeLists.txt
+++ b/src/jllvm/vm/CMakeLists.txt
@@ -14,7 +14,7 @@
 llvm_map_components_to_libnames(llvm_native_libs ${LLVM_NATIVE_ARCH})
 
 add_library(JLLVMVirtualMachine VirtualMachine.cpp JIT.cpp StackMapRegistrationPlugin.cpp
-        JNIImplementation.cpp NativeImplementation.cpp native/IO.cpp
+        JNIImplementation.cpp NativeImplementation.cpp JavaFrame.cpp native/IO.cpp
         native/Lang.cpp native/JDK.cpp native/Security.cpp
 )
 target_link_libraries(JLLVMVirtualMachine

--- a/src/jllvm/vm/JIT.hpp
+++ b/src/jllvm/vm/JIT.hpp
@@ -37,6 +37,8 @@
 
 #include <memory>
 
+#include "JavaFrame.hpp"
+
 namespace jllvm
 {
 class JIT
@@ -72,8 +74,6 @@ class JIT
     JNIImplementationLayer m_jniLayer;
 
     llvm::DenseSet<std::uintptr_t> m_javaFrames;
-
-    llvm::SmallVector<std::uint64_t> readLocals(const UnwindFrame& frame) const;
 
     void optimize(llvm::Module& module);
 
@@ -169,7 +169,7 @@ public:
     /// method at the JVM bytecode corresponding to 'byteCodeOffset'. This method is meant to be used for executing
     /// exception handlers and therefore puts only 'exception' on the operand stack.
     /// 'frame' must be the execution of a Java method.
-    [[noreturn]] void doExceptionOnStackReplacement(const UnwindFrame& frame, std::uint16_t byteCodeOffset,
+    [[noreturn]] void doExceptionOnStackReplacement(JavaFrame frame, std::uint16_t byteCodeOffset,
                                                     Throwable* exception);
 
     /// Looks up the method 'methodName' within the class 'className' with the type given by 'methodDescriptor'

--- a/src/jllvm/vm/JavaFrame.cpp
+++ b/src/jllvm/vm/JavaFrame.cpp
@@ -1,6 +1,15 @@
-// Licensed under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023 The JLLVM Contributors.
+//
+// This file is part of JLLVM.
+//
+// JLLVM is free software; you can redistribute it and/or modify it under  the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 3, or (at your option) any later version.
+//
+// JLLVM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with JLLVM; see the file LICENSE.txt.  If not
+// see <http://www.gnu.org/licenses/>.
 
 #include "JavaFrame.hpp"
 

--- a/src/jllvm/vm/JavaFrame.cpp
+++ b/src/jllvm/vm/JavaFrame.cpp
@@ -1,0 +1,32 @@
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "JavaFrame.hpp"
+
+std::optional<std::uint16_t> jllvm::JavaFrame::getByteCodeOffset() const
+{
+    switch (m_javaMethodMetadata->getKind())
+    {
+        case JavaMethodMetadata::Kind::JIT:
+            return m_javaMethodMetadata->getJITData()[m_unwindFrame->getProgramCounter()].byteCodeOffset;
+        case JavaMethodMetadata::Kind::Native: return std::nullopt;
+    }
+    llvm_unreachable("invalid kind");
+}
+
+llvm::SmallVector<std::uint64_t> jllvm::JavaFrame::readLocals() const
+{
+    switch (m_javaMethodMetadata->getKind())
+    {
+        case JavaMethodMetadata::Kind::Native: return {};
+        case JavaMethodMetadata::Kind::JIT:
+        {
+            llvm::ArrayRef<FrameValue<std::uint64_t>> locals =
+                m_javaMethodMetadata->getJITData()[m_unwindFrame->getProgramCounter()].locals;
+            return llvm::to_vector(llvm::map_range(locals, [&](FrameValue<std::uint64_t> frameValue)
+                                                   { return frameValue.readScalar(*m_unwindFrame); }));
+        }
+    }
+    llvm_unreachable("invalid kind");
+}

--- a/src/jllvm/vm/JavaFrame.hpp
+++ b/src/jllvm/vm/JavaFrame.hpp
@@ -1,7 +1,15 @@
-
-// Licensed under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023 The JLLVM Contributors.
+//
+// This file is part of JLLVM.
+//
+// JLLVM is free software; you can redistribute it and/or modify it under  the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 3, or (at your option) any later version.
+//
+// JLLVM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with JLLVM; see the file LICENSE.txt.  If not
+// see <http://www.gnu.org/licenses/>.
 
 #pragma once
 

--- a/src/jllvm/vm/JavaFrame.hpp
+++ b/src/jllvm/vm/JavaFrame.hpp
@@ -1,0 +1,58 @@
+
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include <jllvm/compiler/ByteCodeCompileUtils.hpp>
+#include <jllvm/unwind/Unwinder.hpp>
+
+namespace jllvm
+{
+
+/// Class representing a specialization of 'UnwindFrame' for frames executing Java methods.
+/// This class allows accessing properties that are specific to a Java frame, such as the currently executing method
+/// or bytecode offset.
+class JavaFrame
+{
+    const JavaMethodMetadata* m_javaMethodMetadata;
+    UnwindFrame* m_unwindFrame;
+
+public:
+    /// Constructs a 'JavaFrame' from a frame and its corresponding java method metadata.
+    explicit JavaFrame(const JavaMethodMetadata& javaMethodMetadata, UnwindFrame& frame)
+        : m_javaMethodMetadata(&javaMethodMetadata), m_unwindFrame(&frame)
+    {
+    }
+
+    /// Returns the bytecode offset of the frame currently being executed.
+    /// Returns an empty optional if the method being executed is native and therefore does not have a bytecode offset.
+    std::optional<std::uint16_t> getByteCodeOffset() const;
+
+    /// Returns the method object currently being executed.
+    const Method* getMethod() const
+    {
+        return m_javaMethodMetadata->getMethod();
+    }
+
+    /// Returns the enclosing class object of the method currently being executed.
+    const ClassObject* getClassObject() const
+    {
+        return getMethod()->getClassObject();
+    }
+
+    /// Returns the lower level unwind frame of the Java frame.
+    UnwindFrame& getUnwindFrame() const
+    {
+        return *m_unwindFrame;
+    }
+
+    /// Reads out the values of all the local variables at the given bytecode offset.
+    /// This method will always return an empty array in following scenarios:
+    /// * If the method being executed is native and therefore does not have local variables
+    /// * If no exception handler exists for a bytecode offset within a JITted method.
+    llvm::SmallVector<std::uint64_t> readLocals() const;
+};
+
+} // namespace jllvm

--- a/src/jllvm/vm/native/JDK.cpp
+++ b/src/jllvm/vm/native/JDK.cpp
@@ -23,22 +23,15 @@ const jllvm::ClassObject* jllvm::jdk::ReflectionModel::getCallerClass(VirtualMac
                                                                       GCRootRef<ClassObject> classObject)
 {
     const ClassObject* result = nullptr;
-    unwindStack(
-        [&](const UnwindFrame& frame)
+    virtualMachine.unwindJavaStack(
+        [&](JavaFrame frame)
         {
-            std::uintptr_t fp = frame.getFunctionPointer();
-            const JavaMethodMetadata* data = virtualMachine.getJIT().getJavaMethodMetadata(fp);
-            if (!data)
-            {
-                return UnwindAction::ContinueUnwinding;
-            }
-
-            if (data->getClassObject() == classObject)
+            if (frame.getClassObject() == classObject)
             {
                 return UnwindAction::ContinueUnwinding;
             }
             // TODO: If the method has the Java annotation '@CallerSensitive' it should be skipped by this method.
-            result = data->getClassObject();
+            result = frame.getClassObject();
             return UnwindAction::StopUnwinding;
         });
     return result;


### PR DESCRIPTION
This class is a specialization of `UnwindFrame` that offers convenient methods to gather Java-specific info about a frame being unwound. Most importantly, it serves as a common API for when adding new execution implementations such as an interpreter.