### PR TITLE
[gc] Fix bug where base-pointer is relocated prior to derived

### DIFF
--- a/src/jllvm/gc/GarbageCollector.cpp
+++ b/src/jllvm/gc/GarbageCollector.cpp
@@ -355,7 +355,7 @@ void jllvm::GarbageCollector::addStackMapEntries(std::uintptr_t addr, llvm::Arra
     }
     auto& vec = m_entries[addr];
     auto iter = vec.insert(vec.end(), entries.begin(), entries.end());
-    // Entries where the locations of the frame value are identical are relocations for the base pointers. These must
+    // Entries where the locations of the frame values are identical are relocations for the base pointers. These must
     // be moved AFTER all derived pointers, which is achieved by partitioning the range of values newly inserted.
     // Not doing so leads to issues as the base pointer may be relocated prior to the derived pointer. Later reading
     // the base pointer would 1) lead to not finding a relocation mapping for the already relocated base pointer and

--- a/src/jllvm/gc/GarbageCollector.cpp
+++ b/src/jllvm/gc/GarbageCollector.cpp
@@ -353,9 +353,15 @@ void jllvm::GarbageCollector::addStackMapEntries(std::uintptr_t addr, llvm::Arra
     {
         return;
     }
-    LLVM_DEBUG({ llvm::dbgs() << "Added stackmap entries for PC " << (void*)addr << '\n'; });
     auto& vec = m_entries[addr];
-    vec.insert(vec.end(), entries.begin(), entries.end());
+    auto iter = vec.insert(vec.end(), entries.begin(), entries.end());
+    // Entries where the locations of the frame value are identical are relocations for the base pointers. These must
+    // be moved AFTER all derived pointers, which is achieved by partitioning the range of values newly inserted.
+    // Not doing so leads to issues as the base pointer may be relocated prior to the derived pointer. Later reading
+    // the base pointer would 1) lead to not finding a relocation mapping for the already relocated base pointer and
+    // 2) makes it impossible to tell the original offset of the derived pointer to the base pointer.
+    std::stable_partition(iter, vec.end(),
+                          [](const StackMapEntry& entry) { return entry.basePointer != entry.derivedPointer; });
 }
 
 void jllvm::GarbageCollector::RootProvider::addRootsForRelocation(RelocateObjectFn relocateObjectFn)

--- a/src/jllvm/unwind/Unwinder.hpp
+++ b/src/jllvm/unwind/Unwinder.hpp
@@ -204,7 +204,7 @@ protected:
                 case Tag::Direct: return direct == rhs.direct;
                 case Tag::Indirect: return indirect == rhs.indirect;
             }
-            llvm_unreachable("should not eb possible");
+            llvm_unreachable("should not be possible");
         }
     } m_union{};
 


### PR DESCRIPTION
When the base-pointer is relocated prior to the derived pointer then the derived pointer cannot be relocated as 1) no mapping exists for the relocated base pointer and 2) no offset between the derived and base pointer can be determined. This PR fixes that issues by doing a partition of the frame values, moving base pointer entries AFTER the derived pointer entries