### PR TITLE
[interpreter] Implement almost all array operations

### DIFF
--- a/src/jllvm/class/ByteCodeIterator.hpp
+++ b/src/jllvm/class/ByteCodeIterator.hpp
@@ -239,6 +239,10 @@ concept IsLoad2 = llvm::is_one_of<T, ILoad2, ALoad2, FLoad2, DLoad2, LLoad2>::va
 template <class T>
 concept IsLoad3 = llvm::is_one_of<T, ILoad3, ALoad3, FLoad3, DLoad3, LLoad3>::value;
 
+/// Satisfied when 'T' is an array load operation.
+template <class T>
+concept IsALoad = llvm::is_one_of<T, BALoad, CALoad, SALoad, IALoad, LALoad, FALoad, DALoad, AALoad>::value;
+
 /// Satisfied when 'T' is a store operation.
 template <class T>
 concept IsStore = llvm::is_one_of<T, IStore, AStore, FStore, DStore, LStore>::value;
@@ -263,31 +267,49 @@ concept IsStore3 = llvm::is_one_of<T, IStore3, AStore3, FStore3, DStore3, LStore
 template <class T>
 concept IsReturnValue = llvm::is_one_of<T, AReturn, DReturn, FReturn, IReturn, LReturn>::value;
 
+/// Satisfied when 'T' is an array store operation.
+template <class T>
+concept IsAStore = llvm::is_one_of<T, BAStore, CAStore, SAStore, IAStore, LAStore, FAStore, DAStore, AAStore>::value;
+
+/// Satisfied when 'T' operates on 'byte' elements.
+template <class T>
+concept OperatesOnByte = llvm::is_one_of<T, BALoad, BAStore>::value;
+
+/// Satisfied when 'T' operates on 'char' elements.
+template <class T>
+concept OperatesOnChar = llvm::is_one_of<T, CALoad, CAStore>::value;
+
+/// Satisfied when 'T' operates on 'short' elements.
+template <class T>
+concept OperatesOnShort = llvm::is_one_of<T, SALoad, SAStore>::value;
+
 /// Satisfied when 'T' operates on 'int' operands.
 template <class T>
 concept OperatesOnIntegers =
     llvm::is_one_of<T, ILoad, ILoad0, ILoad1, ILoad2, ILoad3, IStore, IStore0, IStore1, IStore2, IStore3, IAdd, ISub,
-                    IMul, IDiv, IRem, IInc, INeg, IReturn, IfICmpEq, IfICmpNe, IfICmpLt, IfICmpGe, IfICmpGt, IfICmpLe, IfEq,
-                    IfNe, IfLt, IfGe, IfGt, IfLe>::value;
+                    IMul, IDiv, IRem, IInc, INeg, IReturn, IfICmpEq, IfICmpNe, IfICmpLt, IfICmpGe, IfICmpGt, IfICmpLe,
+                    IfEq, IfNe, IfLt, IfGe, IfGt, IfLe, IALoad, IAStore>::value;
 
 /// Satisfied when 'T' operates on reference operands.
 template <class T>
-concept OperatesOnReferences = llvm::is_one_of<T, ALoad, ALoad0, ALoad1, ALoad2, ALoad3, AStore, AStore0, AStore1,
-                                               AStore2, AStore3, AReturn, IfACmpEq, IfACmpNe, IfNull, IfNonNull>::value;
+concept OperatesOnReferences =
+    llvm::is_one_of<T, ALoad, ALoad0, ALoad1, ALoad2, ALoad3, AStore, AStore0, AStore1, AStore2, AStore3, AReturn,
+                    IfACmpEq, IfACmpNe, IfNull, IfNonNull, AALoad, AAStore>::value;
 
 /// Satisfied when 'T' operates on 'float' operands.
 template <class T>
 concept OperatesOnFloat = llvm::is_one_of<T, FLoad, FLoad0, FLoad1, FLoad2, FLoad3, FStore, FStore0, FStore1, FStore2,
-                                          FStore3, FAdd, FSub, FMul, FDiv, FRem, FNeg, FReturn>::value;
+                                          FStore3, FAdd, FSub, FMul, FDiv, FRem, FNeg, FReturn, FALoad, FAStore>::value;
 
 /// Satisfied when 'T' operates on 'double' operands.
 template <class T>
-concept OperatesOnDouble = llvm::is_one_of<T, DLoad, DLoad0, DLoad1, DLoad2, DLoad3, DStore, DStore0, DStore1, DStore2,
-                                           DStore3, DAdd, DSub, DMul, DDiv, DRem, DNeg, DReturn>::value;
+concept OperatesOnDouble =
+    llvm::is_one_of<T, DLoad, DLoad0, DLoad1, DLoad2, DLoad3, DStore, DStore0, DStore1, DStore2, DStore3, DAdd, DSub,
+                    DMul, DDiv, DRem, DNeg, DReturn, DALoad, DAStore>::value;
 
 /// Satisfied when 'T' operates on 'long' operands.
 template <class T>
 concept OperatesOnLong = llvm::is_one_of<T, LLoad, LLoad0, LLoad1, LLoad2, LLoad3, LStore, LStore0, LStore1, LStore2,
-                                         LStore3, LAdd, LSub, LMul, LDiv, LRem, LNeg, LReturn>::value;
+                                         LStore3, LAdd, LSub, LMul, LDiv, LRem, LNeg, LReturn, LALoad, LAStore>::value;
 
 } // namespace jllvm

--- a/src/jllvm/compiler/CodeGenerator.cpp
+++ b/src/jllvm/compiler/CodeGenerator.cpp
@@ -583,12 +583,11 @@ bool CodeGenerator::generateInstruction(ByteCodeOp operation)
                     m_builder.SetInsertPoint(throwBlock);
 
                     llvm::CallBase* exception = m_builder.CreateCall(
-                        m_function->getParent()->getOrInsertFunction("jllvm_build_class_cast_exception",
+                        m_function->getParent()->getOrInsertFunction("jllvm_throw_class_cast_exception",
                                                                      llvm::FunctionType::get(ty, {ty, ty}, false)),
                         {object, classObject});
                     addExceptionHandlingDeopts(getOffset(operation), exception);
-
-                    generateExceptionThrow(getOffset(operation), exception);
+                    m_builder.CreateUnreachable();
 
                     m_builder.SetInsertPoint(continueBlock);
                 });
@@ -1537,7 +1536,7 @@ void CodeGenerator::generateBuiltinExceptionThrow(std::uint16_t byteCodeOffset, 
                              builderArgs);
     addExceptionHandlingDeopts(byteCodeOffset, exception);
 
-    generateExceptionThrow(byteCodeOffset, exception);
+    m_builder.CreateUnreachable();
 
     m_builder.SetInsertPoint(continueBlock);
 }
@@ -1547,7 +1546,7 @@ void CodeGenerator::generateNullPointerCheck(std::uint16_t byteCodeOffset, llvm:
     llvm::Value* null = llvm::ConstantPointerNull::get(referenceType(m_builder.getContext()));
     llvm::Value* isNull = m_builder.CreateICmpEQ(object, null);
 
-    generateBuiltinExceptionThrow(byteCodeOffset, isNull, "jllvm_build_null_pointer_exception", {});
+    generateBuiltinExceptionThrow(byteCodeOffset, isNull, "jllvm_throw_null_pointer_exception", {});
 }
 
 void CodeGenerator::generateArrayIndexCheck(std::uint16_t byteCodeOffset, llvm::Value* array, llvm::Value* index)
@@ -1562,7 +1561,7 @@ void CodeGenerator::generateArrayIndexCheck(std::uint16_t byteCodeOffset, llvm::
     llvm::Value* isBigger = m_builder.CreateICmpSGE(index, size);
     llvm::Value* outOfBounds = m_builder.CreateOr(isNegative, isBigger);
 
-    generateBuiltinExceptionThrow(byteCodeOffset, outOfBounds, "jllvm_build_array_index_out_of_bounds_exception",
+    generateBuiltinExceptionThrow(byteCodeOffset, outOfBounds, "jllvm_throw_array_index_out_of_bounds_exception",
                                   {index, size});
 }
 
@@ -1570,7 +1569,7 @@ void CodeGenerator::generateNegativeArraySizeCheck(std::uint16_t byteCodeOffset,
 {
     llvm::Value* isNegative = m_builder.CreateICmpSLT(size, m_builder.getInt32(0));
 
-    generateBuiltinExceptionThrow(byteCodeOffset, isNegative, "jllvm_build_negative_array_size_exception", {size});
+    generateBuiltinExceptionThrow(byteCodeOffset, isNegative, "jllvm_throw_negative_array_size_exception", {size});
 }
 
 void CodeGenerator::generateExceptionThrow(std::uint16_t byteCodeOffset, llvm::Value* exception)

--- a/src/jllvm/vm/VirtualMachine.hpp
+++ b/src/jllvm/vm/VirtualMachine.hpp
@@ -159,6 +159,14 @@ public:
         throwJavaException(exception);
     }
 
+    /// Construct and throws an 'ArrayIndexOutOfBoundsException' with a message created from the index that was accessed
+    /// and the length of the array.
+    [[noreturn]] void throwArrayIndexOutOfBoundsException(std::int32_t indexAccessed, std::int32_t arrayLength);
+
+    /// Construct and throws a 'NegativeArraySizeException' with a message created from the length that the array was
+    /// attempted to be constructed with.
+    [[noreturn]] void throwNegativeArraySizeException(std::int32_t arrayLength);
+
     /// Performs stack unwinding, calling 'f' for every Java frame encountered.
     /// 'f' may optionally return a 'UnwindAction' to control whether unwinding should continue.
     /// Returns true if 'UnwindAction::UnwindAction' was ever returned.

--- a/tests/Compiler/exceptions-missing-deopt.j
+++ b/tests/Compiler/exceptions-missing-deopt.j
@@ -19,18 +19,17 @@
 .method public static test()V
     .limit stack 2
     iconst_1
-    ; CHECK: call {{.*}} @jllvm_build_negative_array_size_exception(
+    ; CHECK: call {{.*}} @jllvm_throw_negative_array_size_exception(
     ; CHECK-SAME: "deopt"(i16 {{.*}}
-    ; CHECK: call {{.*}} @jllvm_throw(
-    ; CHECK-SAME: "deopt"(i16 {{.*}}
+    ; CHECK-NEXT: unreachable
     anewarray Ljava/lang/Object;
     iconst_0
-    ; CHECK: call {{.*}} @jllvm_build_null_pointer_exception(
+    ; CHECK: call {{.*}} @jllvm_throw_null_pointer_exception(
     ; CHECK-SAME: "deopt"(i16 [[AALOAD_OFFSET:[0-9]+]]
-    ; CHECK: call {{.*}} @jllvm_build_array_index_out_of_bounds_exception(
+    ; CHECK: call {{.*}} @jllvm_throw_array_index_out_of_bounds_exception(
     ; CHECK-SAME: "deopt"(i16 [[AALOAD_OFFSET]]
     aaload
-    ; CHECK: call {{.*}} @jllvm_build_class_cast_exception(
+    ; CHECK: call {{.*}} @jllvm_throw_class_cast_exception(
     ; CHECK-SAME: "deopt"(i16 {{.*}}
     checkcast Ljava/lang/Object;
     return


### PR DESCRIPTION
This PR implements all array operations but `multianewarray` and `newarray`. As many of these operations are capable of throwing different exceptions where the JIT compiler already uses nice messages, the methods creating these exception objects and throwing them were moved to their own methods in `VirtualMachine` and reused. Since the version of them throwing is nicer and easier to use, the JIT code was also adjusted to expect these methods to throw the exception rather than create the exception object.