### PR TITLE
[codegen] Correctly deduce local variable types in exception handlers

### DIFF
--- a/src/jllvm/class/ByteCodeIterator.hpp
+++ b/src/jllvm/class/ByteCodeIterator.hpp
@@ -251,4 +251,13 @@ template <class T>
 concept OperatesOnLong = llvm::is_one_of<T, LLoad, LLoad0, LLoad1, LLoad2, LLoad3, LStore, LStore0, LStore1, LStore2,
                                          LStore3, LAdd, LSub, LMul, LDiv, LRem, LNeg>::value;
 
+/// Satisfied when 'T' may throw an exception.
+template <class T>
+concept MayThrowException =
+    llvm::is_one_of<T, AALoad, AAStore, ANewArray, AReturn, ArrayLength, AThrow, BALoad, BAStore, CALoad, CAStore,
+                    CheckCast, DALoad, DAStore, DReturn, FALoad, FAStore, FReturn, GetField, GetStatic, IALoad, IAStore,
+                    IDiv, InstanceOf, InvokeDynamic, InvokeInterface, InvokeSpecial, InvokeStatic, InvokeVirtual, IRem,
+                    IReturn, LALoad, LAStore, LDC, LDCW, LDC2W, LDiv, LRem, LReturn, MonitorEnter, MonitorExit,
+                    MultiANewArray, New, NewArray, PutField, PutStatic, Return, SALoad, SAStore>::value;
+
 } // namespace jllvm

--- a/src/jllvm/class/ClassFile.cpp
+++ b/src/jllvm/class/ClassFile.cpp
@@ -253,11 +253,14 @@ Code Code::parse(llvm::ArrayRef<char> bytes)
     result.m_code = llvm::ArrayRef(rawString.begin(), rawString.end());
     auto exceptionTableCount = consume<std::uint16_t>(bytes);
     result.m_exceptionTable.resize(exceptionTableCount);
-    for (auto& iter : result.m_exceptionTable)
+    for (auto&& [index, iter] : llvm::enumerate(result.m_exceptionTable))
     {
         iter = {consume<std::uint16_t>(bytes), consume<std::uint16_t>(bytes), consume<std::uint16_t>(bytes),
                 consume<PoolIndex<ClassInfo>>(bytes)};
+        // The interval tree is inclusive while the exception table is exclusive.
+        result.m_intervalTree.insert(iter.startPc, iter.endPc - 1, index);
     }
+    result.m_intervalTree.create();
     return result;
 }
 

--- a/src/jllvm/compiler/CodeGeneratorUtils.hpp
+++ b/src/jllvm/compiler/CodeGeneratorUtils.hpp
@@ -15,6 +15,7 @@
 
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/Instructions.h>
+#include <llvm/ADT/SetVector.h>
 
 #include <jllvm/class/ByteCodeIterator.hpp>
 #include <jllvm/object/ClassLoader.hpp>
@@ -58,8 +59,7 @@ private:
     llvm::LLVMContext& m_context;
     const ClassFile& m_classFile;
     const Code& m_code;
-    std::vector<std::uint16_t> m_offsetStack;
-    llvm::DenseMap<std::uint16_t, std::vector<std::uint16_t>> m_exceptionHandlerStarts;
+    llvm::SetVector<std::uint16_t> m_offsetStack;
     std::vector<JVMType> m_locals;
     std::vector<JVMType> m_typeStack;
     llvm::DenseMap<std::uint16_t, std::uint16_t> m_returnAddressToSubroutineMap;

--- a/src/jllvm/compiler/Compiler.cpp
+++ b/src/jllvm/compiler/Compiler.cpp
@@ -28,10 +28,8 @@ llvm::Function* jllvm::compileMethod(llvm::Module& module, const Method& method)
     addJavaMethodMetadata(function, &method, JavaMethodMetadata::Kind::JIT);
     applyABIAttributes(function);
 
-    auto* code = methodInfo.getAttributes().find<Code>();
-    assert(code && "method to compile must have a code attribute");
     compileMethodBody(
-        function, method, *code,
+        function, method,
         [&](llvm::IRBuilder<>& builder, LocalVariables& locals, OperandStack&, const ByteCodeTypeChecker::TypeInfo&)
         {
             // Arguments are put into the locals. According to the specification, i64s and doubles are
@@ -68,13 +66,10 @@ llvm::Function* jllvm::compileOSRMethod(llvm::Module& module, std::uint16_t offs
     addJavaMethodMetadata(function, &method, JavaMethodMetadata::Kind::JIT);
     applyABIAttributes(function);
 
-    auto* code = methodInfo.getAttributes().find<Code>();
-    assert(code && "method to compile must have a code attribute");
-
     llvm::Value* osrState = function->getArg(0);
 
     compileMethodBody(
-        function, method, *code,
+        function, method,
         [&](llvm::IRBuilder<>& builder, LocalVariables& locals, OperandStack& operandStack,
             const ByteCodeTypeChecker::TypeInfo& typeInfo)
         {

--- a/tests/Compiler/locals-types-dataflow-merge.j
+++ b/tests/Compiler/locals-types-dataflow-merge.j
@@ -1,5 +1,6 @@
 ; RUN: jasmin %s -d %t
 ; RUN: jllvm-jvmc --method "test:()V" %t/Test.class | FileCheck %s
+; RUN: jllvm-jvmc --method "test:()V" --osr 26 %t/Test.class | FileCheck --check-prefix=EXC %s
 
 .class public Test
 .super java/lang/Object
@@ -29,9 +30,9 @@
     istore_0
     fconst_1
     fstore_1
+start:
     invokestatic Test/random()I
     ifne handler
-start:
     aconst_null
     astore_1
     invokestatic Test/random()I
@@ -44,11 +45,17 @@ handler:
     ; CHECK: call void @"Static Call to Test.deopt:()V"
     ; CHECK-SAME: "deopt"(i16 {{[0-9]+}}, i16 2, i32 {{.*}}, i8 poison, i64 0)
     invokestatic Test/deopt()V
+    aconst_null
+    astore_0
     return
 endHandler:
     pop
+    ; EXC: call void @"Static Call to Test.deopt:()V"
+    ; EXC-SAME: "deopt"(i16 {{[0-9]+}}, i16 2, i8 poison, i8 poison)
+    invokestatic Test/deopt()V
+endFunction:
     return
 
-.catch all from handler to endHandler using endHandler
+.catch all from start to endFunction using endHandler
 
 .end method

--- a/tests/Compiler/locals-types-dataflow-merge.j
+++ b/tests/Compiler/locals-types-dataflow-merge.j
@@ -51,7 +51,7 @@ handler:
 endHandler:
     pop
     ; EXC: call void @"Static Call to Test.deopt:()V"
-    ; EXC-SAME: "deopt"(i16 {{[0-9]+}}, i16 2, i8 poison, i8 poison)
+    ; EXC-SAME: "deopt"(i16 {{[0-9]+}}, i16 2, i8 poison, i8 poison, i64 0)
     invokestatic Test/deopt()V
 endFunction:
     return


### PR DESCRIPTION
The bytecode type checker was only propagating types of local variables to exception handler at the start of the exception handler. This would lead to incorrectly deducing a type of a local variable where it should be inaccessible instead. This PR fixes the issue by propagating local variable types for every operation that may throw an exception. As a side-effect of this change, `Code` now also builds an interval tree for conveniently and quickly finding all exception handlers for a given bytecode offset.