### PR TITLE
[vm] Introduce `OSRState` class

### DIFF
--- a/src/jllvm/compiler/ByteCodeCompileUtils.cpp
+++ b/src/jllvm/compiler/ByteCodeCompileUtils.cpp
@@ -262,7 +262,7 @@ void jllvm::applyABIAttributes(llvm::CallBase* call, MethodType methodType, bool
 
 llvm::FunctionType* jllvm::osrMethodSignature(MethodType methodType, llvm::LLVMContext& context)
 {
-    auto* pointerType = llvm::PointerType::get(context, 0);
-    return llvm::FunctionType::get(descriptorToType(methodType.returnType(), context), {pointerType, pointerType},
+    return llvm::FunctionType::get(descriptorToType(methodType.returnType(), context),
+                                   {llvm::PointerType::get(context, 0)},
                                    /*isVarArg=*/false);
 }

--- a/src/jllvm/vm/CMakeLists.txt
+++ b/src/jllvm/vm/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(JLLVMVirtualMachine VirtualMachine.cpp JIT.cpp StackMapRegistrationP
         JNIImplementation.cpp NativeImplementation.cpp JavaFrame.cpp native/IO.cpp
         native/Lang.cpp native/JDK.cpp native/Security.cpp
         Interpreter.cpp
+        OSRState.cpp
 )
 target_link_libraries(JLLVMVirtualMachine
         PRIVATE JLLVMLLVMPasses ${llvm_native_libs} LLVMTargetParser LLVMOrcTargetProcess LLVMScalarOpts LLVMAnalysis

--- a/src/jllvm/vm/Interpreter.cpp
+++ b/src/jllvm/vm/Interpreter.cpp
@@ -55,7 +55,8 @@ jllvm::ClassObject* jllvm::Interpreter::getClassObject(const ClassFile& classFil
 void jllvm::Interpreter::escapeToJIT()
 {
     m_virtualMachine.unwindJavaStack(
-        [&](JavaFrame frame) { m_virtualMachine.getJIT().doI2JOnStackReplacement(frame, *frame.getByteCodeOffset()); });
+        [&](JavaFrame frame)
+        { m_virtualMachine.getJIT().doI2JOnStackReplacement(llvm::cast<InterpreterFrame>(frame)); });
     llvm_unreachable("not possible");
 }
 

--- a/src/jllvm/vm/JIT.hpp
+++ b/src/jllvm/vm/JIT.hpp
@@ -40,6 +40,7 @@
 #include <memory>
 
 #include "JavaFrame.hpp"
+#include "OSRState.hpp"
 
 namespace jllvm
 {
@@ -184,15 +185,17 @@ public:
     }
 
     /// Performs On-Stack-Replacement of 'frame' and all its callees, replacing it with the execution of the same
-    /// method at the JVM bytecode corresponding to 'byteCodeOffset'. This method is meant to be used for executing
-    /// exception handlers and therefore puts only 'exception' on the operand stack.
-    /// 'frame' must be the execution of a Java method.
-    [[noreturn]] void doExceptionOnStackReplacement(JavaFrame frame, std::uint16_t byteCodeOffset,
-                                                    Throwable* exception);
+    /// method. The abstract machine state of the new execution is initialized with 'state'.
+    [[noreturn]] void doOnStackReplacement(JavaFrame frame, OSRState&& state);
 
     /// Performs On-Stack-Replacement of 'frame' and all its callees, replacing it with the execution of the same
-    /// method at the JVM bytecode corresponding to 'byteCodeOffset'.
-    [[noreturn]] void doI2JOnStackReplacement(JavaFrame frame, std::uint16_t byteCodeOffset);
+    /// method. This method is meant to be used for executing exception handlers and therefore puts only 'exception'
+    /// on the operand stack. 'frame' must be the execution of a Java method.
+    [[noreturn]] void doExceptionOnStackReplacement(JavaFrame frame, std::uint16_t handlerOffset, Throwable* exception);
+
+    /// Performs On-Stack-Replacement of 'frame' and all its callees, replacing it with the execution of the same
+    /// method.
+    [[noreturn]] void doI2JOnStackReplacement(InterpreterFrame frame);
 
     /// Looks up the method 'methodName' within the class 'className' with the type given by 'methodDescriptor'
     /// returning a pointer to the function if successful or an error otherwise.

--- a/src/jllvm/vm/JavaFrame.cpp
+++ b/src/jllvm/vm/JavaFrame.cpp
@@ -44,17 +44,6 @@ llvm::SmallVector<std::uint64_t> jllvm::JavaFrame::readLocals() const
     llvm_unreachable("invalid kind");
 }
 
-llvm::ArrayRef<std::uint64_t> jllvm::JavaFrame::readOperandStack() const
-{
-    switch (m_javaMethodMetadata->getKind())
-    {
-        case JavaMethodMetadata::Kind::JIT:
-        case JavaMethodMetadata::Kind::Native: return {};
-        case JavaMethodMetadata::Kind::Interpreter: return llvm::cast<InterpreterFrame>(*this).getOperandStack();
-    }
-    llvm_unreachable("invalid kind");
-}
-
 llvm::MutableArrayRef<std::uint64_t> jllvm::InterpreterFrame::getLocals() const
 {
     std::uint16_t numLocals =

--- a/src/jllvm/vm/JavaFrame.hpp
+++ b/src/jllvm/vm/JavaFrame.hpp
@@ -89,14 +89,6 @@ public:
     /// * If the method being executed is native and therefore does not have local variables
     /// * If no exception handler exists for a bytecode offset within a JITted method.
     llvm::SmallVector<std::uint64_t> readLocals() const;
-
-    /// Reads out the values of the operand stack at the current bytecode offset.
-    /// This method will always return an empty array in following scenarios:
-    /// * If the method being executed is not being executed by the interpreter.
-    ///
-    /// Note that 'double' and 'long' occupy two slots in the operand stack array where the first contains the value
-    /// and the second an unspecified value.
-    llvm::ArrayRef<std::uint64_t> readOperandStack() const;
 };
 
 /// Specialization of 'JavaFrame' for interpreter frames. This contains all methods specific to interpreter frames.

--- a/src/jllvm/vm/OSRState.cpp
+++ b/src/jllvm/vm/OSRState.cpp
@@ -1,0 +1,39 @@
+// Copyright (C) 2023 The JLLVM Contributors.
+//
+// This file is part of JLLVM.
+//
+// JLLVM is free software; you can redistribute it and/or modify it under  the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 3, or (at your option) any later version.
+//
+// JLLVM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with JLLVM; see the file LICENSE.txt.  If not
+// see <http://www.gnu.org/licenses/>.
+
+#include "OSRState.hpp"
+
+jllvm::OSRState jllvm::OSRState::fromInterpreter(InterpreterFrame sourceFrame, OSRTarget target)
+{
+    switch (target)
+    {
+        case OSRTarget::Interpreter: llvm::report_fatal_error("not yet implemented");
+        case OSRTarget::JIT:
+            return OSRState(*sourceFrame.getByteCodeOffset(), sourceFrame.readLocals(), sourceFrame.getOperandStack());
+    }
+}
+
+jllvm::OSRState jllvm::OSRState::fromException(JavaFrame sourceFrame, std::uint16_t handlerOffset, Throwable* exception,
+                                               OSRTarget target)
+{
+    assert(!sourceFrame.isNative() && "cannot OSR out of native frame");
+
+    switch (target)
+    {
+        case OSRTarget::Interpreter: llvm::report_fatal_error("not yet implemented");
+        case OSRTarget::JIT:
+            return OSRState(
+                handlerOffset, sourceFrame.readLocals(),
+                /*operandStack=*/std::initializer_list<std::uint64_t>{reinterpret_cast<std::uint64_t>(exception)});
+    }
+}

--- a/src/jllvm/vm/OSRState.hpp
+++ b/src/jllvm/vm/OSRState.hpp
@@ -1,0 +1,101 @@
+// Copyright (C) 2023 The JLLVM Contributors.
+//
+// This file is part of JLLVM.
+//
+// JLLVM is free software; you can redistribute it and/or modify it under  the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 3, or (at your option) any later version.
+//
+// JLLVM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with JLLVM; see the file LICENSE.txt.  If not
+// see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <llvm/ADT/STLExtras.h>
+#include <llvm/Support/MathExtras.h>
+
+#include <cassert>
+#include <cstdint>
+#include <limits>
+#include <memory>
+
+#include "JavaFrame.hpp"
+
+namespace jllvm
+{
+
+/// Target tier that should replace the existing Java frame.
+enum class OSRTarget
+{
+    Interpreter,
+    JIT,
+};
+
+/// Class representing the abstract machine state required for transitioning execution from one tier to another.
+/// It is used to internally build up a buffer in the OSR calling convention to initialize the abstract machine state.
+class OSRState
+{
+    std::unique_ptr<std::uint64_t[]> m_buffer;
+    OSRTarget m_target{};
+    std::uint16_t m_byteCodeOffset{};
+
+    static std::size_t getNumGCMask(std::uint16_t size)
+    {
+        return llvm::divideCeil(size, 64);
+    }
+
+    static std::size_t calculateJITBufferSize(std::uint16_t numLocalVariables, std::uint16_t numOperandStack)
+    {
+        return numLocalVariables + numOperandStack;
+    }
+
+    OSRState(std::uint16_t byteCodeOffset, auto&& locals, auto&& operandStack)
+        : m_target(OSRTarget::JIT), m_byteCodeOffset(byteCodeOffset)
+    {
+        std::size_t numLocals = llvm::size(locals);
+        std::size_t numOperandStack = llvm::size(operandStack);
+
+        m_buffer = std::make_unique<std::uint64_t[]>(calculateJITBufferSize(numLocals, numOperandStack));
+
+        auto outIter = llvm::copy(std::forward<decltype(locals)>(locals), m_buffer.get());
+        outIter = llvm::copy(std::forward<decltype(operandStack)>(operandStack), outIter);
+    }
+
+public:
+    /// Creates an OSRState from an interpreter frame.
+    static OSRState fromInterpreter(InterpreterFrame sourceFrame, OSRTarget target);
+
+    /// Creates an OSRState for exception handling from a source frame and an exception.
+    static OSRState fromException(JavaFrame sourceFrame, std::uint16_t handlerOffset, Throwable* exception,
+                                  OSRTarget target);
+
+    /// Releases the internal buffer filled with the OSR state and returns it.
+    ///
+    /// The pointed to array depends on the target being OSRed into.
+    ///
+    /// If the target is a JIT frame, the memory has the following layout:
+    ///  std::uint64_t localVariables[numLocalVariables]
+    ///  std::uint64_t operandStack[numOperandStack]
+    ///
+    /// This array is used by OSR versions to initialize their machine state.
+    std::uint64_t* release()
+    {
+        assert(m_buffer && "must not have been released previously");
+        return m_buffer.release();
+    }
+
+    /// Returns the bytecode offset with which this instance was initialized.
+    std::uint16_t getByteCodeOffset() const
+    {
+        return m_byteCodeOffset;
+    }
+
+    /// Returns the OSR target of this state.
+    OSRTarget getTarget() const
+    {
+        return m_target;
+    }
+};
+} // namespace jllvm

--- a/tests/Compiler/osr-frames.j
+++ b/tests/Compiler/osr-frames.j
@@ -24,8 +24,7 @@
 ; ENTRY-SAME: $0"
 ; LOOP-SAME: $16"
 ; EXC-SAME: $29"
-; CHECK-SAME: ptr %[[OPERANDS:[[:alnum:]]+]]
-; CHECK-SAME: ptr %[[LOCALS:[[:alnum:]]+]]
+; CHECK-SAME: ptr %[[OSR_STATE:[[:alnum:]]+]]
 .method public static test(I)I
 ; CHECK: %[[OP0:.*]] = alloca ptr
 ; CHECK: %[[LOCAL0:.*]] = alloca ptr
@@ -37,16 +36,16 @@
 ; Entry has just one local.
 ; Exc has two locals and no operands on the stack.
 
-; LOOP: %[[GEP:.*]] = getelementptr ptr, ptr %[[OPERANDS]], i32 0
-; LOOP: %[[LOAD:.*]] = load i32, ptr %[[GEP]]
-; LOOP: store i32 %[[LOAD]], ptr %[[OP0]]
-; CHECK: %[[GEP:.*]] = getelementptr ptr, ptr %[[LOCALS]], i32 0
+; CHECK: %[[GEP:.*]] = getelementptr i64, ptr %[[OSR_STATE]], i32 0
 ; CHECK: %[[LOAD:.*]] = load i32, ptr %[[GEP]]
 ; CHECK: store i32 %[[LOAD]], ptr %[[LOCAL0]]
-; EXC: %[[GEP:.*]] = getelementptr ptr, ptr %[[LOCALS]], i32 1
+; EXC: %[[GEP:.*]] = getelementptr i64, ptr %[[OSR_STATE]], i32 1
 ; EXC: %[[LOAD:.*]] = load ptr addrspace(1), ptr %[[GEP]]
 ; EXC: store ptr addrspace(1) %[[LOAD]], ptr %[[LOCAL1]]
-; CHECK: call void @jllvm_osr_frame_delete(ptr %[[OPERANDS]])
+; LOOP: %[[GEP:.*]] = getelementptr i64, ptr %[[OSR_STATE]], i32 2
+; LOOP: %[[LOAD:.*]] = load i32, ptr %[[GEP]]
+; LOOP: store i32 %[[LOAD]], ptr %[[OP0]]
+; CHECK: call void @jllvm_osr_frame_delete(ptr %[[OSR_STATE]])
 
 ; Entry continues to start of bytecode as usual.
 ; ENTRY: br label %[[ENTRY:[[:alnum:]]+]]


### PR DESCRIPTION
This class is meant to be an abstraction representing the abstract machine state of a given target, adding nicer named "constructors" and generic getter functions. Most importantly it internally builds up the internal datastructure used in the calling convention to pass the given state.
