### PR TITLE
[interpreter] fix bug in `put*` of wide types

### DIFF
--- a/src/jllvm/vm/Interpreter.cpp
+++ b/src/jllvm/vm/Interpreter.cpp
@@ -440,11 +440,7 @@ std::uint64_t jllvm::Interpreter::executeMethod(const Method& method, std::uint1
 
                 std::uint64_t value{};
                 std::memcpy(&value, reinterpret_cast<char*>(object) + field->getOffset(), descriptor.sizeOf());
-                context.pushRaw(value, descriptor.isReference());
-                if (descriptor.isWide())
-                {
-                    context.pushRaw(0, descriptor.isReference());
-                }
+                context.push(value, descriptor);
                 return NextPC{};
             },
             [&](GetStatic getStatic)
@@ -456,11 +452,7 @@ std::uint64_t jllvm::Interpreter::executeMethod(const Method& method, std::uint1
 
                 std::uint64_t value{};
                 std::memcpy(&value, field->getAddressOfStatic(), descriptor.sizeOf());
-                context.pushRaw(value, descriptor.isReference());
-                if (descriptor.isWide())
-                {
-                    context.pushRaw(0, descriptor.isReference());
-                }
+                context.push(value, descriptor);
                 return NextPC{};
             },
             [&](Goto gotoInst) { return SetPC{static_cast<std::uint16_t>(gotoInst.offset + gotoInst.target)}; },
@@ -571,11 +563,7 @@ std::uint64_t jllvm::Interpreter::executeMethod(const Method& method, std::uint1
                 auto [classObject, fieldName, descriptor] = getFieldInfo(classFile, putField.index);
                 const Field* field = classObject->getInstanceField(fieldName, descriptor);
 
-                std::uint64_t value = context.popRaw().first;
-                if (descriptor.isWide())
-                {
-                    context.popRaw();
-                }
+                std::uint64_t value = context.pop(descriptor);
                 auto* object = context.pop<ObjectInterface*>();
                 if (!object)
                 {
@@ -592,12 +580,7 @@ std::uint64_t jllvm::Interpreter::executeMethod(const Method& method, std::uint1
                 m_virtualMachine.initialize(*classObject);
                 Field* field = classObject->getStaticField(fieldName, descriptor);
 
-                std::uint64_t value = context.popRaw().first;
-                if (descriptor.isWide())
-                {
-                    context.popRaw();
-                }
-
+                std::uint64_t value = context.pop(descriptor);
                 std::memcpy(field->getAddressOfStatic(), &value, descriptor.sizeOf());
                 return NextPC{};
             },

--- a/src/jllvm/vm/Interpreter.hpp
+++ b/src/jllvm/vm/Interpreter.hpp
@@ -95,6 +95,16 @@ public:
         }
     }
 
+    /// Pushes a value of the type give by 'descriptor' to the operand stack.
+    void push(std::uint64_t value, FieldType descriptor)
+    {
+        pushRaw(value, descriptor.isReference());
+        if (descriptor.isWide())
+        {
+            pushRaw(0, descriptor.isReference());
+        }
+    }
+
     /// Pushes the value into the top operand stack slot.
     /// This method operates on operand slots rather than 'InterpreterValue' as 'push' does.
     /// This notably has different behaviour for types such as 'long' or 'double'.
@@ -122,6 +132,16 @@ public:
             popRaw();
         }
         return llvm::bit_cast<T>(static_cast<NextSizedUInt<T>>(popRaw().first));
+    }
+
+    /// Pops the top value of the type given by 'descriptor' from the operand stack.
+    std::uint64_t pop(FieldType descriptor)
+    {
+        if (descriptor.isWide())
+        {
+            popRaw();
+        }
+        return popRaw().first;
     }
 
     /// Pops the top-most operand stack slot from the stack.

--- a/tests/Execution/interpreter-wide-putstatic-bug.j
+++ b/tests/Execution/interpreter-wide-putstatic-bug.j
@@ -1,0 +1,28 @@
+; RUN: jasmin %s -d %t
+; RUN: jllvm -Xint %t/Test.class | FileCheck %s
+
+.class public Test
+.super java/lang/Object
+
+.field public static final d D = 4.0d
+.field public static other D = 4.0d
+
+.method public <init>()V
+    aload_0
+    invokespecial java/lang/Object/<init>()V
+    return
+.end method
+
+.method public static native print(D)V
+.end method
+
+.method public static main([Ljava/lang/String;)V
+.limit locals 1
+.limit stack 2
+    getstatic Test/d D
+    putstatic Test/other D
+    getstatic Test/other D
+    ; CHECK: 4
+    invokestatic Test.print(D)V
+    return
+.end method


### PR DESCRIPTION
The implementations of field access methods made use of `pushRaw` and `popRaw` as the types being operated on are runtime dependent on the type of the field being accessed. However, using these methods is dangerous, as this requires manually handling wide types such as `long` and `double`. This has happened in the implementations of `putstatic` and `putfield` where the order of `popRaw` calls was incorrect, leading to always storing 0 in the field.

This PR fixes that issue by adding new overloads for `push` and `pop` which take a field descriptor as parameter. This adds a safe and convenient version of `pop` and `raw` while still being capable of specifying types at runtime.