### PR TITLE
[interpreter] Implement field accesses

### DIFF
--- a/src/jllvm/object/ClassLoader.cpp
+++ b/src/jllvm/object/ClassLoader.cpp
@@ -152,25 +152,7 @@ jllvm::ClassObject& jllvm::ClassLoader::add(std::unique_ptr<llvm::MemoryBuffer>&
             continue;
         }
 
-        auto fieldSizeAndAlignment = match(
-            fieldInfo.getDescriptor(classFile),
-            [](BaseType baseType) -> std::size_t
-            {
-                switch (baseType.getValue())
-                {
-                    case BaseType::Byte: return 1;
-                    case BaseType::Char: return 2;
-                    case BaseType::Double: return sizeof(double);
-                    case BaseType::Float: return sizeof(float);
-                    case BaseType::Int: return 4;
-                    case BaseType::Long: return 8;
-                    case BaseType::Short: return 2;
-                    case BaseType::Boolean: return 1;
-                    case BaseType::Void: break;
-                }
-                llvm_unreachable("Field can't be void");
-            },
-            [](const ObjectType&) { return sizeof(void*); }, [](const ArrayType&) { return sizeof(void*); });
+        std::size_t fieldSizeAndAlignment = fieldInfo.getDescriptor(classFile).sizeOf();
         instanceSize = llvm::alignTo(instanceSize, fieldSizeAndAlignment);
         fields.emplace_back(fieldInfo.getName(classFile), fieldInfo.getDescriptor(classFile),
                             instanceSize + sizeof(ObjectHeader), fieldInfo.getAccessFlags());

--- a/src/jllvm/object/ClassObject.hpp
+++ b/src/jllvm/object/ClassObject.hpp
@@ -623,6 +623,11 @@ public:
         return getField(fieldName, fieldType, &Field::isStatic);
     }
 
+    Field* getStaticField(llvm::StringRef fieldName, FieldType fieldType)
+    {
+        return getField(fieldName, fieldType, &Field::isStatic);
+    }
+
     /// Non-const and strongly typed variant of the above, retuning a 'StaticFieldRef' instead.
     template <class T>
     StaticFieldRef<T> getStaticField(llvm::StringRef fieldName, FieldType fieldType)

--- a/src/jllvm/vm/Interpreter.hpp
+++ b/src/jllvm/vm/Interpreter.hpp
@@ -166,6 +166,10 @@ class Interpreter
     /// Returns the class object referred to by 'index' within 'classFile', loading it if necessary.
     ClassObject* getClassObject(const ClassFile& classFile, PoolIndex<ClassInfo> index);
 
+    /// Returns the class object, field name and type referred to by 'index' within 'classFile'.
+    std::tuple<ClassObject*, llvm::StringRef, FieldType> getFieldInfo(const ClassFile& classFile,
+                                                                      PoolIndex<FieldRefInfo> index);
+
     /// Replaces the current interpreter frame with a compiled frame. This should only be called from within
     /// 'executeMethod' when called from the 'jllvm_interpreter' implementation in 'VirtualMachine'.
     [[noreturn]] void escapeToJIT();
@@ -180,6 +184,6 @@ public:
     /// offset are kept up-to-date during execution with the current local variables, operand stack and offset being
     /// executed.
     /// Returns the result of the method bitcast to an uint64_t.
-    std::uint64_t executeMethod(const Method& method, std::uint16_t& offset, InterpreterContext& context);
+    std::uint64_t executeMethod(const Method& putField, std::uint16_t& offset, InterpreterContext& context);
 };
 } // namespace jllvm

--- a/src/jllvm/vm/Interpreter.hpp
+++ b/src/jllvm/vm/Interpreter.hpp
@@ -184,6 +184,6 @@ public:
     /// offset are kept up-to-date during execution with the current local variables, operand stack and offset being
     /// executed.
     /// Returns the result of the method bitcast to an uint64_t.
-    std::uint64_t executeMethod(const Method& putField, std::uint16_t& offset, InterpreterContext& context);
+    std::uint64_t executeMethod(const Method& method, std::uint16_t& offset, InterpreterContext& context);
 };
 } // namespace jllvm

--- a/src/jllvm/vm/native/JDK.hpp
+++ b/src/jllvm/vm/native/JDK.hpp
@@ -113,18 +113,7 @@ public:
     std::uint32_t arrayIndexScale0(GCRootRef<ClassObject> arrayClass)
     {
         assert(arrayClass->isArray());
-        const ClassObject* componentType = arrayClass->getComponentType();
-        if (!componentType->isPrimitive())
-        {
-            return sizeof(Object*);
-        }
-
-        static llvm::DenseMap<llvm::StringRef, std::uint32_t> mapping = {
-            {"Z", sizeof(bool)},         {"C", sizeof(std::uint16_t)}, {"B", sizeof(std::int8_t)},
-            {"S", sizeof(std::int16_t)}, {"I", sizeof(std::int32_t)},  {"D", sizeof(double)},
-            {"F", sizeof(float)},        {"L", sizeof(std::int64_t)},
-        };
-        return mapping.lookup(componentType->getClassName());
+        return arrayClass->getComponentType()->getDescriptor().sizeOf();
     }
 
     std::uint32_t objectFieldOffset1(GCRootRef<ClassObject> clazz, GCRootRef<String> fieldName)


### PR DESCRIPTION
This PR implements accessing both instance and static fields of Java Objects. The implementation simply finds the given field in the class object and then uses memcpy to load the corresponding value according to the descriptor. The address is either formed via an offset from the object if an instance field or directly returned by the field if static.