### PR TITLE
[vm][compiler] Introduce globals for interned strings

### DIFF
--- a/src/jllvm/compiler/ByteCodeCompileUtils.cpp
+++ b/src/jllvm/compiler/ByteCodeCompileUtils.cpp
@@ -84,6 +84,11 @@ llvm::GlobalVariable* jllvm::methodGlobal(llvm::Module& module, const Method* me
     return getOrInsertImportingGlobal(module, mangleMethodGlobal(method), /*addressSpace=*/0);
 }
 
+llvm::GlobalVariable* jllvm::stringGlobal(llvm::Module& module, llvm::StringRef contents)
+{
+    return getOrInsertImportingGlobal(module, mangleStringGlobal(contents), /*addressSpace=*/1);
+}
+
 llvm::Type* jllvm::descriptorToType(FieldType type, llvm::LLVMContext& context)
 {
     return jllvm::match(

--- a/src/jllvm/compiler/ByteCodeCompileUtils.hpp
+++ b/src/jllvm/compiler/ByteCodeCompileUtils.hpp
@@ -46,6 +46,9 @@ llvm::GlobalVariable* classObjectGlobal(llvm::Module& module, FieldType classObj
 /// Returns the global variable importing the given method.
 llvm::GlobalVariable* methodGlobal(llvm::Module& module, const Method* method);
 
+/// Returns the global variable importing the given interned string.
+llvm::GlobalVariable* stringGlobal(llvm::Module& module, llvm::StringRef contents);
+
 /// Returns the corresponding LLVM type for a given Java field descriptor.
 llvm::Type* descriptorToType(FieldType type, llvm::LLVMContext& context);
 

--- a/src/jllvm/compiler/ClassObjectStubMangling.cpp
+++ b/src/jllvm/compiler/ClassObjectStubMangling.cpp
@@ -92,12 +92,25 @@ std::string jllvm::mangleMethodGlobal(const Method* method)
     return '&' + mangleDirectMethodCall(method);
 }
 
+constexpr llvm::StringLiteral globalStringPrefix = "'";
+
+std::string jllvm::mangleStringGlobal(llvm::StringRef contents)
+{
+    return globalStringPrefix.data() + contents.str();
+}
+
 jllvm::DemangledVariant jllvm::demangleStubSymbolName(llvm::StringRef symbolName)
 {
     bool isStatic = false;
     bool isClassObjectLoad = false;
     bool isSpecialMethod = false;
     std::optional<MethodResolution> resolution;
+
+    if (symbolName.consume_front(globalStringPrefix))
+    {
+        return DemangledStringGlobal{symbolName};
+    }
+
     if (symbolName.consume_front(classObjectPrefix))
     {
         isClassObjectLoad = true;

--- a/src/jllvm/compiler/ClassObjectStubMangling.hpp
+++ b/src/jllvm/compiler/ClassObjectStubMangling.hpp
@@ -112,6 +112,12 @@ std::string mangleClassObjectGlobal(FieldType descriptor);
 /// <method-global> ::= '&' <direct-call>
 std::string mangleMethodGlobal(const Method* method);
 
+/// Mangling for a global interned string.
+///
+/// Syntax:
+/// <string-global> ::= "'" <string-contents>
+std::string mangleStringGlobal(llvm::StringRef contents);
+
 /// A call produced via 'mangleFieldAccess'.
 struct DemangledFieldAccess
 {
@@ -158,9 +164,15 @@ struct DemangledClassObjectGlobal
     FieldType classObject;
 };
 
+/// A global produced via 'mangleStringGlobal'.
+struct DemangledStringGlobal
+{
+    llvm::StringRef contents;
+};
+
 using DemangledVariant =
     swl::variant<std::monostate, DemangledFieldAccess, DemangledMethodResolutionCall, DemangledStaticCall,
-                 DemangledLoadClassObject, DemangledSpecialCall, DemangledClassObjectGlobal>;
+                 DemangledLoadClassObject, DemangledSpecialCall, DemangledClassObjectGlobal, DemangledStringGlobal>;
 
 /// Attempts to demangle a symbol produced by any of the 'mangle*' functions above with the exception of
 /// 'mangleDirectMethodCall'.

--- a/src/jllvm/compiler/CodeGenerator.cpp
+++ b/src/jllvm/compiler/CodeGenerator.cpp
@@ -1154,11 +1154,7 @@ bool CodeGenerator::generateInstruction(ByteCodeOp operation)
                 {
                     llvm::StringRef text = stringInfo->stringValue.resolve(m_classFile)->text;
 
-                    String* string = m_stringInterner.intern(text);
-
-                    m_operandStack.push_back(
-                        m_builder.CreateIntToPtr(m_builder.getInt64(reinterpret_cast<std::uint64_t>(string)),
-                                                 referenceType(m_builder.getContext())));
+                    m_operandStack.push_back(stringGlobal(*m_function->getParent(), text));
                 },
                 [&](const ClassInfo*)
                 { m_operandStack.push_back(loadClassObjectFromPool(getOffset(operation), ldc.index)); },

--- a/src/jllvm/compiler/Compiler.cpp
+++ b/src/jllvm/compiler/Compiler.cpp
@@ -16,7 +16,7 @@
 #include "ClassObjectStubMangling.hpp"
 #include "CodeGenerator.hpp"
 
-llvm::Function* jllvm::compileMethod(llvm::Module& module, const Method& method, StringInterner& stringInterner)
+llvm::Function* jllvm::compileMethod(llvm::Module& module, const Method& method)
 {
     const MethodInfo& methodInfo = method.getMethodInfo();
     const ClassObject* classObject = method.getClassObject();
@@ -31,7 +31,7 @@ llvm::Function* jllvm::compileMethod(llvm::Module& module, const Method& method,
     auto* code = methodInfo.getAttributes().find<Code>();
     assert(code && "method to compile must have a code attribute");
     compileMethodBody(
-        function, method, stringInterner, *code,
+        function, method, *code,
         [&](llvm::IRBuilder<>& builder, LocalVariables& locals, OperandStack&, const ByteCodeTypeChecker::TypeInfo&)
         {
             // Arguments are put into the locals. According to the specification, i64s and doubles are
@@ -58,8 +58,7 @@ llvm::Function* jllvm::compileMethod(llvm::Module& module, const Method& method,
     return function;
 }
 
-llvm::Function* jllvm::compileOSRMethod(llvm::Module& module, std::uint16_t offset, const Method& method,
-                                        StringInterner& stringInterner)
+llvm::Function* jllvm::compileOSRMethod(llvm::Module& module, std::uint16_t offset, const Method& method)
 {
     const MethodInfo& methodInfo = method.getMethodInfo();
     const ClassObject* classObject = method.getClassObject();
@@ -77,7 +76,7 @@ llvm::Function* jllvm::compileOSRMethod(llvm::Module& module, std::uint16_t offs
     llvm::Value* localsInput = function->getArg(1);
 
     compileMethodBody(
-        function, method, stringInterner, *code,
+        function, method, *code,
         [&](llvm::IRBuilder<>& builder, LocalVariables& locals, OperandStack& operandStack,
             const ByteCodeTypeChecker::TypeInfo& typeInfo)
         {

--- a/src/jllvm/compiler/Compiler.hpp
+++ b/src/jllvm/compiler/Compiler.hpp
@@ -17,16 +17,14 @@
 
 #include <jllvm/class/ClassFile.hpp>
 #include <jllvm/object/ClassObject.hpp>
-#include <jllvm/object/StringInterner.hpp>
 
 namespace jllvm
 {
 
 /// Compiles 'method' to a new LLVM function inside of 'module' and returns it.
-llvm::Function* compileMethod(llvm::Module& module, const Method& method, StringInterner& stringInterner);
+llvm::Function* compileMethod(llvm::Module& module, const Method& method);
 
 /// Compiles 'method' to a LLVM function suitable for OSR entry at the bytecode offset 'offset'. The function is placed
 /// into 'module' and returned.
-llvm::Function* compileOSRMethod(llvm::Module& module, std::uint16_t offset, const Method& method,
-                                 StringInterner& stringInterner);
+llvm::Function* compileOSRMethod(llvm::Module& module, std::uint16_t offset, const Method& method);
 } // namespace jllvm

--- a/src/jllvm/materialization/ByteCodeCompileLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeCompileLayer.cpp
@@ -31,7 +31,7 @@ void jllvm::ByteCodeCompileLayer::emit(std::unique_ptr<llvm::orc::Materializatio
     auto context = std::make_unique<llvm::LLVMContext>();
     auto module = std::make_unique<llvm::Module>(methodName, *context);
 
-    compileMethod(*module, *method, m_stringInterner);
+    compileMethod(*module, *method);
 
     module->setDataLayout(m_dataLayout);
     module->setTargetTriple(LLVM_HOST_TRIPLE);

--- a/src/jllvm/materialization/ByteCodeCompileLayer.hpp
+++ b/src/jllvm/materialization/ByteCodeCompileLayer.hpp
@@ -15,8 +15,6 @@
 
 #include <llvm/ExecutionEngine/Orc/Layer.h>
 
-#include <jllvm/object/StringInterner.hpp>
-
 #include "ByteCodeLayer.hpp"
 
 namespace jllvm
@@ -24,14 +22,13 @@ namespace jllvm
 /// Layer for compiling a JVM method to LLVM IR and handing it to an IR Layer for further compilation.
 class ByteCodeCompileLayer : public ByteCodeLayer
 {
-    StringInterner& m_stringInterner;
     llvm::orc::IRLayer& m_baseLayer;
     llvm::DataLayout m_dataLayout;
 
 public:
-    ByteCodeCompileLayer(StringInterner& stringInterner, llvm::orc::IRLayer& baseLayer,
-                         llvm::orc::MangleAndInterner& mangler, const llvm::DataLayout& dataLayout)
-        : ByteCodeLayer(mangler), m_stringInterner(stringInterner), m_baseLayer(baseLayer), m_dataLayout(dataLayout)
+    ByteCodeCompileLayer(llvm::orc::IRLayer& baseLayer, llvm::orc::MangleAndInterner& mangler,
+                         const llvm::DataLayout& dataLayout)
+        : ByteCodeLayer{mangler}, m_baseLayer{baseLayer}, m_dataLayout{dataLayout}
     {
     }
 

--- a/src/jllvm/materialization/ByteCodeOSRCompileLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeOSRCompileLayer.cpp
@@ -24,7 +24,7 @@ void jllvm::ByteCodeOSRCompileLayer::emit(std::unique_ptr<llvm::orc::Materializa
     module->setDataLayout(m_dataLayout);
     module->setTargetTriple(LLVM_HOST_TRIPLE);
 
-    compileOSRMethod(*module, offset, *method, m_stringInterner);
+    compileOSRMethod(*module, offset, *method);
 
     m_baseLayer.emit(std::move(mr), llvm::orc::ThreadSafeModule(std::move(module), std::move(context)));
 }

--- a/src/jllvm/materialization/ByteCodeOSRCompileLayer.hpp
+++ b/src/jllvm/materialization/ByteCodeOSRCompileLayer.hpp
@@ -15,8 +15,6 @@
 
 #include <llvm/ExecutionEngine/Orc/Layer.h>
 
-#include <jllvm/object/StringInterner.hpp>
-
 #include "ByteCodeOSRLayer.hpp"
 
 namespace jllvm
@@ -24,14 +22,13 @@ namespace jllvm
 /// Layer for compiling OSR versions of methods at a given bytecode to LLVM IR.
 class ByteCodeOSRCompileLayer : public ByteCodeOSRLayer
 {
-    StringInterner& m_stringInterner;
     llvm::orc::IRLayer& m_baseLayer;
     llvm::DataLayout m_dataLayout;
 
 public:
-    ByteCodeOSRCompileLayer(StringInterner& stringInterner, llvm::orc::IRLayer& baseLayer,
-                            llvm::orc::MangleAndInterner& mangler, const llvm::DataLayout& dataLayout)
-        : ByteCodeOSRLayer(mangler), m_stringInterner(stringInterner), m_baseLayer(baseLayer), m_dataLayout(dataLayout)
+    ByteCodeOSRCompileLayer(llvm::orc::IRLayer& baseLayer, llvm::orc::MangleAndInterner& mangler,
+                            const llvm::DataLayout& dataLayout)
+        : ByteCodeOSRLayer{mangler}, m_baseLayer{baseLayer}, m_dataLayout{dataLayout}
     {
     }
 

--- a/src/jllvm/materialization/ClassObjectStubDefinitionsGenerator.cpp
+++ b/src/jllvm/materialization/ClassObjectStubDefinitionsGenerator.cpp
@@ -97,11 +97,16 @@ llvm::Error jllvm::ClassObjectStubDefinitionsGenerator::tryToGenerate(llvm::orc:
             continue;
         }
 
-        // Globals are resolved immediately. Its not possible to use a compile stub or the like.
+        // Globals are resolved immediately. It is not possible to use a compile stub or the like.
         if (auto* classObjectGlobal = get_if<DemangledClassObjectGlobal>(&demangleVariant))
         {
             generated[symbol] =
                 llvm::JITEvaluatedSymbol::fromPointer(&m_classLoader.forName(classObjectGlobal->classObject));
+            continue;
+        }
+        if (auto* stringGlobal = get_if<DemangledStringGlobal>(&demangleVariant))
+        {
+            generated[symbol] = llvm::JITEvaluatedSymbol::fromPointer(m_stringInterner.intern(stringGlobal->contents));
             continue;
         }
 

--- a/tests/Compiler/string-globals.j
+++ b/tests/Compiler/string-globals.j
@@ -18,8 +18,6 @@
     .limit stack 1
     ; CHECK: store ptr addrspace(1) @"'Test String", ptr %[[TOP:[[:alnum:]]+]]
     ldc "Test String"
-    ; CHECK-NEXT: %[[ARG:[[:alnum:]]+]] = load ptr addrspace(1), ptr %[[TOP]],
-    ; CHECK-NEXT: call void @"Static Call to Test.print:(Ljava/lang/String;)V"(ptr addrspace(1) %[[ARG]])
     invokestatic Test/print(Ljava/lang/String;)V
     return
 .end method

--- a/tests/Compiler/string-globals.j
+++ b/tests/Compiler/string-globals.j
@@ -1,0 +1,25 @@
+; RUN: jasmin %s -d %t
+; RUN: jllvm-jvmc --method "test:()V" %t/Test.class | FileCheck %s
+
+.class public Test
+.super java/lang/Object
+
+.method public <init>()V
+    aload_0
+    invokespecial java/lang/Object/<init>()V
+    return
+.end method
+
+.method public static native print(Ljava/lang/String;)V
+.end method
+
+; CHECK-LABEL: define void @"Test.test:()V"
+.method public static test()V
+    .limit stack 1
+    ; CHECK: store ptr addrspace(1) @"'Test String", ptr %[[TOP:[[:alnum:]]+]]
+    ldc "Test String"
+    ; CHECK-NEXT: %[[ARG:[[:alnum:]]+]] = load ptr addrspace(1), ptr %[[TOP]],
+    ; CHECK-NEXT: call void @"Static Call to Test.print:(Ljava/lang/String;)V"(ptr addrspace(1) %[[ARG]])
+    invokestatic Test/print(Ljava/lang/String;)V
+    return
+.end method

--- a/tools/jllvm-jvmc/main.cpp
+++ b/tools/jllvm-jvmc/main.cpp
@@ -127,8 +127,6 @@ int main(int argc, char** argv)
         [&]() -> void** { return new (allocator.Allocate<void*>()) void* {}; });
 
     loader.loadBootstrapClasses();
-    jllvm::StringInterner stringInterner(loader);
-    stringInterner.loadStringClass();
 
     auto buffer = llvm::MemoryBuffer::getFile(inputFile);
     if (!buffer)
@@ -159,11 +157,11 @@ int main(int argc, char** argv)
             llvm::errs() << "invalid integer '" << ref << "' as argument to '--osr'\n";
             return -1;
         }
-        compileOSRMethod(module, offset, *method, stringInterner);
+        compileOSRMethod(module, offset, *method);
     }
     else
     {
-        compileMethod(module, *method, stringInterner);
+        compileMethod(module, *method);
     }
     if (llvm::verifyModule(module, &llvm::dbgs()))
     {


### PR DESCRIPTION
This PR removes the embedding of pointers to strings interned at compile time with proper external global variables which the JIT linker later resolves.
This in term removes the need for `StringInterner` for the generation of LLVM IR and all associated facets.
Altogether reducing coupling and leading to a cleaner design.