### PR TITLE
[interpreter] add support for `new`

### DIFF
--- a/src/jllvm/vm/Interpreter.hpp
+++ b/src/jllvm/vm/Interpreter.hpp
@@ -35,7 +35,7 @@ concept InterpreterPrimitive =
 /// Java objects (references).
 template <class T>
 concept InterpreterValue =
-    InterpreterPrimitive<T> || (std::is_pointer_v<T> && std::derived_from<std::remove_pointer<T>, ObjectInterface>);
+    InterpreterPrimitive<T> || (std::is_pointer_v<T> && std::derived_from<std::remove_pointer_t<T>, ObjectInterface>);
 
 /// Context used in the execution of one Java frame. It incorporates and contains convenience methods for interacting
 /// with local variables and the operand stack.
@@ -128,6 +128,9 @@ class Interpreter
     VirtualMachine& m_virtualMachine;
     /// Enable OSR from the interpreter into the JIT if the method is hot enough.
     bool m_enableOSR;
+
+    /// Returns the class object referred to by 'index' within 'classFile', loading it if necessary.
+    ClassObject* getClassObject(const ClassFile& classFile, PoolIndex<ClassInfo> index);
 
     /// Replaces the current interpreter frame with a compiled frame. This should only be called from within
     /// 'executeMethod' when called from the 'jllvm_interpreter' implementation in 'VirtualMachine'.

--- a/src/jllvm/vm/JIT.cpp
+++ b/src/jllvm/vm/JIT.cpp
@@ -319,7 +319,7 @@ void jllvm::JIT::doI2JOnStackReplacement(JavaFrame frame, std::uint16_t byteCode
     assert(frame.isInterpreter() && "frame must currently be within the interpreter");
 
     llvm::SmallVector<std::uint64_t> locals = frame.readLocals();
-    llvm::SmallVector<std::uint64_t> operandStack = frame.readOperandStack();
+    llvm::ArrayRef<std::uint64_t> operandStack = frame.readOperandStack();
 
     // Dynamically allocating memory here as this frame will be replaced at the end of this method and all local
     // variables destroyed. The OSR method will delete the array on entry once no longer needed.

--- a/src/jllvm/vm/VirtualMachine.hpp
+++ b/src/jllvm/vm/VirtualMachine.hpp
@@ -61,8 +61,6 @@ class VirtualMachine
     GCRootRef<Object> m_mainThreadGroup = m_gc.allocateStatic();
     std::string m_javaHome;
 
-    void initialize(ClassObject& classObject);
-
     // Instances of 'Model::State', subtypes of ModelState.
     std::vector<std::unique_ptr<ModelState>> m_modelState;
 
@@ -141,6 +139,9 @@ public:
         auto addr = llvm::cantFail(m_jit.lookup(className, methodName, methodDescriptor));
         return invokeJava<Ret>(addr, args...);
     }
+
+    /// Performs class initialization for 'classObject'. This is a noop if 'classObject' is not uninitialized.
+    void initialize(ClassObject& classObject);
 
     /// Throws a Java exception which can be caught by exception handlers in Java. This also causes stack unwinding in
     /// C++ code, executing destructors as a C++ exception would.

--- a/src/jllvm/vm/native/Lang.hpp
+++ b/src/jllvm/vm/native/Lang.hpp
@@ -98,10 +98,17 @@ public:
 #endif
     }
 
+    String* initClassName()
+    {
+        std::string string = javaThis->getClassName().str();
+        std::replace(string.begin(), string.end(), '/', '.');
+        return virtualMachine.getStringInterner().intern(string);
+    }
+
     constexpr static llvm::StringLiteral className = "java/lang/Class";
     constexpr static auto methods =
         std::make_tuple(&ClassModel::registerNatives, &ClassModel::isArray, &ClassModel::desiredAssertionStatus0,
-                        &ClassModel::getPrimitiveClass, &ClassModel::isPrimitive);
+                        &ClassModel::getPrimitiveClass, &ClassModel::isPrimitive, &ClassModel::initClassName);
 };
 
 class FloatModel : public ModelBase<>

--- a/tests/Execution/interpreter-gc.j
+++ b/tests/Execution/interpreter-gc.j
@@ -1,0 +1,34 @@
+; RUN: jasmin %s -d %t
+; RUN: jllvm -Xint %t/Test.class | FileCheck %s
+
+.class public Test
+.super java/lang/Object
+
+.method public <init>()V
+    aload_0
+    invokespecial java/lang/Object/<init>()V
+    return
+.end method
+
+.method public static native print(Ljava/lang/String;)V
+.end method
+
+.method public static main([Ljava/lang/String;)V
+.limit locals 1
+.limit stack 3
+    ; If GC were to not work, the second allocation would take place of the first, making the print below fail.
+    new Test
+    new java/lang/Object
+    dup
+    invokespecial java/lang/Object.<init>()V
+    swap
+    dup
+    invokespecial Test.<init>()V
+    ; CHECK: Test@{{.*}}
+    ; CHECK: java.lang.Object@{{.*}}
+    invokevirtual java/lang/Object.toString()Ljava/lang/String;
+    invokestatic Test.print(Ljava/lang/String;)V
+    invokevirtual java/lang/Object.toString()Ljava/lang/String;
+    invokestatic Test.print(Ljava/lang/String;)V
+    return
+.end method


### PR DESCRIPTION
This PR adds support for the 'new' instruction, making it possible to create Java objects from within the interpreter. Since Java objects are now in the interpreter context, garbage collection support was added to the interpreter as well. This is implemented using the new `RootProvider` API, making it possible to add the interpreter's operand stack and local variables as roots for marking and relocation.