### PR TITLE
[interpreter] add basic integer stack and variable instructions

### DIFF
--- a/src/jllvm/vm/Interpreter.cpp
+++ b/src/jllvm/vm/Interpreter.cpp
@@ -54,6 +54,7 @@ std::uint64_t jllvm::Interpreter::executeMethod(const Method& method, std::uint1
 {
     const ClassFile& classFile = *method.getClassObject()->getClassFile();
     Code* code = method.getMethodInfo().getAttributes().find<Code>();
+    assert(code && "method being interpreted must have code");
     llvm::ArrayRef<char> codeArray = code->getCode();
     auto curr = ByteCodeIterator(codeArray.data(), offset);
 

--- a/src/jllvm/vm/Interpreter.hpp
+++ b/src/jllvm/vm/Interpreter.hpp
@@ -22,6 +22,21 @@ namespace jllvm
 
 class VirtualMachine;
 
+/// Possible primitive types of values in the interpreter. Note that this includes both signed and unsigned variants
+/// of integer types as the most suitable variant is dependent on the operation. E.g. if wraparound semantics are
+/// desirable, doing calculations with unsigned type should be done to avoid undefined behaviour in C++.
+/// Signed integer types can be assumed to be two's complement.
+template <class T>
+concept InterpreterPrimitive =
+    std::same_as<T, std::int32_t> || std::same_as<T, std::int64_t> || std::same_as<T, std::uint32_t>
+    || std::same_as<T, std::uint64_t> || std::same_as<T, float> || std::same_as<T, double>;
+
+/// Possible types of values in the interpreter. These are all the primitive types with the addition of pointers to
+/// Java objects (references).
+template <class T>
+concept InterpreterValue =
+    InterpreterPrimitive<T> || (std::is_pointer_v<T> && std::derived_from<std::remove_pointer<T>, ObjectInterface>);
+
 /// Context used in the execution of one Java frame. It incorporates and contains convenience methods for interacting
 /// with local variables and the operand stack.
 class InterpreterContext
@@ -32,8 +47,28 @@ class InterpreterContext
     std::uint64_t* m_localVariables;
     std::uint64_t* m_localVariableGCMask;
 
-public:
+    /// Returns true if 'T' is a reference to the Java heap.
+    template <InterpreterValue T>
+    constexpr static bool isReference()
+    {
+        return !InterpreterPrimitive<T>;
+    }
 
+    /// Sets the corresponding bit in 'mask' at index to 'value'.
+    static void setMaskBit(std::uint64_t* mask, std::size_t index, bool value)
+    {
+        constexpr auto bitWidth = std::numeric_limits<std::decay_t<decltype(*mask)>>::digits;
+        if (value)
+        {
+            mask[index / bitWidth] |= 1ull << (index % bitWidth);
+        }
+        else
+        {
+            mask[index / bitWidth] &= ~(1ull << (index % bitWidth));
+        }
+    }
+
+public:
     /// Creates a new 'InterpreterContext' from the given parameters. 'topOfStack' is a reference that is always kept
     /// up to date as the current top of stack. The two 'gc' mask parameters are used as bitsets and have their "i"th
     /// bit always set to true if the corresponding operand stack slot or local variable contains a Java reference.
@@ -49,7 +84,42 @@ public:
     {
     }
 
-    // TODO: Implement methods for operand stack and global variables.
+    /// Pushes a value of type 'T' to the operand stack.
+    template <InterpreterValue T>
+    void push(T value)
+    {
+        std::memcpy(m_operandStack + m_topOfStack, &value, sizeof(T));
+        setMaskBit(m_operandGCMask, m_topOfStack, isReference<T>());
+        m_topOfStack++;
+    }
+
+    /// Pops the top value of type 'T' from the operand stack.
+    template <InterpreterValue T>
+    T pop()
+    {
+        assert(m_topOfStack != 0 && "bottom of stack already reached");
+        T result;
+        m_topOfStack--;
+        std::memcpy(&result, m_operandStack + m_topOfStack, sizeof(T));
+        return result;
+    }
+
+    /// Sets the local 'index' to the given 'value'.
+    template <InterpreterValue T>
+    void setLocal(std::uint16_t index, T value)
+    {
+        std::memcpy(m_localVariables + index, &value, sizeof(T));
+        setMaskBit(m_localVariableGCMask, index, isReference<T>());
+    }
+
+    /// Gets the value of the local 'index' and interprets it as 'T'.
+    template <InterpreterValue T>
+    T getLocal(std::uint16_t index) const
+    {
+        T result;
+        std::memcpy(&result, m_localVariables + index, sizeof(T));
+        return result;
+    }
 };
 
 /// Interpreter instance containing all global state of the interpreter.
@@ -59,8 +129,11 @@ class Interpreter
     /// Enable OSR from the interpreter into the JIT if the method is hot enough.
     bool m_enableOSR;
 
-public:
+    /// Replaces the current interpreter frame with a compiled frame. This should only be called from within
+    /// 'executeMethod' when called from the 'jllvm_interpreter' implementation in 'VirtualMachine'.
+    [[noreturn]] void escapeToJIT();
 
+public:
     explicit Interpreter(VirtualMachine& virtualMachine, bool enableOSR)
         : m_virtualMachine(virtualMachine), m_enableOSR(enableOSR)
     {

--- a/tests/Execution/iadd.java
+++ b/tests/Execution/iadd.java
@@ -11,11 +11,17 @@ class Test
         int x = 3;
         int y = 2;
         int z = 1;
+
+        // TODO: workaround until the interpreter supports 'invokestatic' to perform addition in the interpreter.
+        int r1 = x + y;
+        int r2 = x + 1;
+        int r3 = 2147483647 + z;
+
         // CHECK: 5
-        print(x+y);
+        print(r1);
         // CHECK: 4
-        print(x+1);
+        print(r2);
         // CHECK: -2147483648
-        print(Integer.MAX_VALUE+z);
+        print(r3);
     }
 }


### PR DESCRIPTION
This PR implements the basic integer operations for manipulating the operand stack and local variables and `iadd`. This makes it possible to first execute some integer instructions such as the `iadd` test case mostly from within the interpreter.

Most importantly, the patch required adding methods to `InterpreterContext` for manipulating the operand stack and local variables.