### PR TITLE
[materialization] Implement OSR to interpreter frames

### DIFF
--- a/src/jllvm/compiler/ByteCodeCompileUtils.hpp
+++ b/src/jllvm/compiler/ByteCodeCompileUtils.hpp
@@ -93,6 +93,7 @@ public:
         {
             std::uint16_t byteCodeOffset{};
             std::vector<FrameValue<std::uint64_t>> locals;
+            std::vector<std::uint64_t> localsGCMask;
         };
 
         /// Pointer to a dynamically allocated instance. This is not just a 'llvm::DenseMap' as that is 1) not a

--- a/src/jllvm/materialization/CMakeLists.txt
+++ b/src/jllvm/materialization/CMakeLists.txt
@@ -19,5 +19,7 @@ add_library(JLLVMMaterialization
         ClassObjectStubDefinitionsGenerator.cpp
         JIT2InterpreterLayer.cpp
         ByteCodeOSRLayer.cpp
-        ByteCodeOSRCompileLayer.cpp)
+        ByteCodeOSRCompileLayer.cpp
+        InterpreterOSRLayer.cpp
+        InterpreterEntry.cpp)
 target_link_libraries(JLLVMMaterialization PUBLIC JLLVMCompiler JLLVMObject LLVMCore LLVMOrcJIT PRIVATE LLVMTargetParser)

--- a/src/jllvm/materialization/InterpreterEntry.cpp
+++ b/src/jllvm/materialization/InterpreterEntry.cpp
@@ -1,0 +1,73 @@
+// Copyright (C) 2023 The JLLVM Contributors.
+//
+// This file is part of JLLVM.
+//
+// JLLVM is free software; you can redistribute it and/or modify it under  the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 3, or (at your option) any later version.
+//
+// JLLVM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with JLLVM; see the file LICENSE.txt.  If not
+// see <http://www.gnu.org/licenses/>.
+
+#include "InterpreterEntry.hpp"
+
+#include <jllvm/compiler/ByteCodeCompileUtils.hpp>
+
+llvm::Value* jllvm::generateInterpreterEntry(
+    llvm::IRBuilder<>& builder, const Method& method,
+    llvm::function_ref<void(llvm::IRBuilder<>&, llvm::AllocaInst*, llvm::AllocaInst*, llvm::AllocaInst*,
+                            llvm::AllocaInst*, llvm::AllocaInst*, llvm::AllocaInst*, const Code& code)>
+        generatePrologue)
+{
+    llvm::Module& module = *builder.GetInsertBlock()->getParent()->getParent();
+    Code* code = method.getMethodInfo().getAttributes().find<Code>();
+    assert(code && "cannot run method without code");
+
+    // Allocate all the variables for the interpretation context.
+    llvm::AllocaInst* byteCodeOffset = builder.CreateAlloca(builder.getInt16Ty());
+    llvm::AllocaInst* topOfStack = builder.CreateAlloca(builder.getInt16Ty());
+    llvm::AllocaInst* operandStack =
+        builder.CreateAlloca(llvm::ArrayType::get(builder.getInt64Ty(), code->getMaxStack()));
+    llvm::AllocaInst* operandGCMask =
+        builder.CreateAlloca(llvm::ArrayType::get(builder.getInt64Ty(), llvm::divideCeil(code->getMaxStack(), 64)));
+    llvm::AllocaInst* localVariables =
+        builder.CreateAlloca(llvm::ArrayType::get(builder.getInt64Ty(), code->getMaxLocals()));
+    llvm::AllocaInst* localVariablesGCMask =
+        builder.CreateAlloca(llvm::ArrayType::get(builder.getInt64Ty(), llvm::divideCeil(code->getMaxLocals(), 64)));
+    llvm::Value* methodRef = methodGlobal(module, &method);
+
+    generatePrologue(builder, byteCodeOffset, topOfStack, operandStack, operandGCMask, localVariables,
+                     localVariablesGCMask, *code);
+
+    std::array<llvm::Value*, 7> arguments = {methodRef,     byteCodeOffset, topOfStack,          operandStack,
+                                             operandGCMask, localVariables, localVariablesGCMask};
+    std::array<llvm::Type*, 7> types{};
+    llvm::transform(arguments, types.begin(), std::mem_fn(&llvm::Value::getType));
+
+    // Deopt all allocas used as context during interpretation. This makes it possible for the unwinder to read the
+    // local variables, the operand stack, the bytecode offset and where GC pointers are contained during unwinding.
+    llvm::CallInst* callInst = builder.CreateCall(
+        module.getOrInsertFunction("jllvm_interpreter",
+                                   llvm::FunctionType::get(builder.getInt64Ty(), types, /*isVarArg=*/false)),
+        arguments, llvm::OperandBundleDef("deopt", llvm::ArrayRef(arguments).drop_front()));
+
+    llvm::Type* returnType = descriptorToType(method.getType().returnType(), builder.getContext());
+    if (returnType->isVoidTy())
+    {
+        return nullptr;
+    }
+
+    // Translate the uint64_t returned by the interpreter to the corresponding type in the C calling convention.
+    llvm::TypeSize typeSize = module.getDataLayout().getTypeSizeInBits(returnType);
+    assert(!typeSize.isScalable() && "return type is never a scalable type");
+
+    llvm::Value* value = callInst;
+    llvm::IntegerType* intNTy = builder.getIntNTy(typeSize.getFixedValue());
+    if (intNTy != value->getType())
+    {
+        value = builder.CreateTrunc(value, intNTy);
+    }
+    return builder.CreateBitOrPointerCast(value, returnType);
+}

--- a/src/jllvm/materialization/InterpreterEntry.hpp
+++ b/src/jllvm/materialization/InterpreterEntry.hpp
@@ -1,0 +1,34 @@
+// Copyright (C) 2023 The JLLVM Contributors.
+//
+// This file is part of JLLVM.
+//
+// JLLVM is free software; you can redistribute it and/or modify it under  the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 3, or (at your option) any later version.
+//
+// JLLVM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with JLLVM; see the file LICENSE.txt.  If not
+// see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <llvm/IR/Function.h>
+#include <llvm/IR/IRBuilder.h>
+
+#include <jllvm/object/ClassObject.hpp>
+
+namespace jllvm
+{
+
+/// Generates LLVM IR using 'builder' creating the required state and instructions followed by the function call to
+/// execute 'method' in the interpreter. 'generatePrologue' is used to initialize the abstract machine state which are
+/// initially uninitialized. Returns the result of the interpreter as the corresponding LLVM type of the return type of
+/// 'method'.
+llvm::Value* generateInterpreterEntry(
+    llvm::IRBuilder<>& builder, const Method& method,
+    llvm::function_ref<void(llvm::IRBuilder<>& builder, llvm::AllocaInst* byteCodeOffset, llvm::AllocaInst* topOfStack,
+                            llvm::AllocaInst* operandStack, llvm::AllocaInst* operandGCMask,
+                            llvm::AllocaInst* localVariables, llvm::AllocaInst* localVariablesGCMask, const Code& code)>
+        generatePrologue);
+} // namespace jllvm

--- a/src/jllvm/materialization/InterpreterOSRLayer.cpp
+++ b/src/jllvm/materialization/InterpreterOSRLayer.cpp
@@ -1,0 +1,121 @@
+// Copyright (C) 2023 The JLLVM Contributors.
+//
+// This file is part of JLLVM.
+//
+// JLLVM is free software; you can redistribute it and/or modify it under  the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 3, or (at your option) any later version.
+//
+// JLLVM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with JLLVM; see the file LICENSE.txt.  If not
+// see <http://www.gnu.org/licenses/>.
+
+#include "InterpreterOSRLayer.hpp"
+
+#include <llvm/IR/DIBuilder.h>
+#include <llvm/IR/IRBuilder.h>
+
+#include <jllvm/compiler/ByteCodeCompileUtils.hpp>
+#include <jllvm/compiler/ClassObjectStubMangling.hpp>
+
+#include "InterpreterEntry.hpp"
+
+void jllvm::InterpreterOSRLayer::emit(std::unique_ptr<llvm::orc::MaterializationResponsibility> mr,
+                                      const Method* method, std::uint16_t offset)
+{
+    auto context = std::make_unique<llvm::LLVMContext>();
+    auto module = std::make_unique<llvm::Module>("module", *context);
+    module->setDataLayout(m_dataLayout);
+    module->setTargetTriple(LLVM_HOST_TRIPLE);
+
+    llvm::DIBuilder debugBuilder(*module);
+    llvm::DIFile* file = debugBuilder.createFile(".", ".");
+
+    debugBuilder.createCompileUnit(llvm::dwarf::DW_LANG_Java, file, "JLLVM", true, "", 0);
+
+    auto* function =
+        llvm::Function::Create(osrMethodSignature(method->getType(), *context), llvm::GlobalValue::ExternalLinkage,
+                               mangleOSRMethod(method, offset), module.get());
+
+    llvm::DISubprogram* subprogram =
+        debugBuilder.createFunction(file, function->getName(), function->getName(), file, 1,
+                                    debugBuilder.createSubroutineType(debugBuilder.getOrCreateTypeArray({})), 1,
+                                    llvm::DINode::FlagZero, llvm::DISubprogram::SPFlagDefinition);
+    function->setSubprogram(subprogram);
+
+    applyABIAttributes(function);
+    function->clearGC();
+    addJavaMethodMetadata(function, method, JavaMethodMetadata::Kind::Interpreter);
+
+    llvm::IRBuilder<> builder(llvm::BasicBlock::Create(*context, "entry", function));
+
+    builder.SetCurrentDebugLocation(llvm::DILocation::get(builder.getContext(), 1, 1, subprogram));
+
+    llvm::Value* returnValue = generateInterpreterEntry(
+        builder, *method,
+        [&](llvm::IRBuilder<>& builder, llvm::AllocaInst* byteCodeOffset, llvm::AllocaInst* topOfStack,
+            llvm::AllocaInst* operandStack, llvm::AllocaInst* operandGCMask, llvm::AllocaInst* localVariables,
+            llvm::AllocaInst* localVariablesGCMask, const Code& code)
+        {
+            llvm::Value* osrState = function->getArg(0);
+
+            // Initialize the abstract machine state from the OSR State. The precise layout of 'osrState' is documented
+            // in 'OSRState::release'. The code below simply traverses through the array, always adding offsets to the
+            // current pointer value and copying the values over to the interpreter frame.
+
+            builder.CreateStore(builder.CreateLoad(builder.getInt16Ty(), osrState), byteCodeOffset);
+            llvm::Value* operandStackSize = builder.CreateLShr(builder.CreateLoad(builder.getInt32Ty(), osrState), 16);
+            builder.CreateStore(builder.CreateTrunc(operandStackSize, builder.getInt16Ty()), topOfStack);
+
+            llvm::Value* localVariablesSrc = builder.CreateConstGEP1_32(builder.getInt64Ty(), osrState, 1);
+            builder.CreateMemCpy(localVariables, /*DstAlign=*/std::nullopt, localVariablesSrc,
+                                 /*SrcAlign=*/std::nullopt, code.getMaxLocals() * sizeof(std::uint64_t));
+
+            llvm::Value* operandStackSrc =
+                builder.CreateConstGEP1_32(builder.getInt64Ty(), localVariablesSrc, code.getMaxLocals());
+            builder.CreateMemCpy(operandStack, /*DstAlign=*/std::nullopt, operandStackSrc, /*SrcAlign=*/std::nullopt,
+                                 builder.CreateMul(operandStackSize, builder.getInt32(sizeof(std::uint64_t))));
+
+            llvm::Value* localVariablesGCMaskSrc =
+                builder.CreateGEP(builder.getInt64Ty(), operandStackSrc, operandStackSize);
+            std::uint64_t localVariablesGCMaskSize = llvm::divideCeil(code.getMaxLocals(), 64);
+            builder.CreateMemCpy(localVariablesGCMask, /*DstAlign=*/std::nullopt, localVariablesGCMaskSrc,
+                                 /*SrcAlign=*/std::nullopt, localVariablesGCMaskSize * sizeof(std::uint64_t));
+
+            // Calculate the operand stack GC mask size from the operand stack size. This is a 'ceil(size / 64)'
+            // operation implemented in IR as "size / 64 + ((size % 64) != 0)".
+            llvm::Value* operandGCMaskSize = operandStackSize;
+            operandGCMaskSize = builder.CreateUDiv(operandGCMaskSize, builder.getInt32(64));
+            llvm::Value* remainder = builder.CreateURem(operandStackSize, builder.getInt32(64));
+            operandGCMaskSize = builder.CreateAdd(
+                operandGCMaskSize,
+                builder.CreateZExt(builder.CreateICmpNE(remainder, builder.getInt32(0)), builder.getInt32Ty()));
+            operandGCMaskSize = builder.CreateMul(operandGCMaskSize, builder.getInt32(sizeof(std::uint64_t)));
+
+            llvm::Value* operandGCMaskSrc =
+                builder.CreateConstGEP1_32(builder.getInt64Ty(), localVariablesGCMaskSrc, localVariablesGCMaskSize);
+            builder.CreateMemCpy(operandGCMask, /*DstAlign=*/std::nullopt, operandGCMaskSrc, /*SrcAlign=*/std::nullopt,
+                                 operandGCMaskSize);
+
+            // The OSR frame is responsible for deleting its input arrays as the frame that originally allocated the
+            // pointer is replaced.
+            llvm::FunctionCallee callee = function->getParent()->getOrInsertFunction(
+                "jllvm_osr_frame_delete", builder.getVoidTy(), builder.getPtrTy());
+            llvm::cast<llvm::Function>(callee.getCallee())->addFnAttr("gc-leaf-function");
+            builder.CreateCall(callee, osrState);
+        });
+    if (returnValue)
+    {
+        builder.CreateRet(returnValue);
+    }
+    else
+    {
+        builder.CreateRetVoid();
+    }
+
+    debugBuilder.finalizeSubprogram(subprogram);
+    debugBuilder.finalize();
+
+    m_baseLayer.emit(std::move(mr), llvm::orc::ThreadSafeModule(std::move(module), std::move(context)));
+}

--- a/src/jllvm/materialization/InterpreterOSRLayer.hpp
+++ b/src/jllvm/materialization/InterpreterOSRLayer.hpp
@@ -1,0 +1,38 @@
+// Copyright (C) 2023 The JLLVM Contributors.
+//
+// This file is part of JLLVM.
+//
+// JLLVM is free software; you can redistribute it and/or modify it under  the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 3, or (at your option) any later version.
+//
+// JLLVM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with JLLVM; see the file LICENSE.txt.  If not
+// see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <llvm/ExecutionEngine/Orc/Layer.h>
+
+#include "ByteCodeOSRLayer.hpp"
+
+namespace jllvm
+{
+
+class InterpreterOSRLayer : public ByteCodeOSRLayer
+{
+    llvm::orc::IRLayer& m_baseLayer;
+    llvm::DataLayout m_dataLayout;
+
+public:
+    InterpreterOSRLayer(llvm::orc::MangleAndInterner& mangler, llvm::orc::IRLayer& baseLayer,
+                        const llvm::DataLayout& dataLayout)
+        : ByteCodeOSRLayer(mangler), m_baseLayer(baseLayer), m_dataLayout(dataLayout)
+    {
+    }
+
+    void emit(std::unique_ptr<llvm::orc::MaterializationResponsibility> mr, const Method* method,
+              std::uint16_t offset) override;
+};
+} // namespace jllvm

--- a/src/jllvm/support/BitArrayRef.hpp
+++ b/src/jllvm/support/BitArrayRef.hpp
@@ -77,6 +77,18 @@ public:
         assert(index < m_size);
         return *std::next(begin(), index);
     }
+
+    /// Returns an iterator to the first word the instance references.
+    auto words_begin() const
+    {
+        return m_bits;
+    }
+
+    /// Returns an iterator past the last word the instance references.
+    auto words_end() const
+    {
+        return m_bits + llvm::divideCeil(m_size, numBits);
+    }
 };
 
 /// Mutable view of a buffer of 'IntegerType', interpreting it as a bitset of a given size.

--- a/src/jllvm/vm/JIT.hpp
+++ b/src/jllvm/vm/JIT.hpp
@@ -30,6 +30,7 @@
 #include <jllvm/gc/GarbageCollector.hpp>
 #include <jllvm/materialization/ByteCodeCompileLayer.hpp>
 #include <jllvm/materialization/ByteCodeOSRCompileLayer.hpp>
+#include <jllvm/materialization/InterpreterOSRLayer.hpp>
 #include <jllvm/materialization/JIT2InterpreterLayer.hpp>
 #include <jllvm/materialization/JNIImplementationLayer.hpp>
 #include <jllvm/materialization/LambdaMaterialization.hpp>
@@ -91,6 +92,7 @@ class JIT
     ByteCodeOSRCompileLayer m_byteCodeOSRCompileLayer;
     JNIImplementationLayer m_jniLayer;
     JIT2InterpreterLayer m_compiled2InterpreterLayer;
+    InterpreterOSRLayer m_interpreterOSRLayer;
 
     llvm::DenseSet<std::uintptr_t> m_javaFrames;
 

--- a/src/jllvm/vm/JavaFrame.hpp
+++ b/src/jllvm/vm/JavaFrame.hpp
@@ -89,6 +89,11 @@ public:
     /// * If the method being executed is native and therefore does not have local variables
     /// * If no exception handler exists for a bytecode offset within a JITted method.
     llvm::SmallVector<std::uint64_t> readLocals() const;
+
+    /// Reads the GC mask for the local variables at the current bytecode offset.
+    /// This is a bitset where the 'i'th bit being set corresponding to the 'i'th local variable being a reference type.
+    /// This method will return an empty array in the same scenarios as 'readLocals'.
+    llvm::SmallVector<std::uint64_t> readLocalsGCMask() const;
 };
 
 /// Specialization of 'JavaFrame' for interpreter frames. This contains all methods specific to interpreter frames.
@@ -112,6 +117,9 @@ public:
     BitArrayRef<> getLocalsGCMask() const;
 
     /// Returns a mutable view of the operand stack of the interpreter.
+    ///
+    /// Note that 'double' and 'long' occupy two slots in the operand stack array where the first contains the value
+    /// and the second an unspecified value.
     llvm::MutableArrayRef<std::uint64_t> getOperandStack() const;
 
     /// Returns the bitset denoting where Java references are contained within the interpreter operand stack.

--- a/src/jllvm/vm/OSRState.cpp
+++ b/src/jllvm/vm/OSRState.cpp
@@ -17,7 +17,9 @@ jllvm::OSRState jllvm::OSRState::fromInterpreter(InterpreterFrame sourceFrame, O
 {
     switch (target)
     {
-        case OSRTarget::Interpreter: llvm::report_fatal_error("not yet implemented");
+        case OSRTarget::Interpreter:
+            return OSRState(*sourceFrame.getByteCodeOffset(), sourceFrame.readLocals(), sourceFrame.getOperandStack(),
+                            sourceFrame.readLocalsGCMask(), sourceFrame.getOperandStackGCMask());
         case OSRTarget::JIT:
             return OSRState(*sourceFrame.getByteCodeOffset(), sourceFrame.readLocals(), sourceFrame.getOperandStack());
     }
@@ -30,7 +32,11 @@ jllvm::OSRState jllvm::OSRState::fromException(JavaFrame sourceFrame, std::uint1
 
     switch (target)
     {
-        case OSRTarget::Interpreter: llvm::report_fatal_error("not yet implemented");
+        case OSRTarget::Interpreter:
+            return OSRState(
+                handlerOffset, sourceFrame.readLocals(),
+                /*operandStack=*/std::initializer_list<std::uint64_t>{reinterpret_cast<std::uint64_t>(exception)},
+                sourceFrame.readLocalsGCMask(), /*operandStackGCMask=*/std::initializer_list<std::uint64_t>{0b1});
         case OSRTarget::JIT:
             return OSRState(
                 handlerOffset, sourceFrame.readLocals(),

--- a/tests/Compiler/elide-deopt.j
+++ b/tests/Compiler/elide-deopt.j
@@ -33,7 +33,7 @@
     .limit locals 1
     iconst_0
     ; EXCEPT: call void @"Static Call to Test.print:(I)V"
-    ; EXCEPT-SAME: "deopt"(i16 1, i16 1, {{[^,]*}})
+    ; EXCEPT-SAME: "deopt"(i16 1, i16 1, {{[^,]*}}, i64 0)
 start:
     invokestatic Test/print(I)V
 end:

--- a/tests/Compiler/locals-deopt-types.j
+++ b/tests/Compiler/locals-deopt-types.j
@@ -34,7 +34,7 @@
     ; CHECK: %[[BITCAST_F32:.*]] = bitcast float %{{.*}} to i32
     ; CHECK: %[[BITCAST_F64:.*]] = bitcast double %{{.*}} to i64
     ; CHECK: call void @"Static Call to Test.print:(I)V"
-    ; CHECK-SAME: "deopt"(i16 {{[0-9]+}}, i16 7, i32 %{{.*}}, i64 %{{.*}}, i8 poison, i32 %[[BITCAST_F32]], ptr addrspace(1) %{{.*}}, i64 %[[BITCAST_F64]], i8 poison)
+    ; CHECK-SAME: "deopt"(i16 {{[0-9]+}}, i16 7, i32 %{{.*}}, i64 %{{.*}}, i8 poison, i32 %[[BITCAST_F32]], ptr addrspace(1) %{{.*}}, i64 %[[BITCAST_F64]], i8 poison, i64 16)
 start:
     invokestatic Test/print(I)V
 end:

--- a/tests/Compiler/locals-types-dataflow-merge.j
+++ b/tests/Compiler/locals-types-dataflow-merge.j
@@ -42,7 +42,7 @@ end:
 handler:
     ; Dataflow algorithm should have determined that the second local has an inconsistent type.
     ; CHECK: call void @"Static Call to Test.deopt:()V"
-    ; CHECK-SAME: "deopt"(i16 {{[0-9]+}}, i16 2, i32 {{.*}}, i8 poison)
+    ; CHECK-SAME: "deopt"(i16 {{[0-9]+}}, i16 2, i32 {{.*}}, i8 poison, i64 0)
     invokestatic Test/deopt()V
     return
 endHandler:

--- a/unittests/BitArrayRefTests.cpp
+++ b/unittests/BitArrayRefTests.cpp
@@ -40,6 +40,9 @@ TEMPLATE_PRODUCT_TEST_CASE("BitArrayRef", "[BitArrayRef]", (BitArrayRef, Mutable
     CHECK(ref[2] == false);
     CHECK(ref[3] == true);
     CHECK(ref[4] == false);
+
+    CHECK_THAT(llvm::make_range(ref.words_begin(), ref.words_end()),
+               RangeEquals(std::initializer_list<decltype(value)>{value}));
 }
 
 TEMPLATE_TEST_CASE("MutableBitArrayRef", "[MutableBitArrayRef]", std::uint32_t, std::uint64_t)


### PR DESCRIPTION
So far it has only been possible to perform OSR into a JITted frame. This PR also adds the capability to OSR into the interpreter and switches the exception handler to do so by default.

This is achieved by creating an `InterpreterOSRLayer` which compiles a version of the interpreter entry stub which initializes the abstract machine state from an `OSRState` instance.