### PR TITLE
[gc] add new interface for adding external roots to the GC

### DIFF
--- a/src/jllvm/gc/GarbageCollector.hpp
+++ b/src/jllvm/gc/GarbageCollector.hpp
@@ -192,7 +192,7 @@ public:
         RootProvider& operator=(RootProvider&&) = delete;
 
         using AddRootObjectFn = llvm::function_ref<void(ObjectInterface*)>;
-        using RelocateObjectFn = llvm::function_ref<void(ObjectInterface**)>;
+        using RelocateObjectFn = llvm::function_ref<void(ObjectInterface*&)>;
 
         /// Called to add additional roots to the mark phase by calling 'relocateObjectFn'.
         /// Objects pointed to by roots are marked as reachable by the GC and are updated by the GC as it relocates

--- a/src/jllvm/gc/RootFreeList.hpp
+++ b/src/jllvm/gc/RootFreeList.hpp
@@ -154,8 +154,7 @@ class RootFreeList
     ObjectInterface** m_freeListNext = nullptr;
     ObjectInterface** m_freeListEnd = nullptr;
 
-    class SlotsIterator : public llvm::iterator_facade_base<SlotsIterator, std::forward_iterator_tag, ObjectInterface**,
-                                                            std::ptrdiff_t, ObjectInterface***, ObjectInterface**>
+    class SlotsIterator : public llvm::iterator_facade_base<SlotsIterator, std::forward_iterator_tag, ObjectInterface*>
     {
         std::size_t m_slabSize = 0;
         const std::unique_ptr<ObjectInterface*[]>* m_currentSlab = nullptr;
@@ -182,7 +181,7 @@ class RootFreeList
 
         reference operator*() const
         {
-            return reinterpret_cast<reference>((*m_currentSlab).get() + m_current);
+            return *(m_currentSlab->get() + m_current);
         }
 
         SlotsIterator& operator++()
@@ -199,12 +198,12 @@ class RootFreeList
 
     struct FilterPredicate
     {
-        bool operator()(ObjectInterface** pointer) const noexcept
+        bool operator()(ObjectInterface* pointer) const noexcept
         {
             // Check whether the root is an alive root or a free slot.
             // In the latter case it is marked with a set LSB which is never the case for used roots since Object's are
             // pointer aligned.
-            return !(reinterpret_cast<std::uintptr_t>(*pointer) & 1);
+            return !(reinterpret_cast<std::uintptr_t>(pointer) & 0b1);
         }
     };
 

--- a/src/jllvm/gc/RootFreeList.hpp
+++ b/src/jllvm/gc/RootFreeList.hpp
@@ -44,18 +44,18 @@ template <class T = ObjectInterface>
 class GCRootRef
 {
 protected:
-    void** m_object = nullptr;
+    ObjectInterface** m_object = nullptr;
 
     friend class RootFreeList;
 
     template <class U>
     friend class GCRootRef;
 
-    explicit GCRootRef(void** object) : m_object(object) {}
+    explicit GCRootRef(ObjectInterface** object) : m_object(object) {}
 
     T* get() const
     {
-        return reinterpret_cast<T*>(*m_object);
+        return static_cast<T*>(*m_object);
     }
 
 public:
@@ -135,7 +135,7 @@ public:
     }
 
     /// Returns the underlying root referred to by this 'GCRootRef'.
-    void** data() const
+    ObjectInterface** data() const
     {
         return m_object;
     }
@@ -149,22 +149,23 @@ public:
 class RootFreeList
 {
     std::size_t m_slabSize;
-    std::vector<std::unique_ptr<void*[]>> m_slabs;
+    std::vector<std::unique_ptr<ObjectInterface*[]>> m_slabs;
     std::size_t m_currentSlab = 0;
-    void** m_freeListNext = nullptr;
-    void** m_freeListEnd = nullptr;
+    ObjectInterface** m_freeListNext = nullptr;
+    ObjectInterface** m_freeListEnd = nullptr;
 
-    class SlotsIterator : public llvm::iterator_facade_base<SlotsIterator, std::forward_iterator_tag, void**,
-                                                            std::ptrdiff_t, void***, void**>
+    class SlotsIterator : public llvm::iterator_facade_base<SlotsIterator, std::forward_iterator_tag, ObjectInterface**,
+                                                            std::ptrdiff_t, ObjectInterface***, ObjectInterface**>
     {
         std::size_t m_slabSize = 0;
-        const std::unique_ptr<void*[]>* m_currentSlab = nullptr;
+        const std::unique_ptr<ObjectInterface*[]>* m_currentSlab = nullptr;
         std::size_t m_current = 0;
 
     public:
         SlotsIterator() = default;
 
-        SlotsIterator(std::size_t slabSize, const std::unique_ptr<void*[]>* currentSlab, void** current)
+        SlotsIterator(std::size_t slabSize, const std::unique_ptr<ObjectInterface*[]>* currentSlab,
+                      ObjectInterface** current)
             : m_slabSize(slabSize), m_currentSlab(currentSlab), m_current(current - currentSlab->get())
         {
             if (m_current == m_slabSize)
@@ -181,7 +182,7 @@ class RootFreeList
 
         reference operator*() const
         {
-            return (*m_currentSlab).get() + m_current;
+            return reinterpret_cast<reference>((*m_currentSlab).get() + m_current);
         }
 
         SlotsIterator& operator++()
@@ -198,7 +199,7 @@ class RootFreeList
 
     struct FilterPredicate
     {
-        bool operator()(void** pointer) const noexcept
+        bool operator()(ObjectInterface** pointer) const noexcept
         {
             // Check whether the root is an alive root or a free slot.
             // In the latter case it is marked with a set LSB which is never the case for used roots since Object's are
@@ -211,7 +212,7 @@ public:
     /// Creates a new root free list with the given amount of roots per slab.
     explicit RootFreeList(std::size_t slabSize) : m_slabSize(slabSize)
     {
-        m_slabs.push_back(std::make_unique<void*[]>(m_slabSize));
+        m_slabs.push_back(std::make_unique<ObjectInterface*[]>(m_slabSize));
         m_freeListNext = m_freeListEnd = m_slabs[m_currentSlab].get();
     }
 

--- a/src/jllvm/object/ClassLoader.hpp
+++ b/src/jllvm/object/ClassLoader.hpp
@@ -91,6 +91,12 @@ public:
     /// classes.
     /// Returns the meta class object.
     ClassObject& loadBootstrapClasses();
+
+    /// Returns a range of 'ClassObject*' of all class objects loaded so far.
+    auto getLoadedClassObjects() const
+    {
+        return llvm::make_second_range(m_mapping);
+    }
 };
 
 } // namespace jllvm

--- a/src/jllvm/vm/VirtualMachine.cpp
+++ b/src/jllvm/vm/VirtualMachine.cpp
@@ -264,6 +264,15 @@ jllvm::VirtualMachine::VirtualMachine(BootOptions&& bootOptions)
 
     registerJavaClasses(*this);
 
+    m_gc.addRootObjectsProvider(
+        [&](GarbageCollector::RootProvider::AddRootObjectFn addRootObjectFn)
+        {
+            for (ClassObject* classObject : m_classLoader.getLoadedClassObjects())
+            {
+                addRootObjectFn(classObject);
+            }
+        });
+
     initialize(m_classLoader.loadBootstrapClasses());
 
     m_stringInterner.loadStringClass();


### PR DESCRIPTION
There are other heaps such as the `ClassLoader` containing Java objects which may refer to Java objects on the GC. To be able to mark such objects as reachable and update references as they are relocated, a new interface is added in this PR called `RootProvider` which adds convenient methods for adding callbacks for root traversal. As a POC, the class objects in the `ClassLoader` are added as root sets. While related code was being touched, some needless occurrences of `void**` were also removed in the code (yay to more typesafety).

Sadly, I failed to write a meaningful test as part of this PR as we are currently incapable of producing scenarios where `ClassObject`s point to Java objects in the GC heap with our current native methods in `Class`.

A later PR will use this functionality to implement GC support with the interpreter.

Fixes https://github.com/JLLVM/JLLVM/issues/197