### PR TITLE
[debuginfo] Extract and consistently use `TrivialDebugInfoBuilder`

### DIFF
--- a/src/jllvm/CMakeLists.txt
+++ b/src/jllvm/CMakeLists.txt
@@ -13,6 +13,7 @@
 
 add_subdirectory(class)
 add_subdirectory(compiler)
+add_subdirectory(debuginfo)
 add_subdirectory(gc)
 add_subdirectory(llvm)
 add_subdirectory(main)

--- a/src/jllvm/compiler/CMakeLists.txt
+++ b/src/jllvm/compiler/CMakeLists.txt
@@ -18,5 +18,5 @@ add_library(JLLVMCompiler
         ClassObjectStubCodeGenerator.cpp
         ClassObjectStubMangling.cpp
         Compiler.cpp)
-target_link_libraries(JLLVMCompiler PUBLIC JLLVMObject JLLVMUnwinder LLVMCore PRIVATE LLVMTargetParser)
+target_link_libraries(JLLVMCompiler PUBLIC JLLVMObject JLLVMUnwinder LLVMCore PRIVATE LLVMTargetParser JLLVMDebugInfo)
 

--- a/src/jllvm/compiler/CodeGenerator.hpp
+++ b/src/jllvm/compiler/CodeGenerator.hpp
@@ -39,7 +39,6 @@ class CodeGenerator
     const ClassObject& m_classObject;
     const ClassFile& m_classFile;
     llvm::IRBuilder<> m_builder;
-    llvm::DIBuilder m_debugBuilder;
     OperandStack m_operandStack;
     LocalVariables m_locals;
     llvm::DenseMap<std::uint16_t, BasicBlockData> m_basicBlocks;
@@ -132,20 +131,10 @@ public:
           m_classObject{*method.getClassObject()},
           m_classFile{*m_classObject.getClassFile()},
           m_builder{llvm::BasicBlock::Create(function->getContext(), "entry", function)},
-          m_debugBuilder{*function->getParent()},
           m_operandStack{m_builder, maxStack},
           m_locals{m_builder, maxLocals}
     {
     }
-
-    ~CodeGenerator()
-    {
-        m_debugBuilder.finalize();
-    }
-    CodeGenerator(const CodeGenerator&) = delete;
-    CodeGenerator& operator=(const CodeGenerator&) = delete;
-    CodeGenerator(CodeGenerator&&) = delete;
-    CodeGenerator& operator=(CodeGenerator&&) = delete;
 
     using PrologueGenFn =
         llvm::function_ref<void(llvm::IRBuilder<>& builder, LocalVariables& locals, OperandStack& operandStack,

--- a/src/jllvm/debuginfo/CMakeLists.txt
+++ b/src/jllvm/debuginfo/CMakeLists.txt
@@ -1,3 +1,15 @@
+# Copyright (C) 2023 The JLLVM Contributors.
+#
+# This file is part of JLLVM.
+#
+# JLLVM is free software; you can redistribute it and/or modify it under  the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3, or (at your option) any later version.
+#
+# JLLVM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with JLLVM; see the file LICENSE.txt.  If not
+# see <http://www.gnu.org/licenses/>.
 
 add_library(JLLVMDebugInfo TrivialDebugInfoBuilder.cpp)
 target_link_libraries(JLLVMDebugInfo PUBLIC LLVMCore LLVMSupport)

--- a/src/jllvm/debuginfo/CMakeLists.txt
+++ b/src/jllvm/debuginfo/CMakeLists.txt
@@ -1,3 +1,3 @@
 
 add_library(JLLVMDebugInfo TrivialDebugInfoBuilder.cpp)
-target_link_libraries(JLLVMDebugInfo LLVMCore)
+target_link_libraries(JLLVMDebugInfo PUBLIC LLVMCore LLVMSupport)

--- a/src/jllvm/debuginfo/CMakeLists.txt
+++ b/src/jllvm/debuginfo/CMakeLists.txt
@@ -1,0 +1,3 @@
+
+add_library(JLLVMDebugInfo TrivialDebugInfoBuilder.cpp)
+target_link_libraries(JLLVMDebugInfo LLVMCore)

--- a/src/jllvm/debuginfo/TrivialDebugInfoBuilder.cpp
+++ b/src/jllvm/debuginfo/TrivialDebugInfoBuilder.cpp
@@ -19,7 +19,7 @@ jllvm::TrivialDebugInfoBuilder::TrivialDebugInfoBuilder(llvm::Function* function
     : m_debugBuilder(*function->getParent())
 {
     llvm::DIFile* file = m_debugBuilder.createFile(".", ".");
-    unsigned runtimeVersion = 1;
+    constexpr unsigned runtimeVersion = 1;
     m_debugBuilder.createCompileUnit(llvm::dwarf::DW_LANG_Java, file, /*Producer=*/"JLLVM", /*isOptimized=*/true,
                                      /*Flags=*/"", runtimeVersion);
 

--- a/src/jllvm/debuginfo/TrivialDebugInfoBuilder.cpp
+++ b/src/jllvm/debuginfo/TrivialDebugInfoBuilder.cpp
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 The JLLVM Contributors.
+//
+// This file is part of JLLVM.
+//
+// JLLVM is free software; you can redistribute it and/or modify it under  the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 3, or (at your option) any later version.
+//
+// JLLVM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with JLLVM; see the file LICENSE.txt.  If not
+// see <http://www.gnu.org/licenses/>.
+
+#include "TrivialDebugInfoBuilder.hpp"
+
+#include <llvm/IR/Function.h>
+
+jllvm::TrivialDebugInfoBuilder::TrivialDebugInfoBuilder(llvm::Function* function)
+    : m_debugBuilder(*function->getParent())
+{
+    llvm::DIFile* file = m_debugBuilder.createFile(".", ".");
+    unsigned runtimeVersion = 1;
+    m_debugBuilder.createCompileUnit(llvm::dwarf::DW_LANG_Java, file, /*Producer=*/"JLLVM", /*isOptimized=*/true,
+                                     /*Flags=*/"", runtimeVersion);
+
+    m_subProgram = m_debugBuilder.createFunction(
+        file, /*Name=*/function->getName(), /*LinkageName=*/function->getName(), file, /*LineNo=*/1,
+        m_debugBuilder.createSubroutineType(m_debugBuilder.getOrCreateTypeArray({})), /*ScopeLine=*/1,
+        /*Flags=*/llvm::DINode::FlagZero, /*SPFlags=*/llvm::DISubprogram::SPFlagDefinition);
+
+    function->setSubprogram(m_subProgram);
+}

--- a/src/jllvm/debuginfo/TrivialDebugInfoBuilder.hpp
+++ b/src/jllvm/debuginfo/TrivialDebugInfoBuilder.hpp
@@ -1,4 +1,3 @@
-
 // Copyright (C) 2023 The JLLVM Contributors.
 //
 // This file is part of JLLVM.

--- a/src/jllvm/debuginfo/TrivialDebugInfoBuilder.hpp
+++ b/src/jllvm/debuginfo/TrivialDebugInfoBuilder.hpp
@@ -1,0 +1,63 @@
+
+// Copyright (C) 2023 The JLLVM Contributors.
+//
+// This file is part of JLLVM.
+//
+// JLLVM is free software; you can redistribute it and/or modify it under  the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 3, or (at your option) any later version.
+//
+// JLLVM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with JLLVM; see the file LICENSE.txt.  If not
+// see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <llvm/IR/DIBuilder.h>
+
+namespace jllvm
+{
+
+/// Class used to build the bare minimum of useful debug info for a single function module.
+/// It creates a 'DISubprogram' for a given function, using the symbol name of the function as name of the function.
+class TrivialDebugInfoBuilder
+{
+    llvm::DIBuilder m_debugBuilder;
+    llvm::DISubprogram* m_subProgram;
+
+public:
+
+    /// Constructs the builder and creates debug info for 'function'.
+    TrivialDebugInfoBuilder(llvm::Function* function);
+
+    ~TrivialDebugInfoBuilder()
+    {
+        finalize();
+    }
+
+    TrivialDebugInfoBuilder(const TrivialDebugInfoBuilder&) = delete;
+    TrivialDebugInfoBuilder(TrivialDebugInfoBuilder&&) = delete;
+    TrivialDebugInfoBuilder& operator=(const TrivialDebugInfoBuilder&) = delete;
+    TrivialDebugInfoBuilder& operator=(TrivialDebugInfoBuilder&&) = delete;
+
+    /// Returns a noop debug info location for use by 'IRBuilder'.
+    llvm::DILocation* getNoopLoc() const
+    {
+        return llvm::DILocation::get(m_subProgram->getContext(), 1, 1, m_subProgram);
+    }
+
+    /// Finalizes debug info. This method must be called at the end of constructing the LLVM module.
+    /// This method is also called by the destructor.
+    void finalize()
+    {
+        if (!m_subProgram)
+        {
+            return;
+        }
+        m_debugBuilder.finalizeSubprogram(std::exchange(m_subProgram, nullptr));
+        m_debugBuilder.finalize();
+    }
+};
+
+} // namespace jllvm

--- a/src/jllvm/materialization/CMakeLists.txt
+++ b/src/jllvm/materialization/CMakeLists.txt
@@ -22,4 +22,5 @@ add_library(JLLVMMaterialization
         ByteCodeOSRCompileLayer.cpp
         InterpreterOSRLayer.cpp
         InterpreterEntry.cpp)
-target_link_libraries(JLLVMMaterialization PUBLIC JLLVMCompiler JLLVMObject LLVMCore LLVMOrcJIT PRIVATE LLVMTargetParser)
+target_link_libraries(JLLVMMaterialization PUBLIC JLLVMCompiler JLLVMDebugInfo JLLVMObject LLVMCore LLVMOrcJIT
+        PRIVATE LLVMTargetParser)


### PR DESCRIPTION
Various methods for generating stubs with LLVM IR where either missing debug info or repeating lots of code to construct the minimum amount of debug info required.

This PR extracts the `TrivialDebugInfoBuilder` out of code generation and makes it available as class and library for reuse.

Looking at the callstack in the debugger is also improved by this PR as methods that previously didn't emit debug info now do.

![Screenshot from 2023-12-09 12-06-06](https://github.com/JLLVM/JLLVM/assets/6625526/7c2976b5-bc8f-46a6-9ee2-f0e955bebda8)
