### PR TITLE
[native] Implement `Object.clone`

### DIFF
--- a/src/jllvm/compiler/CodeGenerator.cpp
+++ b/src/jllvm/compiler/CodeGenerator.cpp
@@ -464,9 +464,9 @@ bool CodeGenerator::generateInstruction(ByteCodeOp operation)
             auto index = PoolIndex<ClassInfo>{aNewArray.index};
             llvm::Value* count = m_operandStack.pop_back();
 
-            llvm::Value* classObject =
-                getClassObject(getOffset(operation),
-                               ArrayType(ObjectType(index.resolve(m_classFile)->nameIndex.resolve(m_classFile)->text)));
+            llvm::Value* classObject = getClassObject(
+                getOffset(operation),
+                ArrayType(FieldType::fromMangled(index.resolve(m_classFile)->nameIndex.resolve(m_classFile)->text)));
 
             generateNegativeArraySizeCheck(getOffset(operation), count);
 

--- a/src/jllvm/object/Object.hpp
+++ b/src/jllvm/object/Object.hpp
@@ -213,6 +213,8 @@ struct Throwable : ObjectInterface
     Array<Object*>* stackTrace = nullptr;
     std::int32_t depth{};
     Object* suppressedExceptions = nullptr;
+
+    explicit Throwable(const ClassObject* classObject) : header(classObject) {}
 };
 
 static_assert(std::is_standard_layout_v<Throwable>);

--- a/src/jllvm/vm/native/Lang.cpp
+++ b/src/jllvm/vm/native/Lang.cpp
@@ -15,19 +15,19 @@
 
 #include <llvm/Support/Endian.h>
 
-jllvm::Object* jllvm::lang::ObjectModel::clone()
+jllvm::ObjectInterface* jllvm::lang::ObjectModel::clone()
 {
     const ClassObject* thisClass = javaThis->getClass();
     ClassLoader& classLoader = virtualMachine.getClassLoader();
     GarbageCollector& garbageCollector = virtualMachine.getGC();
 
-    auto arrayClone = [&]<class T = Object*>(T = {})
+    auto arrayClone = [&]<class T = Object*>(T = {})->ObjectInterface*
     {
         auto original = static_cast<GCRootRef<Array<T>>>(javaThis);
         auto* clone = garbageCollector.allocate<Array<T>>(original->getClass(), original->size());
         llvm::copy(*original, clone->begin());
 
-        return static_cast<Object*>(static_cast<ObjectInterface*>(clone));
+        return clone;
     };
 
     if (thisClass->isArray())

--- a/src/jllvm/vm/native/Lang.hpp
+++ b/src/jllvm/vm/native/Lang.hpp
@@ -47,9 +47,11 @@ public:
         // Noop while we are single threaded.
     }
 
+    Object* clone();
+
     constexpr static llvm::StringLiteral className = "java/lang/Object";
     constexpr static auto methods =
-        std::make_tuple(&ObjectModel::hashCode, &ObjectModel::getClass, &ObjectModel::notifyAll);
+        std::make_tuple(&ObjectModel::hashCode, &ObjectModel::getClass, &ObjectModel::notifyAll, &ObjectModel::clone);
 };
 
 /// Model implementation for the native methods of Javas 'Class' class.

--- a/src/jllvm/vm/native/Lang.hpp
+++ b/src/jllvm/vm/native/Lang.hpp
@@ -47,7 +47,7 @@ public:
         // Noop while we are single threaded.
     }
 
-    Object* clone();
+    ObjectInterface* clone();
 
     constexpr static llvm::StringLiteral className = "java/lang/Object";
     constexpr static auto methods =

--- a/tests/Execution/object-clone.java
+++ b/tests/Execution/object-clone.java
@@ -1,0 +1,63 @@
+// RUN: rm -rf %t && split-file %s %t
+// RUN: cd %t && javac %t/Test.java -d %t
+
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
+
+//--- Test.java
+
+class Test
+{
+    public static native void print(boolean b);
+    public static native void print(String s);
+    public static native void print(int i);
+
+    public static void main(String[] args) throws Exception {
+        int arr1[] = {1, 2};
+        int arr2[] = arr1.clone();
+        // CHECK: 0
+        print(arr1 == arr2);
+        arr1[1]++;
+        // CHECK: 2
+        print(arr2[1]);
+
+        int arr3[][] = {{1,2}, null};
+        int arr4[][] = arr3.clone();
+        // CHECK: 1
+        print(arr3[0] == arr4[0]);
+        // CHECK: 1
+        print(arr3[1] == arr4[1]);
+
+        try
+        {
+            new Test().clone();
+        }
+        catch(CloneNotSupportedException e)
+        {
+            // CHECK: Test not Cloneable
+            print("Test not Cloneable");
+        }
+
+        var o1 = new Other();
+
+        // CHECK-NOT: java.lang.CloneNotSupportedException:
+        var o2 = (Other) o1.clone();
+
+        // CHECK: 0
+        print(o1 == o2);
+        o1.i++;
+        // CHECK: 5
+        print(o2.i);
+    }
+
+    public Object clone() throws CloneNotSupportedException {
+        return super.clone();
+    }
+}
+
+//--- Other.java
+
+public class Other extends Test implements Cloneable
+{
+    public int i = 5;
+}


### PR DESCRIPTION
This PR implements `Object.clone` to be able to clone array required by #255.
It also fixes a bug in loading the class object for `anewarray`  in `CodeGenerator`.