### PR TITLE
[interpreter] initial interpreter infrastructure

### DIFF
--- a/src/jllvm/main/Opts.td
+++ b/src/jllvm/main/Opts.td
@@ -29,3 +29,5 @@ def Xno_system_init : F<"Xno-system-init", "Do not do System initialization (ini
 def Xsystem_init : F<"Xsystem-init", "Do System initialization (initPhase1 to 3) (Default)">, Group<grp_internal>;
 
 def Xenable_test_utils : F<"Xenable-test-utils", "Enables native test functions">, Group<grp_internal>;
+def Xint : F<"Xint", "Execute code only with Interpreter">, Group<grp_internal>;
+def Xjit : F<"Xjit", "Execute code only with JIT">, Group<grp_internal>;

--- a/src/jllvm/materialization/ByteCodeOSRCompileLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeOSRCompileLayer.cpp
@@ -1,0 +1,30 @@
+// Copyright (C) 2023 The JLLVM Contributors.
+//
+// This file is part of JLLVM.
+//
+// JLLVM is free software; you can redistribute it and/or modify it under  the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 3, or (at your option) any later version.
+//
+// JLLVM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with JLLVM; see the file LICENSE.txt.  If not
+// see <http://www.gnu.org/licenses/>.
+
+#include "ByteCodeOSRCompileLayer.hpp"
+
+#include "jllvm/compiler/Compiler.hpp"
+
+void jllvm::ByteCodeOSRCompileLayer::emit(std::unique_ptr<llvm::orc::MaterializationResponsibility> mr,
+                                          const jllvm::Method* method, std::uint16_t offset)
+{
+    auto context = std::make_unique<llvm::LLVMContext>();
+    auto module = std::make_unique<llvm::Module>("name", *context);
+
+    module->setDataLayout(m_dataLayout);
+    module->setTargetTriple(LLVM_HOST_TRIPLE);
+
+    compileOSRMethod(*module, offset, *method, m_stringInterner);
+
+    m_baseLayer.emit(std::move(mr), llvm::orc::ThreadSafeModule(std::move(module), std::move(context)));
+}

--- a/src/jllvm/materialization/ByteCodeOSRCompileLayer.hpp
+++ b/src/jllvm/materialization/ByteCodeOSRCompileLayer.hpp
@@ -21,7 +21,7 @@
 
 namespace jllvm
 {
-/// Base class layer for any layer consuming a JVM method at a given bytecode offset for OSR.
+/// Layer for compiling OSR versions of methods at a given bytecode to LLVM IR.
 class ByteCodeOSRCompileLayer : public ByteCodeOSRLayer
 {
     StringInterner& m_stringInterner;

--- a/src/jllvm/materialization/ByteCodeOSRCompileLayer.hpp
+++ b/src/jllvm/materialization/ByteCodeOSRCompileLayer.hpp
@@ -1,0 +1,41 @@
+// Copyright (C) 2023 The JLLVM Contributors.
+//
+// This file is part of JLLVM.
+//
+// JLLVM is free software; you can redistribute it and/or modify it under  the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 3, or (at your option) any later version.
+//
+// JLLVM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with JLLVM; see the file LICENSE.txt.  If not
+// see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <llvm/ExecutionEngine/Orc/Layer.h>
+
+#include <jllvm/object/StringInterner.hpp>
+
+#include "ByteCodeOSRLayer.hpp"
+
+namespace jllvm
+{
+/// Base class layer for any layer consuming a JVM method at a given bytecode offset for OSR.
+class ByteCodeOSRCompileLayer : public ByteCodeOSRLayer
+{
+    StringInterner& m_stringInterner;
+    llvm::orc::IRLayer& m_baseLayer;
+    llvm::DataLayout m_dataLayout;
+
+public:
+    ByteCodeOSRCompileLayer(StringInterner& stringInterner, llvm::orc::IRLayer& baseLayer,
+                            llvm::orc::MangleAndInterner& mangler, const llvm::DataLayout& dataLayout)
+        : ByteCodeOSRLayer(mangler), m_stringInterner(stringInterner), m_baseLayer(baseLayer), m_dataLayout(dataLayout)
+    {
+    }
+
+    void emit(std::unique_ptr<llvm::orc::MaterializationResponsibility> mr, const Method* method,
+              std::uint16_t offset) override;
+};
+} // namespace jllvm

--- a/src/jllvm/materialization/ByteCodeOSRLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeOSRLayer.cpp
@@ -1,0 +1,65 @@
+// Copyright (C) 2023 The JLLVM Contributors.
+//
+// This file is part of JLLVM.
+//
+// JLLVM is free software; you can redistribute it and/or modify it under  the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 3, or (at your option) any later version.
+//
+// JLLVM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with JLLVM; see the file LICENSE.txt.  If not
+// see <http://www.gnu.org/licenses/>.
+
+#include "ByteCodeOSRLayer.hpp"
+
+#include <jllvm/compiler/ClassObjectStubMangling.hpp>
+
+namespace
+{
+class ByteCodeOSRMaterializationUnit : public llvm::orc::MaterializationUnit
+{
+    jllvm::ByteCodeOSRLayer& m_layer;
+    const jllvm::Method* m_method;
+    std::uint16_t m_offset;
+
+public:
+    ByteCodeOSRMaterializationUnit(jllvm::ByteCodeOSRLayer& layer, const jllvm::Method* method, std::uint16_t offset)
+        : llvm::orc::MaterializationUnit(
+              [&]
+              {
+                  llvm::orc::SymbolFlagsMap result;
+                  std::string name = jllvm::mangleOSRMethod(method, offset);
+                  result[layer.getInterner()(name)] = llvm::JITSymbolFlags::Exported | llvm::JITSymbolFlags::Callable;
+                  return llvm::orc::MaterializationUnit::Interface(std::move(result), nullptr);
+              }()),
+          m_layer(layer),
+          m_method(method),
+          m_offset(offset)
+    {
+    }
+
+    llvm::StringRef getName() const override
+    {
+        return "ByteCodeOSRMaterializationUnit";
+    }
+
+    void materialize(std::unique_ptr<llvm::orc::MaterializationResponsibility> r) override
+    {
+        m_layer.emit(std::move(r), m_method, m_offset);
+    }
+
+private:
+    void discard(const llvm::orc::JITDylib&, const llvm::orc::SymbolStringPtr&) override
+    {
+        llvm_unreachable("Should not be possible");
+    }
+};
+
+} // namespace
+
+llvm::Error jllvm::ByteCodeOSRLayer::add(llvm::orc::JITDylib& dylib, const jllvm::Method* method,
+                                         std::uint16_t byteCodeOffset)
+{
+    return dylib.define(std::make_unique<ByteCodeOSRMaterializationUnit>(*this, method, byteCodeOffset));
+}

--- a/src/jllvm/materialization/ByteCodeOSRLayer.hpp
+++ b/src/jllvm/materialization/ByteCodeOSRLayer.hpp
@@ -1,0 +1,51 @@
+// Copyright (C) 2023 The JLLVM Contributors.
+//
+// This file is part of JLLVM.
+//
+// JLLVM is free software; you can redistribute it and/or modify it under  the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 3, or (at your option) any later version.
+//
+// JLLVM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with JLLVM; see the file LICENSE.txt.  If not
+// see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <llvm/ExecutionEngine/Orc/Mangling.h>
+
+#include <jllvm/class/ClassFile.hpp>
+#include <jllvm/object/ClassObject.hpp>
+
+namespace jllvm
+{
+/// Layer for compiling a JVM method at a given bytecode offset for OSR to LLVM IR and handing it to an IR Layer for
+/// further compilation.
+class ByteCodeOSRLayer
+{
+    llvm::orc::MangleAndInterner& m_interner;
+
+public:
+    explicit ByteCodeOSRLayer(llvm::orc::MangleAndInterner& mangler) : m_interner(mangler) {}
+
+    virtual ~ByteCodeOSRLayer() = default;
+    ByteCodeOSRLayer(const ByteCodeOSRLayer&) = delete;
+    ByteCodeOSRLayer& operator=(const ByteCodeOSRLayer&) = delete;
+    ByteCodeOSRLayer(ByteCodeOSRLayer&&) = delete;
+    ByteCodeOSRLayer& operator=(ByteCodeOSRLayer&&) = delete;
+
+    llvm::orc::MangleAndInterner& getInterner() const
+    {
+        return m_interner;
+    }
+
+    /// Method called by the JIT to emit the requested symbols.
+    virtual void emit(std::unique_ptr<llvm::orc::MaterializationResponsibility> mr, const Method* method,
+                      std::uint16_t byteCodeOffset) = 0;
+
+    /// Adds a materialization unit for the given method at the given bytecode offset to 'dylib'.
+    llvm::Error add(llvm::orc::JITDylib& dylib, const Method* method, std::uint16_t byteCodeOffset);
+};
+
+} // namespace jllvm

--- a/src/jllvm/materialization/CMakeLists.txt
+++ b/src/jllvm/materialization/CMakeLists.txt
@@ -16,5 +16,8 @@ add_library(JLLVMMaterialization
         ByteCodeLayer.cpp
         ByteCodeMaterializationUnit.cpp
         JNIImplementationLayer.cpp
-        ClassObjectStubDefinitionsGenerator.cpp)
+        ClassObjectStubDefinitionsGenerator.cpp
+        JIT2InterpreterLayer.cpp
+        ByteCodeOSRLayer.cpp
+        ByteCodeOSRCompileLayer.cpp)
 target_link_libraries(JLLVMMaterialization PUBLIC JLLVMCompiler JLLVMObject LLVMCore LLVMOrcJIT PRIVATE LLVMTargetParser)

--- a/src/jllvm/materialization/JIT2InterpreterLayer.cpp
+++ b/src/jllvm/materialization/JIT2InterpreterLayer.cpp
@@ -1,6 +1,15 @@
-// Licensed under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023 The JLLVM Contributors.
+//
+// This file is part of JLLVM.
+//
+// JLLVM is free software; you can redistribute it and/or modify it under  the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 3, or (at your option) any later version.
+//
+// JLLVM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with JLLVM; see the file LICENSE.txt.  If not
+// see <http://www.gnu.org/licenses/>.
 
 #include "JIT2InterpreterLayer.hpp"
 

--- a/src/jllvm/materialization/JIT2InterpreterLayer.cpp
+++ b/src/jllvm/materialization/JIT2InterpreterLayer.cpp
@@ -1,0 +1,146 @@
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "JIT2InterpreterLayer.hpp"
+
+#include <llvm/IR/DIBuilder.h>
+#include <llvm/IR/IRBuilder.h>
+
+#include <jllvm/compiler/ByteCodeCompileUtils.hpp>
+#include <jllvm/compiler/ClassObjectStubMangling.hpp>
+
+void jllvm::JIT2InterpreterLayer::emit(std::unique_ptr<llvm::orc::MaterializationResponsibility> mr,
+                                       const Method* method)
+{
+    auto context = std::make_unique<llvm::LLVMContext>();
+    auto module = std::make_unique<llvm::Module>("module", *context);
+    module->setDataLayout(m_dataLayout);
+    module->setTargetTriple(LLVM_HOST_TRIPLE);
+
+    llvm::DIBuilder debugBuilder(*module);
+    llvm::DIFile* file = debugBuilder.createFile(".", ".");
+
+    debugBuilder.createCompileUnit(llvm::dwarf::DW_LANG_Java, file, "JLLVM", true, "", 0);
+
+    auto* function =
+        llvm::Function::Create(descriptorToType(method->getType(), method->isStatic(), *context),
+                               llvm::GlobalValue::ExternalLinkage, mangleDirectMethodCall(method), module.get());
+
+    llvm::DISubprogram* subprogram =
+        debugBuilder.createFunction(file, function->getName(), function->getName(), file, 1,
+                                    debugBuilder.createSubroutineType(debugBuilder.getOrCreateTypeArray({})), 1,
+                                    llvm::DINode::FlagZero, llvm::DISubprogram::SPFlagDefinition);
+    function->setSubprogram(subprogram);
+
+    applyABIAttributes(function, method->getType(), method->isStatic());
+    function->clearGC();
+    addJavaMethodMetadata(function, method, JavaMethodMetadata::Kind::Interpreter);
+
+    llvm::IRBuilder<> builder(llvm::BasicBlock::Create(*context, "entry", function));
+
+    builder.SetCurrentDebugLocation(llvm::DILocation::get(builder.getContext(), 1, 1, subprogram));
+
+    Code* code = method->getMethodInfo().getAttributes().find<Code>();
+    assert(code && "cannot run method without code");
+
+    // Allocate all the variables for the interpretation context.
+    llvm::AllocaInst* byteCodeOffset = builder.CreateAlloca(builder.getInt16Ty());
+    llvm::AllocaInst* topOfStack = builder.CreateAlloca(builder.getInt16Ty());
+    llvm::AllocaInst* operandStack =
+        builder.CreateAlloca(llvm::ArrayType::get(builder.getInt64Ty(), code->getMaxStack()));
+    llvm::AllocaInst* operandGCMask =
+        builder.CreateAlloca(llvm::ArrayType::get(builder.getInt64Ty(), llvm::divideCeil(code->getMaxStack(), 64)));
+    llvm::AllocaInst* localVariables =
+        builder.CreateAlloca(llvm::ArrayType::get(builder.getInt64Ty(), code->getMaxLocals()));
+    llvm::AllocaInst* localVariablesGCMask =
+        builder.CreateAlloca(llvm::ArrayType::get(builder.getInt64Ty(), llvm::divideCeil(code->getMaxLocals(), 64)));
+    llvm::Value* methodRef = methodGlobal(*module, method);
+
+    // Zero init all the allocas.
+    builder.CreateMemSet(byteCodeOffset, builder.getInt8(0), sizeof(std::uint16_t), std::nullopt);
+    builder.CreateMemSet(topOfStack, builder.getInt8(0), sizeof(std::uint16_t), std::nullopt);
+    builder.CreateMemSet(operandStack, builder.getInt8(0), sizeof(std::uint64_t) * code->getMaxStack(), std::nullopt);
+    builder.CreateMemSet(operandGCMask, builder.getInt8(0),
+                         sizeof(std::uint64_t) * llvm::divideCeil(code->getMaxStack(), 64), std::nullopt);
+    builder.CreateMemSet(localVariables, builder.getInt8(0), sizeof(std::uint64_t) * code->getMaxLocals(),
+                         std::nullopt);
+    builder.CreateMemSet(localVariablesGCMask, builder.getInt8(0), llvm::divideCeil(code->getMaxLocals(), 64),
+                         std::nullopt);
+
+    // Initialize the local variables from the function arguments. This does the translation from the C calling
+    // convention to the interpreters local variables.
+    // If the argument being stored into the local variable is a reference type, the corresponding bit is set in the GC
+    // mask as well.
+    std::size_t localVariableIndex = 0;
+    if (!method->isStatic())
+    {
+        // Store the 'this' argument.
+        llvm::Value* gep = builder.CreateConstGEP1_32(builder.getInt64Ty(), localVariables, localVariableIndex);
+        builder.CreateStore(function->getArg(0), gep);
+        llvm::Value* maskGep =
+            builder.CreateConstGEP1_32(builder.getInt64Ty(), localVariablesGCMask, localVariableIndex / 64);
+        llvm::Value* value = builder.CreateLoad(builder.getInt64Ty(), maskGep);
+        value = builder.CreateOr(value, builder.getInt64(1 << (localVariableIndex % 64)));
+        builder.CreateStore(value, maskGep);
+        localVariableIndex++;
+    }
+
+    for (auto&& [argument, paramType] :
+         llvm::zip_equal(llvm::drop_begin(function->args(), localVariableIndex), method->getType().parameters()))
+    {
+        llvm::Value* gep = builder.CreateConstGEP1_32(builder.getInt64Ty(), localVariables, localVariableIndex);
+        builder.CreateStore(&argument, gep);
+        if (paramType.isReference())
+        {
+            llvm::Value* maskGep =
+                builder.CreateConstGEP1_32(builder.getInt64Ty(), localVariablesGCMask, localVariableIndex / 64);
+            llvm::Value* value = builder.CreateLoad(builder.getInt64Ty(), maskGep);
+            value = builder.CreateOr(value, builder.getInt64(1 << (localVariableIndex % 64)));
+            builder.CreateStore(value, maskGep);
+        }
+
+        localVariableIndex++;
+        if (paramType.isWide())
+        {
+            localVariableIndex++;
+        }
+    }
+
+    std::array<llvm::Value*, 7> arguments = {methodRef,     byteCodeOffset, topOfStack,          operandStack,
+                                             operandGCMask, localVariables, localVariablesGCMask};
+    std::array<llvm::Type*, 7> types{};
+    llvm::transform(arguments, types.begin(), std::mem_fn(&llvm::Value::getType));
+
+    // Deopt all allocas used as context during interpretation. This makes it possible for the unwinder to read the
+    // local variables, the operand stack, the bytecode offset and where GC pointers are contained during unwinding.
+    llvm::CallInst* callInst = builder.CreateCall(
+        module->getOrInsertFunction("jllvm_interpreter",
+                                    llvm::FunctionType::get(builder.getInt64Ty(), types, /*isVarArg=*/false)),
+        arguments, llvm::OperandBundleDef("deopt", llvm::ArrayRef(arguments).drop_front()));
+
+    if (function->getReturnType()->isVoidTy())
+    {
+        builder.CreateRetVoid();
+    }
+    else
+    {
+        // Translate the uint64_t returned by the interpreter to the corresponding type in the C calling convention.
+        llvm::TypeSize typeSize = m_dataLayout.getTypeSizeInBits(function->getReturnType());
+        assert(!typeSize.isScalable() && "return type is never a scalable type");
+
+        llvm::Value* value = callInst;
+        llvm::IntegerType* intNTy = builder.getIntNTy(typeSize.getFixedValue());
+        if (intNTy != value->getType())
+        {
+            value = builder.CreateTrunc(value, intNTy);
+        }
+        value = builder.CreateBitOrPointerCast(value, function->getReturnType());
+        builder.CreateRet(value);
+    }
+
+    debugBuilder.finalizeSubprogram(subprogram);
+    debugBuilder.finalize();
+
+    m_baseLayer.emit(std::move(mr), llvm::orc::ThreadSafeModule(std::move(module), std::move(context)));
+}

--- a/src/jllvm/materialization/JIT2InterpreterLayer.hpp
+++ b/src/jllvm/materialization/JIT2InterpreterLayer.hpp
@@ -1,0 +1,30 @@
+
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include <llvm/ExecutionEngine/Orc/Layer.h>
+
+#include "ByteCodeLayer.hpp"
+
+namespace jllvm
+{
+/// Layer used to compile stubs to start interpreting a method. The functions added to the layer use direct call name
+/// mangling and adhere to the C calling convention used by VM code and the JIT.
+class JIT2InterpreterLayer : public ByteCodeLayer
+{
+    llvm::orc::IRLayer& m_baseLayer;
+    llvm::DataLayout m_dataLayout;
+
+public:
+    JIT2InterpreterLayer(llvm::orc::MangleAndInterner& mangler, llvm::orc::IRLayer& baseLayer,
+                              const llvm::DataLayout& dataLayout)
+        : ByteCodeLayer(mangler), m_baseLayer(baseLayer), m_dataLayout(dataLayout)
+    {
+    }
+
+    void emit(std::unique_ptr<llvm::orc::MaterializationResponsibility> mr, const Method* method) override;
+};
+} // namespace jllvm

--- a/src/jllvm/materialization/JIT2InterpreterLayer.hpp
+++ b/src/jllvm/materialization/JIT2InterpreterLayer.hpp
@@ -1,7 +1,15 @@
-
-// Licensed under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023 The JLLVM Contributors.
+//
+// This file is part of JLLVM.
+//
+// JLLVM is free software; you can redistribute it and/or modify it under  the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 3, or (at your option) any later version.
+//
+// JLLVM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with JLLVM; see the file LICENSE.txt.  If not
+// see <http://www.gnu.org/licenses/>.
 
 #pragma once
 

--- a/src/jllvm/vm/CMakeLists.txt
+++ b/src/jllvm/vm/CMakeLists.txt
@@ -16,11 +16,12 @@ llvm_map_components_to_libnames(llvm_native_libs ${LLVM_NATIVE_ARCH})
 add_library(JLLVMVirtualMachine VirtualMachine.cpp JIT.cpp StackMapRegistrationPlugin.cpp
         JNIImplementation.cpp NativeImplementation.cpp JavaFrame.cpp native/IO.cpp
         native/Lang.cpp native/JDK.cpp native/Security.cpp
+        Interpreter.cpp
 )
 target_link_libraries(JLLVMVirtualMachine
         PRIVATE JLLVMLLVMPasses ${llvm_native_libs} LLVMTargetParser LLVMOrcTargetProcess LLVMScalarOpts LLVMAnalysis
         PUBLIC JLLVMClassParser JLLVMObject JLLVMGC JLLVMMaterialization JLLVMUnwinder LLVMExecutionEngine LLVMOrcJIT
-        LLVMJITLink
+        LLVMJITLink LLVMOrcShared
         )
 
 set(JAVA_INCLUDE_PATH "${JAVA_HOME}/../include")

--- a/src/jllvm/vm/Interpreter.cpp
+++ b/src/jllvm/vm/Interpreter.cpp
@@ -1,6 +1,15 @@
-// Licensed under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023 The JLLVM Contributors.
+//
+// This file is part of JLLVM.
+//
+// JLLVM is free software; you can redistribute it and/or modify it under  the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 3, or (at your option) any later version.
+//
+// JLLVM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with JLLVM; see the file LICENSE.txt.  If not
+// see <http://www.gnu.org/licenses/>.
 
 #include "Interpreter.hpp"
 

--- a/src/jllvm/vm/Interpreter.cpp
+++ b/src/jllvm/vm/Interpreter.cpp
@@ -1,0 +1,62 @@
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "Interpreter.hpp"
+
+#include <jllvm/class/ByteCodeIterator.hpp>
+
+#include "VirtualMachine.hpp"
+
+std::uint64_t jllvm::Interpreter::executeMethod(const Method& method, std::uint16_t& offset,
+                                                InterpreterContext& /*context*/)
+{
+    Code* code = method.getMethodInfo().getAttributes().find<Code>();
+    llvm::ArrayRef<char> codeArray = code->getCode();
+    auto curr = ByteCodeIterator(codeArray.drop_front(offset).data(), offset);
+
+    /// Tag returned when interpreting an instruction to jump to a new bytecode offset.
+    struct SetPC
+    {
+        std::uint16_t newPC;
+    };
+
+    /// Tag returned when interpreting an instruction to continue to the next instruction in the bytecode.
+    struct NextPC
+    {
+    };
+
+    /// Tag returned when interpreting an instruction to stop interpretation and return a result.
+    struct ReturnValue
+    {
+        std::uint64_t value;
+    };
+
+    using InstructionResult = swl::variant<SetPC, NextPC, ReturnValue>;
+
+    while (true)
+    {
+        // Update the current offset to the new instruction.
+        offset = curr.getOffset();
+        InstructionResult result =
+            match(*curr,
+                  [&](...) -> InstructionResult
+                  {
+                      // While the interpreter is not fully implemented, we escaped to JIT code that implements the
+                      // given bytecode instruction.
+                      // TODO: Remove this once interpreter implements all bytecodes.
+                      m_virtualMachine.unwindJavaStack(
+                          [&](JavaFrame frame) { m_virtualMachine.getJIT().doI2JOnStackReplacement(frame, offset); });
+                      llvm_unreachable("not possible");
+                  });
+
+        if (auto* returnValue = get_if<ReturnValue>(&result))
+        {
+            return returnValue->value;
+        }
+
+        match(
+            result, [](ReturnValue) {}, [&](NextPC) { ++curr; },
+            [&](SetPC setPc) { curr = ByteCodeIterator(codeArray.drop_front(setPc.newPC).data(), setPc.newPC); });
+    }
+}

--- a/src/jllvm/vm/Interpreter.hpp
+++ b/src/jllvm/vm/Interpreter.hpp
@@ -1,7 +1,15 @@
-
-// Licensed under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023 The JLLVM Contributors.
+//
+// This file is part of JLLVM.
+//
+// JLLVM is free software; you can redistribute it and/or modify it under  the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 3, or (at your option) any later version.
+//
+// JLLVM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with JLLVM; see the file LICENSE.txt.  If not
+// see <http://www.gnu.org/licenses/>.
 
 #pragma once
 

--- a/src/jllvm/vm/Interpreter.hpp
+++ b/src/jllvm/vm/Interpreter.hpp
@@ -1,0 +1,67 @@
+
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include <jllvm/object/ClassObject.hpp>
+
+#include <cstdint>
+
+namespace jllvm
+{
+
+class VirtualMachine;
+
+/// Context used in the execution of one Java frame. It incorporates and contains convenience methods for interacting
+/// with local variables and the operand stack.
+class InterpreterContext
+{
+    std::uint16_t& m_topOfStack;
+    std::uint64_t* m_operandStack;
+    std::uint64_t* m_operandGCMask;
+    std::uint64_t* m_localVariables;
+    std::uint64_t* m_localVariableGCMask;
+
+public:
+
+    /// Creates a new 'InterpreterContext' from the given parameters. 'topOfStack' is a reference that is always kept
+    /// up to date as the current top of stack. The two 'gc' mask parameters are used as bitsets and have their "i"th
+    /// bit always set to true if the corresponding operand stack slot or local variable contains a Java reference.
+    /// All the pointers passed here are not taken ownership of and must be allocated externally and valid while the
+    /// 'InterpreterContext' is still in use.
+    InterpreterContext(std::uint16_t& topOfStack, std::uint64_t* operandStack, std::uint64_t* operandGCMask,
+                       std::uint64_t* localVariables, std::uint64_t* localVariableGCMask)
+        : m_topOfStack(topOfStack),
+          m_operandStack(operandStack),
+          m_operandGCMask(operandGCMask),
+          m_localVariables(localVariables),
+          m_localVariableGCMask(localVariableGCMask)
+    {
+    }
+
+    // TODO: Implement methods for operand stack and global variables.
+};
+
+/// Interpreter instance containing all global state of the interpreter.
+class Interpreter
+{
+    VirtualMachine& m_virtualMachine;
+    /// Enable OSR from the interpreter into the JIT if the method is hot enough.
+    bool m_enableOSR;
+
+public:
+
+    explicit Interpreter(VirtualMachine& virtualMachine, bool enableOSR)
+        : m_virtualMachine(virtualMachine), m_enableOSR(enableOSR)
+    {
+    }
+
+    /// Method called to start executing 'method' at the given 'offset' with the given 'context'. Both the context and
+    /// offset are kept up-to-date during execution with the current local variables, operand stack and offset being
+    /// executed.
+    /// Returns the result of the method bitcast to an uint64_t.
+    std::uint64_t executeMethod(const Method& method, std::uint16_t& offset, InterpreterContext& context);
+};
+} // namespace jllvm

--- a/src/jllvm/vm/JIT.hpp
+++ b/src/jllvm/vm/JIT.hpp
@@ -29,6 +29,8 @@
 #include <jllvm/compiler/ClassObjectStubMangling.hpp>
 #include <jllvm/gc/GarbageCollector.hpp>
 #include <jllvm/materialization/ByteCodeCompileLayer.hpp>
+#include <jllvm/materialization/ByteCodeOSRCompileLayer.hpp>
+#include <jllvm/materialization/JIT2InterpreterLayer.hpp>
 #include <jllvm/materialization/JNIImplementationLayer.hpp>
 #include <jllvm/materialization/LambdaMaterialization.hpp>
 #include <jllvm/object/ClassLoader.hpp>
@@ -41,6 +43,14 @@
 
 namespace jllvm
 {
+
+enum class ExecutionMode
+{
+    JIT,
+    Interpreter,
+    Mixed
+};
+
 class JIT
 {
     std::unique_ptr<llvm::orc::ExecutionSession> m_session;
@@ -51,9 +61,10 @@ class JIT
     llvm::orc::JITDylib& m_externalStubs;
     /// Dylib containing only the actual JIT compiled Java methods.
     llvm::orc::JITDylib& m_javaJITSymbols;
+    llvm::orc::JITDylib& m_compiled2InterpreterSymbols;
     /// Dylib containing all additional symbols required by 'm_javaJITSymbols' to link correctly, but are not part of
     /// the public interface of the JIT.
-    llvm::orc::JITDylib& m_javaJITImplDetails;
+    llvm::orc::JITDylib& m_implDetails;
     std::unique_ptr<llvm::orc::EPCIndirectionUtils> m_epciu;
     std::unique_ptr<llvm::TargetMachine> m_targetMachine;
     llvm::orc::LazyCallThroughManager& m_lazyCallThroughManager;
@@ -65,13 +76,16 @@ class JIT
     StringInterner& m_stringInterner;
 
     llvm::DataLayout m_dataLayout;
+    ExecutionMode m_executionMode;
 
     llvm::orc::MangleAndInterner m_interner;
     llvm::orc::ObjectLinkingLayer m_objectLayer;
     llvm::orc::IRCompileLayer m_compilerLayer;
     llvm::orc::IRTransformLayer m_optimizeLayer;
     ByteCodeCompileLayer m_byteCodeCompileLayer;
+    ByteCodeOSRCompileLayer m_byteCodeOSRCompileLayer;
     JNIImplementationLayer m_jniLayer;
+    JIT2InterpreterLayer m_compiled2InterpreterLayer;
 
     llvm::DenseSet<std::uintptr_t> m_javaFrames;
 
@@ -79,11 +93,11 @@ class JIT
 
     JIT(std::unique_ptr<llvm::orc::ExecutionSession>&& session, std::unique_ptr<llvm::orc::EPCIndirectionUtils>&& epciu,
         llvm::orc::JITTargetMachineBuilder&& builder, llvm::DataLayout&& layout, ClassLoader& classLoader,
-        GarbageCollector& gc, StringInterner& stringInterner, void* jniFunctions);
+        GarbageCollector& gc, StringInterner& stringInterner, void* jniFunctions, ExecutionMode executionMode);
 
 public:
     static jllvm::JIT create(ClassLoader& classLoader, GarbageCollector& gc, StringInterner& stringInterner,
-                             void* jniFunctions);
+                             void* jniFunctions, ExecutionMode executionMode);
 
     ~JIT();
 
@@ -123,7 +137,7 @@ public:
     void addImplementationSymbol(std::string symbol, const F& f)
         requires(!std::is_pointer_v<F> && !std::is_function_v<F>)
     {
-        llvm::cantFail(m_javaJITImplDetails.define(
+        llvm::cantFail(m_implDetails.define(
             createLambdaMaterializationUnit(std::move(symbol), m_optimizeLayer, f, m_dataLayout, m_interner)));
     }
 
@@ -131,7 +145,7 @@ public:
     template <class Ret, class... Args>
     void addImplementationSymbol(llvm::StringRef symbol, Ret (*f)(Args...))
     {
-        llvm::cantFail(m_javaJITImplDetails.define(llvm::orc::absoluteSymbols(
+        llvm::cantFail(m_implDetails.define(llvm::orc::absoluteSymbols(
             {{m_interner(symbol), llvm::JITEvaluatedSymbol::fromPointer(f, llvm::JITSymbolFlags::Exported
                                                                                | llvm::JITSymbolFlags::Callable)}})));
     }
@@ -140,7 +154,7 @@ public:
     template <class T>
     void addImplementationSymbol(llvm::StringRef symbol, T* ptr) requires(!std::is_function_v<T>)
     {
-        llvm::cantFail(m_javaJITImplDetails.define(
+        llvm::cantFail(m_implDetails.define(
             llvm::orc::absoluteSymbols({{m_interner(symbol), llvm::JITEvaluatedSymbol::fromPointer(ptr)}})));
     }
 
@@ -171,6 +185,10 @@ public:
     /// 'frame' must be the execution of a Java method.
     [[noreturn]] void doExceptionOnStackReplacement(JavaFrame frame, std::uint16_t byteCodeOffset,
                                                     Throwable* exception);
+
+    /// Performs On-Stack-Replacement of 'frame' and all its callees, replacing it with the execution of the same
+    /// method at the JVM bytecode corresponding to 'byteCodeOffset'.
+    [[noreturn]] void doI2JOnStackReplacement(JavaFrame frame, std::uint16_t byteCodeOffset);
 
     /// Looks up the method 'methodName' within the class 'className' with the type given by 'methodDescriptor'
     /// returning a pointer to the function if successful or an error otherwise.

--- a/src/jllvm/vm/JIT.hpp
+++ b/src/jllvm/vm/JIT.hpp
@@ -44,10 +44,14 @@
 namespace jllvm
 {
 
+/// Where code should be executed by default.
 enum class ExecutionMode
 {
+    /// Executes code in the JIT whenever possible.
     JIT,
+    /// Executes code in the interpreter whenever possible.
     Interpreter,
+    /// Dynamically adjusts where code is being executed.
     Mixed
 };
 
@@ -61,7 +65,7 @@ class JIT
     llvm::orc::JITDylib& m_externalStubs;
     /// Dylib containing only the actual JIT compiled Java methods.
     llvm::orc::JITDylib& m_javaJITSymbols;
-    llvm::orc::JITDylib& m_compiled2InterpreterSymbols;
+    llvm::orc::JITDylib& m_jit2InterpreterSymbols;
     /// Dylib containing all additional symbols required by 'm_javaJITSymbols' to link correctly, but are not part of
     /// the public interface of the JIT.
     llvm::orc::JITDylib& m_implDetails;

--- a/src/jllvm/vm/JavaFrame.hpp
+++ b/src/jllvm/vm/JavaFrame.hpp
@@ -74,13 +74,13 @@ public:
         return *m_unwindFrame;
     }
 
-    /// Reads out the values of all the local variables at the given bytecode offset.
+    /// Reads out the values of all the local variables at the current bytecode offset.
     /// This method will always return an empty array in following scenarios:
     /// * If the method being executed is native and therefore does not have local variables
     /// * If no exception handler exists for a bytecode offset within a JITted method.
     llvm::SmallVector<std::uint64_t> readLocals() const;
 
-    /// Reads out the values of the operand stack at the given bytecode offset.
+    /// Reads out the values of the operand stack at the current bytecode offset.
     /// This method will always return an empty array in following scenarios:
     /// * If the method being executed is not being executed by the interpreter.
     llvm::SmallVector<std::uint64_t> readOperandStack() const;

--- a/src/jllvm/vm/JavaFrame.hpp
+++ b/src/jllvm/vm/JavaFrame.hpp
@@ -34,6 +34,24 @@ public:
     {
     }
 
+    /// Returns true if this java frame is being executed in the JIT.
+    bool isJIT() const
+    {
+        return m_javaMethodMetadata->isJIT();
+    }
+
+    /// Returns true if this java frame is being executed in the interpreter.
+    bool isInterpreter() const
+    {
+        return m_javaMethodMetadata->isInterpreter();
+    }
+
+    /// Returns true if this java frame is a native method.
+    bool isNative() const
+    {
+        return m_javaMethodMetadata->isNative();
+    }
+
     /// Returns the bytecode offset of the frame currently being executed.
     /// Returns an empty optional if the method being executed is native and therefore does not have a bytecode offset.
     std::optional<std::uint16_t> getByteCodeOffset() const;
@@ -61,6 +79,11 @@ public:
     /// * If the method being executed is native and therefore does not have local variables
     /// * If no exception handler exists for a bytecode offset within a JITted method.
     llvm::SmallVector<std::uint64_t> readLocals() const;
+
+    /// Reads out the values of the operand stack at the given bytecode offset.
+    /// This method will always return an empty array in following scenarios:
+    /// * If the method being executed is not being executed by the interpreter.
+    llvm::SmallVector<std::uint64_t> readOperandStack() const;
 };
 
 } // namespace jllvm

--- a/src/jllvm/vm/StackMapRegistrationPlugin.hpp
+++ b/src/jllvm/vm/StackMapRegistrationPlugin.hpp
@@ -47,6 +47,9 @@ class StackMapRegistrationPlugin : public llvm::orc::ObjectLinkingLayer::Plugin
     void parseJITEntry(JavaMethodMetadata::JITData& jitData, StackMapParser::RecordAccessor& record,
                        StackMapParser& parser, std::uint64_t functionAddress);
 
+    void parseInterpreterEntry(JavaMethodMetadata::InterpreterData& interpreterData,
+                               StackMapParser::RecordAccessor& record, StackMapParser& parser);
+
 public:
     explicit StackMapRegistrationPlugin(GarbageCollector& gc, llvm::DenseSet<std::uintptr_t>& javaFrameSet)
         : m_gc(gc), m_javaFrameSet(javaFrameSet)

--- a/src/jllvm/vm/VirtualMachine.hpp
+++ b/src/jllvm/vm/VirtualMachine.hpp
@@ -25,6 +25,7 @@
 #include <random>
 
 #include "InteropHelpers.hpp"
+#include "Interpreter.hpp"
 #include "JIT.hpp"
 #include "JavaFrame.hpp"
 
@@ -37,6 +38,7 @@ struct BootOptions
     llvm::StringRef javaHome;
     std::vector<std::string> classPath;
     bool systemInitialization = true;
+    ExecutionMode executionMode = ExecutionMode::Mixed;
 };
 
 struct ModelState;
@@ -51,7 +53,8 @@ class VirtualMachine
     ClassLoader m_classLoader;
     GarbageCollector m_gc;
     StringInterner m_stringInterner;
-    JIT m_jit = JIT::create(m_classLoader, m_gc, m_stringInterner, m_jniEnv.get());
+    JIT m_jit;
+    Interpreter m_interpreter;
     std::mt19937 m_pseudoGen;
     std::uniform_int_distribution<std::uint32_t> m_hashIntDistrib;
     GCRootRef<Object> m_mainThread = m_gc.allocateStatic();

--- a/tests/Execution/abstract-class-interface.java
+++ b/tests/Execution/abstract-class-interface.java
@@ -1,6 +1,7 @@
 // RUN: rm -rf %t && split-file %s %t
 // RUN: cd %t && javac %t/Other.java -d %t
-// RUN: jllvm %t/Other.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Other.class | FileCheck %s
+// RUN: jllvm -Xint %t/Other.class | FileCheck %s
 
 //--- Test.java
 

--- a/tests/Execution/args.java
+++ b/tests/Execution/args.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class foo bar baz | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class foo bar baz | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class foo bar baz | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/array-index-out-of-bounds-exception-error.java
+++ b/tests/Execution/array-index-out-of-bounds-exception-error.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: not jllvm %t/Test.class 2>&1 | FileCheck %s
+// RUN: not jllvm -Xint %t/Test.class 2>&1 | FileCheck %s
+// RUN: not jllvm -Xjit %t/Test.class 2>&1 | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/assert.java
+++ b/tests/Execution/assert.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class
+// RUN: jllvm -Xint %t/Test.class
+// RUN: jllvm -Xjit %t/Test.class
 
 class Test
 {

--- a/tests/Execution/athrow.java
+++ b/tests/Execution/athrow.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: not jllvm %t/Test.class 2>&1 | FileCheck %s
+// RUN: not jllvm -Xint %t/Test.class 2>&1 | FileCheck %s
+// RUN: not jllvm -Xjit %t/Test.class 2>&1 | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/basic-blocks.java
+++ b/tests/Execution/basic-blocks.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/bipush.java
+++ b/tests/Execution/bipush.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/blocks-with-different-types-on-stack.j
+++ b/tests/Execution/blocks-with-different-types-on-stack.j
@@ -1,5 +1,6 @@
 ; RUN: jasmin %s -d %t
-; RUN: jllvm %t/Test.class
+; RUN: jllvm -Xjit %t/Test.class
+; RUN: jllvm -Xint %t/Test.class
 
 .class public Test
 .super java/lang/Object

--- a/tests/Execution/checkcast.java
+++ b/tests/Execution/checkcast.java
@@ -1,6 +1,7 @@
 // RUN: rm -rf %t && split-file %s %t
 // RUN: cd %t && javac %t/Test.java -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 //--- Test.java
 

--- a/tests/Execution/circular-class-loader.java
+++ b/tests/Execution/circular-class-loader.java
@@ -1,6 +1,7 @@
 // RUN: rm -rf %t && split-file %s %t
 // RUN: cd %t && javac %t/Test.java -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 //--- Test.java
 

--- a/tests/Execution/class-cast-exception-error.java
+++ b/tests/Execution/class-cast-exception-error.java
@@ -1,6 +1,7 @@
 // RUN: rm -rf %t && split-file %s %t
 // RUN: cd %t && javac %t/Test.java -d %t
-// RUN: not jllvm %t/Test.class 2>&1 | FileCheck %s
+// RUN: not jllvm -Xjit %t/Test.class 2>&1 | FileCheck %s
+// RUN: not jllvm -Xint %t/Test.class 2>&1 | FileCheck %s
 
 //--- Test.java
 

--- a/tests/Execution/class-object-as-java-object.java
+++ b/tests/Execution/class-object-as-java-object.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/compact-string-to-utf8.java
+++ b/tests/Execution/compact-string-to-utf8.java
@@ -1,5 +1,6 @@
 // RUN: javac -encoding utf-8 %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/constructor-in-other-class.java
+++ b/tests/Execution/constructor-in-other-class.java
@@ -1,6 +1,7 @@
 // RUN: rm -rf %t && split-file %s %t
 // RUN: cd %t && javac %t/Other.java -d %t
-// RUN: jllvm %t/Other.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Other.class | FileCheck %s
+// RUN: jllvm -Xint %t/Other.class | FileCheck %s
 
 //--- Test.java
 

--- a/tests/Execution/constructors.java
+++ b/tests/Execution/constructors.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/control-flow-false-positive.java
+++ b/tests/Execution/control-flow-false-positive.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class
+// RUN: jllvm -Xjit %t/Test.class
+// RUN: jllvm -Xint %t/Test.class
 
 class Test
 {

--- a/tests/Execution/control-flow-path-dependent-operand-stack.java
+++ b/tests/Execution/control-flow-path-dependent-operand-stack.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test {
     public static native void print(int i);

--- a/tests/Execution/create-array-of-other-class.java
+++ b/tests/Execution/create-array-of-other-class.java
@@ -1,6 +1,7 @@
 // RUN: rm -rf %t && split-file %s %t
 // RUN: cd %t && javac %t/Test.java -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 //--- Test.java
 

--- a/tests/Execution/create-array.java
+++ b/tests/Execution/create-array.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/dadd.java
+++ b/tests/Execution/dadd.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/ddiv.java
+++ b/tests/Execution/ddiv.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/dead-code.j
+++ b/tests/Execution/dead-code.j
@@ -1,5 +1,6 @@
 ; RUN: jasmin %s -d %t
-; RUN: jllvm %t/Test.class
+; RUN: jllvm -Xjit %t/Test.class
+; RUN: jllvm -Xint %t/Test.class
 
 .class public Test
 .super java/lang/Object

--- a/tests/Execution/deopt-smaller-than-pointer.j
+++ b/tests/Execution/deopt-smaller-than-pointer.j
@@ -1,5 +1,6 @@
 ; RUN: jasmin %s -d %t
-; RUN: jllvm %t/Test.class | FileCheck %s
+; RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+; RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 .class public Test
 .super java/lang/Object

--- a/tests/Execution/dmul.java
+++ b/tests/Execution/dmul.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/dneg.java
+++ b/tests/Execution/dneg.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/double-casts.java
+++ b/tests/Execution/double-casts.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/double-comparisons.java
+++ b/tests/Execution/double-comparisons.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/double-float-bits.java
+++ b/tests/Execution/double-float-bits.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/drem.java
+++ b/tests/Execution/drem.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/dsub.java
+++ b/tests/Execution/dsub.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/dynamic-stack-usage-gc.java
+++ b/tests/Execution/dynamic-stack-usage-gc.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/empty-string.java
+++ b/tests/Execution/empty-string.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/exception-handling-stack-type-mismatch.j
+++ b/tests/Execution/exception-handling-stack-type-mismatch.j
@@ -1,6 +1,7 @@
 ; RUN: rm -rf %t && split-file %s %t
 ; RUN: cd %t && jasmin %t/Test.j -d %t && jasmin %t/A.j
-; RUN: jllvm %t/Test.class
+; RUN: jllvm -Xjit %t/Test.class
+; RUN: jllvm -Xint %t/Test.class
 
 ;--- A.j
 

--- a/tests/Execution/fadd.java
+++ b/tests/Execution/fadd.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/faload-fastore.java
+++ b/tests/Execution/faload-fastore.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/fdiv.java
+++ b/tests/Execution/fdiv.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/final-method-call.java
+++ b/tests/Execution/final-method-call.java
@@ -1,6 +1,7 @@
 // RUN: rm -rf %t && split-file %s %t
 // RUN: cd %t && javac %t/Other.java -d %t
-// RUN: jllvm %t/Other.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Other.class | FileCheck %s
+// RUN: jllvm -Xint %t/Other.class | FileCheck %s
 
 //--- Test.java
 

--- a/tests/Execution/fload-fstore.java
+++ b/tests/Execution/fload-fstore.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/float-casts.java
+++ b/tests/Execution/float-casts.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/float-comparisons.java
+++ b/tests/Execution/float-comparisons.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/fmul.java
+++ b/tests/Execution/fmul.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/fneg.java
+++ b/tests/Execution/fneg.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/for-loop.java
+++ b/tests/Execution/for-loop.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/frem.java
+++ b/tests/Execution/frem.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/fsub.java
+++ b/tests/Execution/fsub.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/getfield-getstatic.java
+++ b/tests/Execution/getfield-getstatic.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/handler-stack-pointer.j
+++ b/tests/Execution/handler-stack-pointer.j
@@ -1,5 +1,6 @@
 ; RUN: jasmin %s -d %t
-; RUN: jllvm %t/Test.class
+; RUN: jllvm -Xjit %t/Test.class
+; RUN: jllvm -Xint %t/Test.class
 
 .class public Test
 .super java/lang/Object

--- a/tests/Execution/iadd.java
+++ b/tests/Execution/iadd.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/iaload-iastore.java
+++ b/tests/Execution/iaload-iastore.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/iand-ior-ineg-ixor.java
+++ b/tests/Execution/iand-ior-ineg-ixor.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/idiv.java
+++ b/tests/Execution/idiv.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/ifnull-ifnonnull.java
+++ b/tests/Execution/ifnull-ifnonnull.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/imul.java
+++ b/tests/Execution/imul.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/instance-fields.java
+++ b/tests/Execution/instance-fields.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/instanceof.java
+++ b/tests/Execution/instanceof.java
@@ -1,6 +1,7 @@
 // RUN: rm -rf %t && split-file %s %t
 // RUN: cd %t && javac %t/Test.java -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 //--- Test.java
 

--- a/tests/Execution/int-shifts.java
+++ b/tests/Execution/int-shifts.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/integer-casts.java
+++ b/tests/Execution/integer-casts.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/integer-comparisons.java
+++ b/tests/Execution/integer-comparisons.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/interface-methods.java
+++ b/tests/Execution/interface-methods.java
@@ -1,6 +1,7 @@
 // RUN: rm -rf %t && split-file %s %t
 // RUN: cd %t && javac %t/Other.java -d %t
-// RUN: jllvm %t/Other.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Other.class | FileCheck %s
+// RUN: jllvm -Xint %t/Other.class | FileCheck %s
 
 //--- Test.java
 

--- a/tests/Execution/interface-object-call.j
+++ b/tests/Execution/interface-object-call.j
@@ -1,6 +1,7 @@
 ; RUN: rm -rf %t && split-file %s %t
 ; RUN: cd %t && jasmin %t/Test.j -d %t && jasmin %t/Other.j -d %t
-; RUN: jllvm %t/Test.class | FileCheck %s
+; RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+; RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 ;--- Test.j
 

--- a/tests/Execution/invoke-virtual-interface-method.java
+++ b/tests/Execution/invoke-virtual-interface-method.java
@@ -1,6 +1,7 @@
 // RUN: rm -rf %t && split-file %s %t
 // RUN: cd %t && javac %t/Test.java -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 //--- Test.java
 

--- a/tests/Execution/invoke-virtual.java
+++ b/tests/Execution/invoke-virtual.java
@@ -1,6 +1,7 @@
 // RUN: rm -rf %t && split-file %s %t
 // RUN: cd %t && javac %t/Other.java -d %t
-// RUN: jllvm %t/Other.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Other.class | FileCheck %s
+// RUN: jllvm -Xint %t/Other.class | FileCheck %s
 
 //--- Test.java
 

--- a/tests/Execution/irem.java
+++ b/tests/Execution/irem.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/ireturn.java
+++ b/tests/Execution/ireturn.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/isub.java
+++ b/tests/Execution/isub.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/jni-primitives.java
+++ b/tests/Execution/jni-primitives.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/ladd.java
+++ b/tests/Execution/ladd.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/land-lor-lxor-lcmp.java
+++ b/tests/Execution/land-lor-lxor-lcmp.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/ldc2_w.java
+++ b/tests/Execution/ldc2_w.java
@@ -1,5 +1,7 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
+
 class Test
 {
     public static native void print(double d);

--- a/tests/Execution/ldiv.java
+++ b/tests/Execution/ldiv.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/less-than-int-args.java
+++ b/tests/Execution/less-than-int-args.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/llvm-miscompile.java
+++ b/tests/Execution/llvm-miscompile.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class
+// RUN: jllvm -Xjit %t/Test.class
+// RUN: jllvm -Xint %t/Test.class
 
 class Test
 {

--- a/tests/Execution/lmul.java
+++ b/tests/Execution/lmul.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/long-casts.java
+++ b/tests/Execution/long-casts.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/long-shifts.java
+++ b/tests/Execution/long-shifts.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/lrem.java
+++ b/tests/Execution/lrem.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/lsub.java
+++ b/tests/Execution/lsub.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/maximally-specific-interface.java
+++ b/tests/Execution/maximally-specific-interface.java
@@ -1,6 +1,7 @@
 // RUN: rm -rf %t && split-file %s %t
 // RUN: cd %t && javac %t/Other.java -d %t
-// RUN: jllvm %t/Other.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Other.class | FileCheck %s
+// RUN: jllvm -Xint %t/Other.class | FileCheck %s
 
 //--- Test.java
 

--- a/tests/Execution/monitor-enter-exit.java
+++ b/tests/Execution/monitor-enter-exit.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class
+// RUN: jllvm -Xjit %t/Test.class
+// RUN: jllvm -Xint %t/Test.class
 
 class Test
 {

--- a/tests/Execution/multianewarray.java
+++ b/tests/Execution/multianewarray.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/multiple-statics.java
+++ b/tests/Execution/multiple-statics.java
@@ -1,7 +1,8 @@
 // RUN: rm -rf %t && split-file %s %t
 // RUN: cd %t && javac %t/Test.java -d %t
 
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
 
 //--- Test.java
 

--- a/tests/Execution/negative-array-size-exception-error.java
+++ b/tests/Execution/negative-array-size-exception-error.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: not jllvm %t/Test.class 2>&1 | FileCheck %s
+// RUN: not jllvm -Xjit %t/Test.class 2>&1 | FileCheck %s
+// RUN: not jllvm -Xint %t/Test.class 2>&1 | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/object-array-ops.java
+++ b/tests/Execution/object-array-ops.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/object-hash-code.java
+++ b/tests/Execution/object-hash-code.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/old-invokenonvirtual.j
+++ b/tests/Execution/old-invokenonvirtual.j
@@ -1,6 +1,7 @@
 ; RUN: rm -rf %t && split-file %s %t
 ; RUN: cd %t && jasmin %t/Test.j -d %t && jasmin %t/A.j  && jasmin %t/B.j -d %t
-; RUN: jllvm %t/Test.class | FileCheck %s
+; RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+; RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 ;--- A.j
 

--- a/tests/Execution/out-of-order-blocks.j
+++ b/tests/Execution/out-of-order-blocks.j
@@ -1,5 +1,6 @@
 ; RUN: jasmin %s -d %t
-; RUN: jllvm %t/Test.class
+; RUN: jllvm -Xjit %t/Test.class
+; RUN: jllvm -Xint %t/Test.class
 
 .class public Test
 .super java/lang/Object

--- a/tests/Execution/private-invoke-interface.java
+++ b/tests/Execution/private-invoke-interface.java
@@ -1,6 +1,7 @@
 // RUN: rm -rf %t && split-file %s %t
 // RUN: cd %t && javac %t/Other.java -d %t
-// RUN: jllvm %t/Main.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Main.class | FileCheck %s
+// RUN: jllvm -Xint %t/Main.class | FileCheck %s
 
 //--- Test.java
 

--- a/tests/Execution/private-invoke-virtual.java
+++ b/tests/Execution/private-invoke-virtual.java
@@ -1,6 +1,7 @@
 // RUN: rm -rf %t && split-file %s %t
 // RUN: cd %t && javac %t/Other.java -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 //--- Test.java
 

--- a/tests/Execution/recursive-function-debug-info-crash.java
+++ b/tests/Execution/recursive-function-debug-info-crash.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class
+// RUN: jllvm -Xjit %t/Test.class
+// RUN: jllvm -Xint %t/Test.class
 
 class Test
 {

--- a/tests/Execution/reflection-get-caller-class.java
+++ b/tests/Execution/reflection-get-caller-class.java
@@ -1,6 +1,7 @@
 // RUN: rm -rf %t && split-file %s %t
 // RUN: cd %t && javac --add-exports java.base/jdk.internal.reflect=ALL-UNNAMED %t/Other.java -d %t
-// RUN: jllvm %t/Other.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Other.class | FileCheck %s
+// RUN: jllvm -Xint %t/Other.class | FileCheck %s
 
 //--- Test.java
 

--- a/tests/Execution/relocation-in-stub.java
+++ b/tests/Execution/relocation-in-stub.java
@@ -1,6 +1,7 @@
 // RUN: rm -rf %t && split-file %s %t
 // RUN: cd %t && javac %t/Other.java -d %t
-// RUN: jllvm %t/Other.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Other.class | FileCheck %s
+// RUN: jllvm -Xint %t/Other.class | FileCheck %s
 
 //--- Test.java
 

--- a/tests/Execution/runtime.java
+++ b/tests/Execution/runtime.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/simple-package-private-override.java
+++ b/tests/Execution/simple-package-private-override.java
@@ -1,6 +1,7 @@
 // RUN: rm -rf %t && split-file %s %t
 // RUN: cd %t && javac %t/Other.java -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 //--- Test.java
 

--- a/tests/Execution/small-int-array.java
+++ b/tests/Execution/small-int-array.java
@@ -1,5 +1,6 @@
 // RUN: javac -encoding utf-8 %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/stack-operations.j
+++ b/tests/Execution/stack-operations.j
@@ -1,5 +1,7 @@
 ; RUN: jasmin %s -d %t
-; RUN: jllvm %t/Test.class | FileCheck %s
+; RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+; RUN: jllvm -Xint %t/Test.class | FileCheck %s
+
 .class public Test
 .super java/lang/Object
 

--- a/tests/Execution/static-class-loader-gc.java
+++ b/tests/Execution/static-class-loader-gc.java
@@ -1,6 +1,7 @@
 // RUN: rm -rf %t && split-file %s %t
 // RUN: cd %t && javac %t/Test.java -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 //--- Test.java
 

--- a/tests/Execution/static-field.java
+++ b/tests/Execution/static-field.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/static-fields-in-other-class.java
+++ b/tests/Execution/static-fields-in-other-class.java
@@ -1,6 +1,7 @@
 // RUN: rm -rf %t && split-file %s %t
 // RUN: cd %t && javac %t/Test.java -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 //--- Test.java
 

--- a/tests/Execution/static-final-fields-optimization.java
+++ b/tests/Execution/static-final-fields-optimization.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/static-method-in-other-class.java
+++ b/tests/Execution/static-method-in-other-class.java
@@ -1,6 +1,7 @@
 // RUN: rm -rf %t && split-file %s %t
 // RUN: cd %t && javac %t/Other.java -d %t
-// RUN: jllvm %t/Other.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Other.class | FileCheck %s
+// RUN: jllvm -Xint %t/Other.class | FileCheck %s
 
 //--- Test.java
 

--- a/tests/Execution/static-method-resolution.java
+++ b/tests/Execution/static-method-resolution.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test extends Other implements Foo
 {

--- a/tests/Execution/static-method.java
+++ b/tests/Execution/static-method.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/string-interner-gc.java
+++ b/tests/Execution/string-interner-gc.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/string-literals.java
+++ b/tests/Execution/string-literals.java
@@ -1,5 +1,6 @@
 // RUN: javac -encoding utf-8 %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/subroutine.j
+++ b/tests/Execution/subroutine.j
@@ -1,5 +1,6 @@
 ; RUN: jasmin %s -d %t
-; RUN: jllvm %t/Test.class
+; RUN: jllvm -Xjit %t/Test.class
+; RUN: jllvm -Xint %t/Test.class
 
 .class public Test
 .super java/lang/Object

--- a/tests/Execution/super-class-fields-gc.java
+++ b/tests/Execution/super-class-fields-gc.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/super-class-super-interface.java
+++ b/tests/Execution/super-class-super-interface.java
@@ -1,6 +1,7 @@
 // RUN: rm -rf %t && split-file %s %t
 // RUN: cd %t && javac %t/Other.java -d %t
-// RUN: jllvm %t/Other.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Other.class | FileCheck %s
+// RUN: jllvm -Xint %t/Other.class | FileCheck %s
 
 //--- Test.java
 

--- a/tests/Execution/superclass-fields.java
+++ b/tests/Execution/superclass-fields.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Other.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Other.class | FileCheck %s
+// RUN: jllvm -Xint %t/Other.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/switch.java
+++ b/tests/Execution/switch.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/system-nanoTime.java
+++ b/tests/Execution/system-nanoTime.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class
+// RUN: jllvm -Xjit %t/Test.class
+// RUN: jllvm -Xint %t/Test.class
 
 class Test
 {

--- a/tests/Execution/try-catch.java
+++ b/tests/Execution/try-catch.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck --match-full-lines %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck --match-full-lines %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck --match-full-lines %s
 
 class Test
 {

--- a/tests/Execution/unsafe-array-base-and-index.java
+++ b/tests/Execution/unsafe-array-base-and-index.java
@@ -1,5 +1,6 @@
 // RUN: javac --add-exports java.base/jdk.internal.misc=ALL-UNNAMED %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 import jdk.internal.misc.Unsafe;
 

--- a/tests/Execution/unsafe-compare-and-set.java
+++ b/tests/Execution/unsafe-compare-and-set.java
@@ -1,5 +1,6 @@
 // RUN: javac --add-exports java.base/jdk.internal.misc=ALL-UNNAMED %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 import jdk.internal.misc.Unsafe;
 

--- a/tests/Execution/unsafe-fences.java
+++ b/tests/Execution/unsafe-fences.java
@@ -1,5 +1,6 @@
 // RUN: javac --add-exports java.base/jdk.internal.misc=ALL-UNNAMED %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 import jdk.internal.misc.Unsafe;
 

--- a/tests/Execution/unsafe-get-put-volatile.java
+++ b/tests/Execution/unsafe-get-put-volatile.java
@@ -1,5 +1,6 @@
 // RUN: javac --add-exports java.base/jdk.internal.misc=ALL-UNNAMED %s -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
 
 import jdk.internal.misc.Unsafe;
 

--- a/tests/Execution/unsatisfied-link-error.java
+++ b/tests/Execution/unsatisfied-link-error.java
@@ -1,5 +1,6 @@
 // RUN: javac %s -d %t
-// RUN: not jllvm %t/Test.class 2>&1 | FileCheck %s
+// RUN: not jllvm -Xjit %t/Test.class 2>&1 | FileCheck %s
+// RUN: not jllvm -Xint %t/Test.class 2>&1 | FileCheck %s
 
 class Test
 {

--- a/tests/Execution/wide.j
+++ b/tests/Execution/wide.j
@@ -1,5 +1,6 @@
 ; RUN: jasmin %s -d %t
-; RUN: jllvm %t/Test.class
+; RUN: jllvm -Xjit %t/Test.class
+; RUN: jllvm -Xint %t/Test.class
 
 .class public Test
 .super java/lang/Object


### PR DESCRIPTION
This PR implements the first initial infrastructure for implementing a Bytecode Interpreter. It most notably hooks into the existing JIT system to generate stubs for compiling interpreter methods using the C calling convention as is currently the case for the JIT and integrates with `JavaFrame` to implement reading metadata such as local variables, the operand stack and the bytecode offset.

The actual interpreter method does not yet implement any JVM instruction. Rather, it only implements On-Stack-Replacement from the interpreter to JITted code, and uses this mechanism as a fallback to continue execution of any method containing bytecode not yet implemented in the interpreter. This allows an incremental implementation strategy of the interpreter.

To retain test-coverage, `-Xjit` and `-Xint` developer options were added that control whether code should only be executed by the JIT or interpreter (if possible). This way our current execution tests can be used for both the interpreter and the JIT to test their correctness.
Since the Interpreter escapes to the JIT on unimplemented instructions, no tests failures currently occur when running with `-Xint`.
 Nevertheless, if an instruction was implemented incorrectly by the interpreter, we would see failing tests.

 This PR contains only the bare minimum of code required to start iterating.
 Things left to do are:
 * actually implementing at least one instruction
 * handling interpreter frames in the GC
 * implementing OSR from JIT to the Interpreter (for e.g. exception handling)