### PR TITLE
[refactor] Make `ByteCodeIterator` constructor more intuitive

### DIFF
--- a/src/jllvm/class/ByteCodeIterator.hpp
+++ b/src/jllvm/class/ByteCodeIterator.hpp
@@ -104,7 +104,7 @@ class ByteCodeIterator : public llvm::iterator_facade_base<ByteCodeIterator, std
 public:
     ByteCodeIterator() = default;
 
-    explicit ByteCodeIterator(const char* current, std::size_t offset = 0) : m_current{current}, m_offset{offset} {}
+    explicit ByteCodeIterator(const char* data, std::size_t offset = 0) : m_current{data + offset}, m_offset{offset} {}
 
     bool operator==(ByteCodeIterator rhs) const
     {
@@ -131,11 +131,11 @@ public:
     }
 };
 
-/// Returns an iterator range returning a 'ByteCodeOp' for every JVM instruction.
-/// Assumes that the beginning of 'current' is the bytecode offset 'offset' and contains valid bytecode.
-inline auto byteCodeRange(llvm::ArrayRef<char> current, std::uint16_t offset = 0)
+/// Returns an iterator range returning a 'ByteCodeOp' for every JVM instruction starting from 'offset' inside 'data'.
+/// Assumes that 'data' contains valid bytecode.
+inline auto byteCodeRange(llvm::ArrayRef<char> data, std::uint16_t offset = 0)
 {
-    return llvm::make_range(ByteCodeIterator(current.begin(), offset), ByteCodeIterator(current.end()));
+    return llvm::make_range(ByteCodeIterator(data.begin(), offset), ByteCodeIterator(data.end()));
 }
 
 inline std::size_t getOffset(const ByteCodeOp& op)

--- a/src/jllvm/compiler/CodeGenerator.cpp
+++ b/src/jllvm/compiler/CodeGenerator.cpp
@@ -307,8 +307,7 @@ void CodeGenerator::generateCodeBody(const Code& code, std::uint16_t startOffset
         }
 
         llvm::ArrayRef<char> bytes = code.getCode();
-        for (auto curr = ByteCodeIterator(bytes.drop_front(start).begin(), start), end = ByteCodeIterator(bytes.end());
-             curr != end;)
+        for (auto curr = ByteCodeIterator(bytes.begin(), start), end = ByteCodeIterator(bytes.end()); curr != end;)
         {
             ByteCodeOp operation = *curr;
             std::size_t offset = getOffset(operation);

--- a/src/jllvm/compiler/CodeGeneratorUtils.cpp
+++ b/src/jllvm/compiler/CodeGeneratorUtils.cpp
@@ -202,7 +202,8 @@ void ByteCodeTypeChecker::checkBasicBlock(llvm::ArrayRef<char> block, std::uint1
                 m_typeStack.back() = m_doubleType;
             },
             [&](OneOfBase<DConst0, DConst1, DLoad, DLoad0, DLoad1, DLoad2, DLoad3>)
-            { m_typeStack.emplace_back(m_doubleType); }, [&](Dup) { m_typeStack.push_back(m_typeStack.back()); },
+            { m_typeStack.emplace_back(m_doubleType); },
+            [&](Dup) { m_typeStack.push_back(m_typeStack.back()); },
             [&](DupX1)
             {
                 auto iter = m_typeStack.rbegin();
@@ -329,7 +330,8 @@ void ByteCodeTypeChecker::checkBasicBlock(llvm::ArrayRef<char> block, std::uint1
                 match(
                     operation,
                     [&](OneOf<IfACmpEq, IfACmpNe, IfICmpEq, IfICmpNe, IfICmpLt, IfICmpGe, IfICmpGt, IfICmpLe>)
-                    { m_typeStack.pop_back(); }, [](...) {});
+                    { m_typeStack.pop_back(); },
+                    [](...) {});
 
                 pushNext(cmpOp.offset + cmpOp.target, m_typeStack);
                 pushNext(cmpOp.offset + sizeof(OpCodes) + sizeof(std::int16_t), m_typeStack);
@@ -515,7 +517,7 @@ const ByteCodeTypeChecker::TypeInfo& ByteCodeTypeChecker::checkAndGetTypeInfo(st
         std::uint16_t startOffset = m_offsetStack.back();
         m_offsetStack.pop_back();
 
-        checkBasicBlock(m_code.getCode().drop_front(startOffset), startOffset);
+        checkBasicBlock(m_code.getCode(), startOffset);
     }
 
     return m_byteCodeTypeInfo;

--- a/src/jllvm/vm/Interpreter.cpp
+++ b/src/jllvm/vm/Interpreter.cpp
@@ -22,7 +22,7 @@ std::uint64_t jllvm::Interpreter::executeMethod(const Method& method, std::uint1
 {
     Code* code = method.getMethodInfo().getAttributes().find<Code>();
     llvm::ArrayRef<char> codeArray = code->getCode();
-    auto curr = ByteCodeIterator(codeArray.drop_front(offset).data(), offset);
+    auto curr = ByteCodeIterator(codeArray.data(), offset);
 
     /// Tag returned when interpreting an instruction to jump to a new bytecode offset.
     struct SetPC
@@ -66,6 +66,6 @@ std::uint64_t jllvm::Interpreter::executeMethod(const Method& method, std::uint1
 
         match(
             result, [](ReturnValue) {}, [&](NextPC) { ++curr; },
-            [&](SetPC setPc) { curr = ByteCodeIterator(codeArray.drop_front(setPc.newPC).data(), setPc.newPC); });
+            [&](SetPC setPc) { curr = ByteCodeIterator(codeArray.data(), setPc.newPC); });
     }
 }


### PR DESCRIPTION
This PR changes the API of constructing a `ByteCodeIterator`  by making to more intuitive and less prone to misuse.