### PR TITLE
[object] Add missing superinterfaces lookup in interface method resolution

### DIFF
--- a/tests/Execution/invoke-interface-superinterfaces.j
+++ b/tests/Execution/invoke-interface-superinterfaces.j
@@ -1,0 +1,49 @@
+; RUN: rm -rf %t && split-file %s %t
+; RUN: cd %t && jasmin %t/Test.j -d %t && jasmin %t/A.j && jasmin %t/B.j -d %t
+; RUN: jllvm %t/Test.class | FileCheck %s
+
+;--- Test.j
+
+.class public Test
+.super java/lang/Object
+.implements B
+
+.method public <init>()V
+    aload_0
+    invokespecial java/lang/Object/<init>()V
+    return
+.end method
+
+.method public static native print(Ljava/lang/String;)V
+.end method
+
+.method public static main([Ljava/lang/String;)V
+.limit stack 2
+    new Test
+    dup
+    invokespecial Test/<init>()V
+    invokeinterface B/asString()Ljava/lang/String; 1
+    ; CHECK: Hello World!
+    invokestatic Test/print(Ljava/lang/String;)V
+    return
+.end method
+
+.method public asString()Ljava/lang/String;
+.limit stack 1
+    ldc "Hello World!"
+    areturn
+.end method
+
+;--- B.j
+
+.interface B
+.super java/lang/Object
+.implements A
+
+;--- A.j
+
+.interface A
+.super java/lang/Object
+
+.method public abstract asString()Ljava/lang/String;
+.end method


### PR DESCRIPTION
The JVM spec states that as a last step, the method should be resolved in any of the interface methods as long as it is not static or private. This was previously not done for unknown reasons.

This patch implements the missing lookup step. While touching the code, `getMethod` was redefined to only do a lookup in the current class, as that is the more common operation. The previous `getMethod` was renamed to `getMethodSuper`