### PR TITLE
[support] Add `[Mutable]BitArrayRef` classes

### DIFF
--- a/src/jllvm/support/BitArrayRef.hpp
+++ b/src/jllvm/support/BitArrayRef.hpp
@@ -1,0 +1,151 @@
+
+// Copyright (C) 2023 The JLLVM Contributors.
+//
+// This file is part of JLLVM.
+//
+// JLLVM is free software; you can redistribute it and/or modify it under  the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 3, or (at your option) any later version.
+//
+// JLLVM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with JLLVM; see the file LICENSE.txt.  If not
+// see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <llvm/ADT/STLExtras.h>
+#include <llvm/Support/MathExtras.h>
+
+#include <limits>
+
+namespace jllvm
+{
+
+/// Read-only view of a buffer of 'IntegerType', interpreting it as a bitset of a given size.
+template <class IntegerType = std::uint64_t>
+requires std::is_unsigned_v<IntegerType> class BitArrayRef
+{
+protected:
+    const IntegerType* m_bits;
+    std::size_t m_size;
+
+    constexpr static std::size_t numBits = std::numeric_limits<IntegerType>::digits;
+
+public:
+
+    /// Create a new 'BitArrayRef' from a given buffer with 'size' many bits.
+    /// 'bits' must be an array of at least 'ceil(size / num_bits(IntegerType))'.
+    BitArrayRef(const IntegerType* bits, std::size_t size) : m_bits(bits), m_size(size) {}
+
+    using value_type = IntegerType;
+
+    class iterator : public llvm::indexed_accessor_iterator<iterator, const IntegerType*, bool>
+    {
+        using Base = llvm::indexed_accessor_iterator<iterator, const IntegerType*, bool>;
+
+    public:
+        iterator(const IntegerType* base, ptrdiff_t index) : Base(base, index) {}
+
+        bool operator*() const
+        {
+            return this->getBase()[this->getIndex() / numBits] & (1 << (this->getIndex() % numBits));
+        }
+    };
+
+    /// Returns the begin iterator over all bits.
+    iterator begin() const
+    {
+        return iterator(m_bits, 0);
+    }
+
+    /// Returns the end iterator over all bits.
+    iterator end() const
+    {
+        return iterator(m_bits, m_size);
+    }
+
+    /// Returns the number of bits of this 'BitArrayRef'.
+    std::size_t size() const
+    {
+        return m_size;
+    }
+
+    /// Returns the value of the 'index'th bit.
+    bool operator[](std::size_t index) const
+    {
+        assert(index < m_size);
+        return *std::next(begin(), index);
+    }
+};
+
+/// Mutable view of a buffer of 'IntegerType', interpreting it as a bitset of a given size.
+template <std::integral IntegerType = std::uint64_t>
+class MutableBitArrayRef : public BitArrayRef<IntegerType>
+{
+    using Base = BitArrayRef<IntegerType>;
+
+    class Proxy
+    {
+        IntegerType* m_bits;
+        std::size_t m_index;
+
+    public:
+        Proxy(IntegerType* bits, size_t index) : m_bits(bits), m_index(index) {}
+
+        operator bool() const
+        {
+            return m_bits[m_index / Base::numBits] & (1 << (m_index % Base::numBits));
+        }
+
+        const Proxy& operator=(bool value) const
+        {
+            if (value)
+            {
+                m_bits[m_index / Base::numBits] |= 1 << m_index % Base::numBits;
+            }
+            else
+            {
+                m_bits[m_index / Base::numBits] &= ~(1 << m_index % Base::numBits);
+            }
+            return *this;
+        }
+    };
+
+public:
+    MutableBitArrayRef(IntegerType* bits, std::size_t size) : Base(bits, size) {}
+
+    class iterator : public llvm::indexed_accessor_iterator<iterator, IntegerType*, Proxy>
+    {
+        using Base = llvm::indexed_accessor_iterator<iterator, IntegerType*, Proxy>;
+
+    public:
+        iterator(IntegerType* base, ptrdiff_t index) : Base(base, index) {}
+
+        Proxy operator*() const
+        {
+            return Proxy(this->getBase(), this->getIndex());
+        }
+    };
+
+    /// Returns the begin iterator over all bits. The iterator returns a proxy object which implicitly converts to a
+    /// 'bool', reading the bit, or can be assigned to, to set the value of the bit.
+    iterator begin() const
+    {
+        return iterator(const_cast<IntegerType*>(this->m_bits), 0);
+    }
+
+    iterator end() const
+    {
+        return iterator(const_cast<IntegerType*>(this->m_bits), this->m_size);
+    }
+
+    /// Returns a proxy to the bit at the given index. The proxy is the same as is returned by the iterators.
+    Proxy operator[](std::size_t index) const
+    {
+        assert(index < this->m_size);
+        return *std::next(begin(), index);
+    }
+};
+
+} // namespace jllvm

--- a/src/jllvm/vm/Interpreter.hpp
+++ b/src/jllvm/vm/Interpreter.hpp
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <jllvm/object/ClassObject.hpp>
+#include <jllvm/support/BitArrayRef.hpp>
 
 #include <cstdint>
 
@@ -57,15 +58,9 @@ class InterpreterContext
     /// Sets the corresponding bit in 'mask' at index to 'value'.
     static void setMaskBit(std::uint64_t* mask, std::size_t index, bool value)
     {
-        constexpr auto bitWidth = std::numeric_limits<std::decay_t<decltype(*mask)>>::digits;
-        if (value)
-        {
-            mask[index / bitWidth] |= 1ull << (index % bitWidth);
-        }
-        else
-        {
-            mask[index / bitWidth] &= ~(1ull << (index % bitWidth));
-        }
+        // While we cannot permanently keep around a 'MutableBitArrayRef' unless wastefully storing the size,
+        // we can reuse its dereferencing implementation with a proper upper bound.
+        MutableBitArrayRef(mask, index + 1)[index] = value;
     }
 
 public:

--- a/src/jllvm/vm/JavaFrame.cpp
+++ b/src/jllvm/vm/JavaFrame.cpp
@@ -63,12 +63,12 @@ llvm::MutableArrayRef<std::uint64_t> jllvm::InterpreterFrame::getLocals() const
     return llvm::MutableArrayRef<std::uint64_t>(locals, locals + numLocals);
 }
 
-llvm::ArrayRef<std::uint64_t> jllvm::InterpreterFrame::getLocalsGCMask() const
+jllvm::BitArrayRef<> jllvm::InterpreterFrame::getLocalsGCMask() const
 {
     std::uint16_t numLocals =
         m_javaMethodMetadata->getMethod()->getMethodInfo().getAttributes().find<Code>()->getMaxLocals();
     std::uint64_t* mask = m_javaMethodMetadata->getInterpreterData().localVariablesGCMask.readScalar(*m_unwindFrame);
-    return llvm::ArrayRef<std::uint64_t>(mask, mask + numLocals);
+    return BitArrayRef<>(mask, numLocals);
 }
 
 llvm::MutableArrayRef<std::uint64_t> jllvm::InterpreterFrame::getOperandStack() const
@@ -78,9 +78,9 @@ llvm::MutableArrayRef<std::uint64_t> jllvm::InterpreterFrame::getOperandStack() 
     return llvm::MutableArrayRef<std::uint64_t>(operands, operands + numStack);
 }
 
-llvm::ArrayRef<std::uint64_t> jllvm::InterpreterFrame::getOperandStackGCMask() const
+jllvm::BitArrayRef<> jllvm::InterpreterFrame::getOperandStackGCMask() const
 {
     std::uint16_t numStack = *m_javaMethodMetadata->getInterpreterData().topOfStack.readScalar(*m_unwindFrame);
     std::uint64_t* mask = m_javaMethodMetadata->getInterpreterData().operandGCMask.readScalar(*m_unwindFrame);
-    return llvm::ArrayRef<std::uint64_t>(mask, mask + numStack);
+    return BitArrayRef<>(mask, numStack);
 }

--- a/src/jllvm/vm/JavaFrame.hpp
+++ b/src/jllvm/vm/JavaFrame.hpp
@@ -16,6 +16,7 @@
 #include <llvm/Support/Casting.h>
 
 #include <jllvm/compiler/ByteCodeCompileUtils.hpp>
+#include <jllvm/support/BitArrayRef.hpp>
 #include <jllvm/unwind/Unwinder.hpp>
 
 namespace jllvm
@@ -113,13 +114,13 @@ public:
     llvm::MutableArrayRef<std::uint64_t> getLocals() const;
 
     /// Returns the bitset denoting where Java references are contained within the interpreter locals.
-    llvm::ArrayRef<std::uint64_t> getLocalsGCMask() const;
+    BitArrayRef<> getLocalsGCMask() const;
 
     /// Returns a mutable view of the operand stack of the interpreter.
     llvm::MutableArrayRef<std::uint64_t> getOperandStack() const;
 
     /// Returns the bitset denoting where Java references are contained within the interpreter operand stack.
-    llvm::ArrayRef<std::uint64_t> getOperandStackGCMask() const;
+    BitArrayRef<> getOperandStackGCMask() const;
 };
 
 } // namespace jllvm

--- a/src/jllvm/vm/VirtualMachine.cpp
+++ b/src/jllvm/vm/VirtualMachine.cpp
@@ -284,11 +284,11 @@ jllvm::VirtualMachine::VirtualMachine(BootOptions&& bootOptions)
                         return;
                     }
 
-                    auto addRoots = [=](llvm::MutableArrayRef<std::uint64_t> array, llvm::ArrayRef<std::uint64_t> mask)
+                    auto addRoots = [=](llvm::MutableArrayRef<std::uint64_t> array, BitArrayRef<> mask)
                     {
-                        for (auto&& [index, iter] : llvm::enumerate(array))
+                        for (auto&& [iter, isReference] : llvm::zip_equal(array, mask))
                         {
-                            if (!(mask[index / 64] & 1 << (index % 64)))
+                            if (!isReference)
                             {
                                 continue;
                             }

--- a/unittests/BitArrayRefTests.cpp
+++ b/unittests/BitArrayRefTests.cpp
@@ -1,0 +1,69 @@
+// Copyright (C) 2023 The JLLVM Contributors.
+//
+// This file is part of JLLVM.
+//
+// JLLVM is free software; you can redistribute it and/or modify it under  the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 3, or (at your option) any later version.
+//
+// JLLVM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with JLLVM; see the file LICENSE.txt.  If not
+// see <http://www.gnu.org/licenses/>.
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_quantifiers.hpp>
+#include <catch2/matchers/catch_matchers_range_equals.hpp>
+
+#include <jllvm/support/BitArrayRef.hpp>
+
+using namespace jllvm;
+using namespace Catch::Matchers;
+
+TEMPLATE_PRODUCT_TEST_CASE("BitArrayRef", "[BitArrayRef]", (BitArrayRef, MutableBitArrayRef),
+                           (std::uint32_t, std::uint64_t))
+{
+    typename TestType::value_type value{};
+    TestType ref(&value, /*size=*/5);
+    CHECK(ref.size() == 5);
+    CHECK(std::distance(ref.begin(), ref.end()) == 5);
+    CHECK_THAT(ref, NoneTrue());
+
+    value = 0b11111;
+    CHECK_THAT(ref, AllTrue());
+
+    value = 0b01001;
+    CHECK_THAT(ref, RangeEquals(std::initializer_list<bool>{true, false, false, true, false}));
+    CHECK(ref[0] == true);
+    CHECK(ref[1] == false);
+    CHECK(ref[2] == false);
+    CHECK(ref[3] == true);
+    CHECK(ref[4] == false);
+}
+
+TEMPLATE_TEST_CASE("MutableBitArrayRef", "[MutableBitArrayRef]", std::uint32_t, std::uint64_t)
+{
+    TestType value{};
+    MutableBitArrayRef ref(&value, /*size=*/5);
+    CHECK(std::distance(ref.begin(), ref.end()) == 5);
+
+    ref[0] = true;
+    ref[1] = true;
+    ref[2] = true;
+    ref[3] = true;
+    ref[4] = true;
+    CHECK_THAT(ref, AllTrue());
+
+    ref[0] = true;
+    ref[1] = false;
+    ref[2] = false;
+    ref[3] = true;
+    ref[4] = false;
+    CHECK_THAT(ref, RangeEquals(std::initializer_list<bool>{true, false, false, true, false}));
+    CHECK(ref[0] == true);
+    CHECK(ref[1] == false);
+    CHECK(ref[2] == false);
+    CHECK(ref[3] == true);
+    CHECK(ref[4] == false);
+}

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -9,7 +9,8 @@ add_executable(GCTests RootFreeListTests.cpp
 target_link_libraries(GCTests JLLVMGC Catch2::Catch2WithMain)
 catch_discover_tests(GCTests)
 
-add_executable(SupportTests NonOwningFrozenSetTests.cpp)
+add_executable(SupportTests NonOwningFrozenSetTests.cpp
+        BitArrayRefTests.cpp)
 target_link_libraries(SupportTests JLLVMSupport Catch2::Catch2WithMain)
 catch_discover_tests(SupportTests)
 


### PR DESCRIPTION
These classes can be used to conveniently interpret external memory as a bitset, allowing convenient methods to access individual bits.