### PR TITLE
[vm] Add support for handling `ConstantValue` attribute of fields

### DIFF
--- a/src/jllvm/class/ClassFile.cpp
+++ b/src/jllvm/class/ClassFile.cpp
@@ -219,13 +219,19 @@ jllvm::ClassFile jllvm::ClassFile::parseFromFile(llvm::ArrayRef<char> bytes, llv
                   [&]()
                   { return consume<PoolIndex<ClassInfo>>(bytes).resolve(result)->nameIndex.resolve(result)->text; });
 
-    result.m_fields.resize(consume<std::uint16_t>(bytes));
-    std::generate(result.m_fields.begin(), result.m_fields.end(),
-                  [&]() { return parseFieldOrMethodInfo<FieldInfo>(bytes, result); });
+    auto fieldCount = consume<std::uint16_t>(bytes);
+    result.m_fields.reserve(fieldCount);
+    for (std::size_t i = 0; i < fieldCount; i++)
+    {
+        result.m_fields.push_back(parseFieldOrMethodInfo<FieldInfo>(bytes, result));
+    }
 
-    result.m_methods.resize(consume<std::uint16_t>(bytes));
-    std::generate(result.m_methods.begin(), result.m_methods.end(),
-                  [&]() { return parseFieldOrMethodInfo<MethodInfo>(bytes, result); });
+    auto methodCount = consume<std::uint16_t>(bytes);
+    result.m_methods.reserve(methodCount);
+    for (std::size_t i = 0; i < methodCount; i++)
+    {
+        result.m_methods.push_back(parseFieldOrMethodInfo<MethodInfo>(bytes, result));
+    }
 
     auto attributeCount = consume<std::uint16_t>(bytes);
     for (std::size_t i = 0; i < attributeCount; i++)

--- a/src/jllvm/class/ClassFile.hpp
+++ b/src/jllvm/class/ClassFile.hpp
@@ -357,13 +357,6 @@ class FieldInfo
     AttributeMap m_attributes;
 
 public:
-    FieldInfo() = default;
-    ~FieldInfo() = default;
-    FieldInfo(const FieldInfo&) = delete;
-    FieldInfo& operator=(const FieldInfo&) = delete;
-    FieldInfo(FieldInfo&&) = default;
-    FieldInfo& operator=(FieldInfo&&) = default;
-
     FieldInfo(AccessFlag accessFlags, PoolIndex<Utf8Info> nameIndex, PoolIndex<Utf8Info> descriptorIndex,
               AttributeMap&& attributes)
         : m_accessFlags(accessFlags),
@@ -407,13 +400,6 @@ class MethodInfo
     AttributeMap m_attributes;
 
 public:
-    MethodInfo() = default;
-    ~MethodInfo() = default;
-    MethodInfo(const MethodInfo&) = delete;
-    MethodInfo& operator=(const MethodInfo&) = delete;
-    MethodInfo(MethodInfo&&) = default;
-    MethodInfo& operator=(MethodInfo&&) = default;
-
     MethodInfo(AccessFlag accessFlags, PoolIndex<Utf8Info> nameIndex, PoolIndex<Utf8Info> descriptorIndex,
                AttributeMap&& attributes)
         : m_accessFlags(accessFlags),

--- a/src/jllvm/materialization/ClassObjectStubDefinitionsGenerator.cpp
+++ b/src/jllvm/materialization/ClassObjectStubDefinitionsGenerator.cpp
@@ -106,7 +106,8 @@ llvm::Error jllvm::ClassObjectStubDefinitionsGenerator::tryToGenerate(llvm::orc:
         }
         if (auto* stringGlobal = get_if<DemangledStringGlobal>(&demangleVariant))
         {
-            generated[symbol] = llvm::JITEvaluatedSymbol::fromPointer(m_stringInterner.intern(stringGlobal->contents));
+            generated[symbol] =
+                llvm::JITEvaluatedSymbol::fromPointer(m_classLoader.getStringInterner().intern(stringGlobal->contents));
             continue;
         }
 

--- a/src/jllvm/materialization/ClassObjectStubDefinitionsGenerator.hpp
+++ b/src/jllvm/materialization/ClassObjectStubDefinitionsGenerator.hpp
@@ -19,8 +19,6 @@
 
 #include <jllvm/object/ClassLoader.hpp>
 
-#include "jllvm/object/StringInterner.hpp"
-
 namespace jllvm
 {
 
@@ -36,14 +34,13 @@ class ClassObjectStubDefinitionsGenerator : public llvm::orc::DefinitionGenerato
     llvm::orc::JITDylib& m_impl;
     llvm::DataLayout m_dataLayout;
     ClassLoader& m_classLoader;
-    StringInterner& m_stringInterner;
     ClassObject* m_objectClassCache = nullptr;
 
 public:
     explicit ClassObjectStubDefinitionsGenerator(llvm::orc::IndirectStubsManager& stubsManager,
                                                  llvm::orc::IRLayer& baseLayer, const llvm::DataLayout& dataLayout,
                                                  const llvm::orc::JITDylibSearchOrder& linkOrder,
-                                                 ClassLoader& classLoader, StringInterner& stringInterner)
+                                                 ClassLoader& classLoader)
         : m_stubsManager{stubsManager},
           m_callbackManager{llvm::cantFail(llvm::orc::createLocalCompileCallbackManager(
               llvm::Triple(LLVM_HOST_TRIPLE), baseLayer.getExecutionSession(),
@@ -51,8 +48,7 @@ public:
           m_baseLayer{baseLayer},
           m_impl{m_baseLayer.getExecutionSession().createBareJITDylib("<classObjectStubs>")},
           m_dataLayout{dataLayout},
-          m_classLoader{classLoader},
-          m_stringInterner{stringInterner}
+          m_classLoader{classLoader}
     {
         m_impl.setLinkOrder(linkOrder);
     }

--- a/src/jllvm/object/StringInterner.cpp
+++ b/src/jllvm/object/StringInterner.cpp
@@ -13,12 +13,6 @@
 
 #include "StringInterner.hpp"
 
-void jllvm::StringInterner::loadStringClass()
-{
-    m_stringClass = &m_classLoader.forName(stringDescriptor);
-    checkStructure();
-}
-
 void jllvm::StringInterner::checkStructure()
 {
 #ifdef NDEBUG
@@ -56,8 +50,9 @@ void jllvm::StringInterner::checkStructure()
 
 jllvm::String* jllvm::StringInterner::createString(llvm::ArrayRef<std::uint8_t> buffer, jllvm::CompactEncoding encoding)
 {
-    auto* value =
-        Array<std::uint8_t>::create(m_allocator, m_classLoader.forNameLoaded(byteArrayDescriptor), buffer.size());
+    assert(m_stringClass && "String class object must be initialized");
+
+    auto* value = Array<std::uint8_t>::create(m_allocator, m_byteArrayClass, buffer.size());
     llvm::copy(buffer, value->begin());
 
     auto* string = new (m_allocator.Allocate(sizeof(String), alignof(String)))

--- a/src/jllvm/object/StringInterner.hpp
+++ b/src/jllvm/object/StringInterner.hpp
@@ -13,11 +13,7 @@
 
 #pragma once
 
-#include <llvm/Support/raw_ostream.h>
-
-#include <jllvm/support/Encoding.hpp>
-
-#include "ClassLoader.hpp"
+#include "ClassObject.hpp"
 
 namespace jllvm
 {
@@ -28,21 +24,20 @@ class StringInterner
 
     llvm::DenseMap<std::pair<llvm::ArrayRef<std::uint8_t>, std::uint8_t>, String*> m_contentToStringMap;
     llvm::BumpPtrAllocator m_allocator;
-    ClassLoader& m_classLoader;
-    ClassObject* m_stringClass{nullptr};
+    ClassObject* m_byteArrayClass{};
+    ClassObject* m_stringClass{};
 
     void checkStructure();
 
     String* createString(llvm::ArrayRef<std::uint8_t> buffer, jllvm::CompactEncoding encoding);
 
 public:
-    StringInterner(ClassLoader& classLoader) : m_classLoader(classLoader) {}
-
-    void loadStringClass();
-
-    ClassObject& getStringClass() const
+    template <std::invocable<FieldType> F>
+    void initialize(F&& initializer)
     {
-        return *m_stringClass;
+        m_byteArrayClass = initializer(byteArrayDescriptor);
+        m_stringClass = initializer(stringDescriptor);
+        checkStructure();
     }
 
     String* intern(llvm::StringRef utf8String);

--- a/src/jllvm/object/StringInterner.hpp
+++ b/src/jllvm/object/StringInterner.hpp
@@ -32,6 +32,8 @@ class StringInterner
     String* createString(llvm::ArrayRef<std::uint8_t> buffer, jllvm::CompactEncoding encoding);
 
 public:
+    /// Initialize the interner by loading the required Java classes. Has to be called before the first call to 'intern'.
+    /// 'initializer' must return a pointer to a fully initialized class object for 'FieldType' of its argument.
     template <std::invocable<FieldType> F>
     void initialize(F&& initializer)
     {

--- a/src/jllvm/vm/JIT.hpp
+++ b/src/jllvm/vm/JIT.hpp
@@ -35,7 +35,6 @@
 #include <jllvm/materialization/JNIImplementationLayer.hpp>
 #include <jllvm/materialization/LambdaMaterialization.hpp>
 #include <jllvm/object/ClassLoader.hpp>
-#include <jllvm/object/StringInterner.hpp>
 #include <jllvm/unwind/Unwinder.hpp>
 
 #include <memory>
@@ -79,7 +78,6 @@ class JIT
     std::unique_ptr<llvm::orc::IndirectStubsManager> m_externalStubsManager;
 
     ClassLoader& m_classLoader;
-    StringInterner& m_stringInterner;
 
     llvm::DataLayout m_dataLayout;
     ExecutionMode m_executionMode;
@@ -100,11 +98,11 @@ class JIT
 
     JIT(std::unique_ptr<llvm::orc::ExecutionSession>&& session, std::unique_ptr<llvm::orc::EPCIndirectionUtils>&& epciu,
         llvm::orc::JITTargetMachineBuilder&& builder, llvm::DataLayout&& layout, ClassLoader& classLoader,
-        GarbageCollector& gc, StringInterner& stringInterner, void* jniFunctions, ExecutionMode executionMode);
+        GarbageCollector& gc, void* jniFunctions, ExecutionMode executionMode);
 
 public:
-    static jllvm::JIT create(ClassLoader& classLoader, GarbageCollector& gc, StringInterner& stringInterner,
-                             void* jniFunctions, ExecutionMode executionMode);
+    static jllvm::JIT create(ClassLoader& classLoader, GarbageCollector& gc, void* jniFunctions,
+                             ExecutionMode executionMode);
 
     ~JIT();
 

--- a/src/jllvm/vm/OSRState.hpp
+++ b/src/jllvm/vm/OSRState.hpp
@@ -84,7 +84,7 @@ class OSRState
         m_buffer = std::make_unique<std::uint64_t[]>(calculateJITBufferSize(numLocals, numOperandStack));
 
         auto outIter = llvm::copy(std::forward<decltype(locals)>(locals), m_buffer.get());
-        outIter = llvm::copy(std::forward<decltype(operandStack)>(operandStack), outIter);
+        llvm::copy(std::forward<decltype(operandStack)>(operandStack), outIter);
     }
 
 public:

--- a/tests/Execution/constant-value-fields.j
+++ b/tests/Execution/constant-value-fields.j
@@ -1,0 +1,57 @@
+; RUN: jasmin %s -d %t
+; RUN: jllvm -Xjit %t/Test.class
+; RUN: jllvm -Xint %t/Test.class
+
+.class public Test
+.super java/lang/Object
+
+.field public static final i I = 1
+
+.field public static final f F = 2.0f
+
+.field public static final l J = 3000000000
+
+.field public static final d D = 4.0d
+
+.field public static final s Ljava/lang/String; = "5"
+
+.method public <init>()V
+    aload_0
+    invokespecial java/lang/Object/<init>()V
+    return
+.end method
+
+.method public static native print(I)V
+.end method
+
+.method public static native print(F)V
+.end method
+
+.method public static native print(J)V
+.end method
+
+.method public static native print(D)V
+.end method
+
+.method public static native print(Ljava/lang/String;)V
+.end method
+
+.method public static main([Ljava/lang/String;)V
+.limit stack 2
+    getstatic     Test/i I
+    ; CHECK: 1
+    invokestatic  Test/print(I)V
+    getstatic     Test/f F
+    ; CHECK: 2
+    invokestatic  Test/print(F)V
+    getstatic     Test/l J
+    ; CHECK: 3000000000
+    invokestatic  Test/print(J)V
+    getstatic     Test/d D
+    ; CHECK: 4
+    invokestatic  Test/print(D)V
+    getstatic     Test/s Ljava/lang/String;
+    ; CHECK: 5
+    invokestatic  Test/print(Ljava/lang/String;)V
+    return
+.end method

--- a/tools/jllvm-jvmc/main.cpp
+++ b/tools/jllvm-jvmc/main.cpp
@@ -130,6 +130,8 @@ int main(int argc, char** argv)
 
     loader.loadBootstrapClasses();
 
+    stringInterner.initialize([&](jllvm::FieldType fieldType) { return &loader.forName(fieldType); });
+
     auto buffer = llvm::MemoryBuffer::getFile(inputFile);
     if (!buffer)
     {

--- a/tools/jllvm-jvmc/main.cpp
+++ b/tools/jllvm-jvmc/main.cpp
@@ -122,8 +122,10 @@ int main(int argc, char** argv)
     llvm::sys::fs::make_absolute(inputFile);
     classPath.emplace_back(llvm::sys::path::parent_path(inputFile));
 
+    jllvm::StringInterner stringInterner;
+
     jllvm::ClassLoader loader(
-        std::move(classPath), [](jllvm::ClassObject&) {},
+        stringInterner, std::move(classPath), [](jllvm::ClassObject&) {},
         [&]() -> void** { return new (allocator.Allocate<void*>()) void* {}; });
 
     loader.loadBootstrapClasses();


### PR DESCRIPTION
This PR adds support for reading the `ConstantValue` attribute of `FieldInfo` structs of classfiles. It also implements the required behavior of the value of static fields with the attribute to have their initial value set to the value indicated by the attribute.