### PR TITLE
[interpreter] implement arithmetic operations

### DIFF
--- a/src/jllvm/class/ByteCodeIterator.hpp
+++ b/src/jllvm/class/ByteCodeIterator.hpp
@@ -170,6 +170,22 @@ struct OneOf : detail::MechanismForBase<Args...>::Base
     }
 };
 
+/// Satisfied when 'T' is an add operation.
+template <class T>
+concept IsAdd = llvm::is_one_of<T, IAdd, FAdd, DAdd, LAdd>::value;
+
+/// Satisfied when 'T' is a sub operation.
+template <class T>
+concept IsSub = llvm::is_one_of<T, ISub, FSub, DSub, LSub>::value;
+
+/// Satisfied when 'T' is a neg operation.
+template <class T>
+concept IsNeg = llvm::is_one_of<T, INeg, FNeg, DNeg, LNeg>::value;
+
+/// Satisfied when 'T' is a mul operation.
+template <class T>
+concept IsMul = llvm::is_one_of<T, IMul, FMul, DMul, LMul>::value;
+
 /// Satisfied when 'T' is a load operation.
 template <class T>
 concept IsLoad = llvm::is_one_of<T, ILoad, ALoad, FLoad, DLoad, LLoad>::value;
@@ -212,8 +228,8 @@ concept IsStore3 = llvm::is_one_of<T, IStore3, AStore3, FStore3, DStore3, LStore
 
 /// Satisfied when 'T' operates on 'int' operands.
 template <class T>
-concept OperatesOnIntegers =
-    llvm::is_one_of<T, ILoad, ILoad0, ILoad1, ILoad2, ILoad3, IStore, IStore0, IStore1, IStore2, IStore3>::value;
+concept OperatesOnIntegers = llvm::is_one_of<T, ILoad, ILoad0, ILoad1, ILoad2, ILoad3, IStore, IStore0, IStore1,
+                                             IStore2, IStore3, IAdd, ISub, IMul, IDiv, IRem, IInc, INeg>::value;
 
 /// Satisfied when 'T' operates on reference operands.
 template <class T>
@@ -222,17 +238,17 @@ concept OperatesOnReferences =
 
 /// Satisfied when 'T' operates on 'float' operands.
 template <class T>
-concept OperatesOnFloat =
-    llvm::is_one_of<T, FLoad, FLoad0, FLoad1, FLoad2, FLoad3, FStore, FStore0, FStore1, FStore2, FStore3>::value;
+concept OperatesOnFloat = llvm::is_one_of<T, FLoad, FLoad0, FLoad1, FLoad2, FLoad3, FStore, FStore0, FStore1, FStore2,
+                                          FStore3, FAdd, FSub, FMul, FDiv, FRem, FNeg>::value;
 
 /// Satisfied when 'T' operates on 'double' operands.
 template <class T>
-concept OperatesOnDouble =
-    llvm::is_one_of<T, DLoad, DLoad0, DLoad1, DLoad2, DLoad3, DStore, DStore0, DStore1, DStore2, DStore3>::value;
+concept OperatesOnDouble = llvm::is_one_of<T, DLoad, DLoad0, DLoad1, DLoad2, DLoad3, DStore, DStore0, DStore1, DStore2,
+                                           DStore3, DAdd, DSub, DMul, DDiv, DRem, DNeg>::value;
 
 /// Satisfied when 'T' operates on 'long' operands.
 template <class T>
-concept OperatesOnLong =
-    llvm::is_one_of<T, LLoad, LLoad0, LLoad1, LLoad2, LLoad3, LStore, LStore0, LStore1, LStore2, LStore3>::value;
+concept OperatesOnLong = llvm::is_one_of<T, LLoad, LLoad0, LLoad1, LLoad2, LLoad3, LStore, LStore0, LStore1, LStore2,
+                                         LStore3, LAdd, LSub, LMul, LDiv, LRem, LNeg>::value;
 
 } // namespace jllvm


### PR DESCRIPTION
This PR reuses the `MultiTypeImpls` class to implement the basic arithmetic operations generically on all types supported by the JVM. Exceptions to this rule are division and remainder, which have differing semantics in the case of `rhs == 0` among other things.

I opted not to implement throwing an `ArithmeticException` yet as it is not done in the JIT yet either. Implementing both at the same time makes the most sense to me.