### PR TITLE
[codegen] Remove exception hanlder chain

### DIFF
--- a/src/jllvm/compiler/CodeGenerator.hpp
+++ b/src/jllvm/compiler/CodeGenerator.hpp
@@ -52,8 +52,6 @@ class CodeGenerator
 
     // std::list because we want the iterator stability when deleting handlers (requires random access).
     std::list<HandlerInfo> m_activeHandlers;
-    // std::map because it is the easiest to use with std::list key.
-    std::map<std::list<HandlerInfo>, llvm::BasicBlock*> m_alreadyGeneratedHandlers;
 
     /// Returns the basic block corresponding to the given bytecode offset and schedules the basic block to be compiled.
     /// The offset must point to the start of a basic block.
@@ -94,8 +92,7 @@ class CodeGenerator
 
     void generateNegativeArraySizeCheck(std::uint16_t byteCodeOffset, llvm::Value* size);
 
-    llvm::BasicBlock* generateHandlerChain(std::uint16_t byteCodeOffset, llvm::Value* exception,
-                                           llvm::BasicBlock* newPred);
+    void generateExceptionThrow(std::uint16_t byteCodeOffset, llvm::Value* exception);
 
     llvm::Value* loadClassObjectFromPool(std::uint16_t offset, PoolIndex<ClassInfo> index);
 

--- a/tests/Compiler/osr-frames.j
+++ b/tests/Compiler/osr-frames.j
@@ -98,9 +98,7 @@ L25:
 ; EXC-NEXT: store ptr addrspace(1) %[[LOAD_LOCAL1]], ptr %[[OP0]]
 ; EXC-NEXT: %[[LOAD_OP0:.*]] = load ptr addrspace(1), ptr %[[OP0]]
 
-; EXC: %[[PHI:.*]] = phi ptr addrspace(1)
-; EXC-SAME: %[[LOAD_OP0]]
-; EXC-NEXT: call void @jllvm_throw(ptr addrspace(1) %[[PHI]])
+; EXC: call void @jllvm_throw(ptr addrspace(1) %[[LOAD_OP0]])
     aload_1
     athrow
 L31:


### PR DESCRIPTION
This PR removes `generateHandlerChain` and `m_alreadyGeneratedHandlers` from `CodeGenerator`, which have become unnecessary due to exception handling being done via deopts.

Fixes: #243