### PR TITLE
[interpreter] Implement invoke* instructions

### DIFF
--- a/src/jllvm/materialization/CMakeLists.txt
+++ b/src/jllvm/materialization/CMakeLists.txt
@@ -22,6 +22,8 @@ add_library(JLLVMMaterialization
         ByteCodeOSRCompileLayer.cpp
         InterpreterOSRLayer.cpp
         InterpreterEntry.cpp
-        ClassObjectDefinitionsGenerator.cpp)
+        ClassObjectDefinitionsGenerator.cpp
+        Interpreter2JITAdaptorDefinitionsGenerator.cpp
+        Interpreter2JITLayer.cpp)
 target_link_libraries(JLLVMMaterialization PUBLIC JLLVMCompiler JLLVMDebugInfo JLLVMObject LLVMCore LLVMOrcJIT
         PRIVATE LLVMTargetParser)

--- a/src/jllvm/materialization/Interpreter2JITAdaptorDefinitionsGenerator.cpp
+++ b/src/jllvm/materialization/Interpreter2JITAdaptorDefinitionsGenerator.cpp
@@ -1,0 +1,159 @@
+// Copyright (C) 2023 The JLLVM Contributors.
+//
+// This file is part of JLLVM.
+//
+// JLLVM is free software; you can redistribute it and/or modify it under  the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 3, or (at your option) any later version.
+//
+// JLLVM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with JLLVM; see the file LICENSE.txt.  If not
+// see <http://www.gnu.org/licenses/>.
+
+#include "Interpreter2JITAdaptorDefinitionsGenerator.hpp"
+
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Verifier.h>
+
+#include <jllvm/compiler/ByteCodeCompileUtils.hpp>
+#include <jllvm/debuginfo/TrivialDebugInfoBuilder.hpp>
+
+namespace
+{
+/// Compile an adaptor of the given 'name'. Returns an empty optional if the name does not conform to the grammar.
+std::optional<llvm::orc::ThreadSafeModule> compileAdaptor(llvm::StringRef name, const llvm::DataLayout& dataLayout)
+{
+    if (name.front() != '(')
+    {
+        return std::nullopt;
+    }
+
+    auto context = std::make_unique<llvm::LLVMContext>();
+    auto module = std::make_unique<llvm::Module>("name", *context);
+
+    module->setDataLayout(dataLayout);
+    module->setTargetTriple(LLVM_HOST_TRIPLE);
+
+    auto* function = llvm::Function::Create(
+        llvm::FunctionType::get(llvm::IntegerType::getInt64Ty(*context),
+                                {llvm::PointerType::get(*context, 0), llvm::PointerType::get(*context, 0)},
+                                /*isVarArg=*/false),
+        llvm::GlobalValue::ExternalLinkage, name, *module);
+    jllvm::TrivialDebugInfoBuilder debugInfoBuilder(function);
+
+    llvm::Value* functionPointer = function->getArg(0);
+    llvm::Value* argumentArray = function->getArg(1);
+
+    llvm::IRBuilder<> builder(llvm::BasicBlock::Create(*context, "entry", function));
+    builder.SetCurrentDebugLocation(debugInfoBuilder.getNoopLoc());
+
+    name = name.drop_front();
+
+    auto convertType = [&](char c) -> llvm::Type*
+    {
+        switch (c)
+        {
+            case 'V': return builder.getVoidTy();
+            case 'B': return builder.getInt8Ty();
+            case 'C': return builder.getInt16Ty();
+            case 'D': return builder.getDoubleTy();
+            case 'F': return builder.getFloatTy();
+            case 'I': return builder.getInt32Ty();
+            case 'J': return builder.getInt64Ty();
+            case 'S': return builder.getInt16Ty();
+            case 'Z': return builder.getInt8Ty();
+            case 'L': return jllvm::referenceType(*context);
+            default: return nullptr;
+        }
+    };
+
+    llvm::SmallVector<llvm::Value*> arguments;
+    std::size_t i = 0;
+    while (!name.empty() && name.front() != ')')
+    {
+        llvm::Value* gep = builder.CreateConstGEP1_32(argumentArray->getType(), argumentArray, i++);
+        llvm::Type* loadType = convertType(name.front());
+        if (!loadType)
+        {
+            return std::nullopt;
+        }
+        // 'double' and 'long' take two slots in the arguments array.
+        if (loadType->isDoubleTy() || loadType->isIntegerTy(64))
+        {
+            i++;
+        }
+        arguments.push_back(builder.CreateLoad(loadType, gep));
+        name = name.drop_front();
+    }
+    if (name.empty() || name.front() != ')')
+    {
+        return std::nullopt;
+    }
+    name = name.drop_front();
+    if (name.size() != 1)
+    {
+        return std::nullopt;
+    }
+
+    llvm::Type* returnType = convertType(name.front());
+    if (!returnType)
+    {
+        return std::nullopt;
+    }
+    auto* functionType = llvm::FunctionType::get(
+        returnType, llvm::to_vector(llvm::map_range(arguments, std::mem_fn(&llvm::Value::getType))),
+        /*isVarArg=*/false);
+
+    llvm::Value* call = builder.CreateCall(functionType, functionPointer, arguments);
+    if (returnType->isVoidTy())
+    {
+        // For void methods returning any kind of value would suffice as it is never read.
+        // C++ callers do not expect a 'poison' or 'undef' value however (as clang uses 'noundef' and 'nopoison'
+        // return attributes), so avoid using those.
+        builder.CreateRet(builder.getInt64(0));
+    }
+    else
+    {
+        // Translate the value returned by the C calling convention to the 'uint64_t' expected by the interpreter.
+        llvm::TypeSize typeSize = dataLayout.getTypeSizeInBits(returnType);
+        assert(!typeSize.isScalable() && "return type is never a scalable type");
+
+        llvm::IntegerType* intNTy = builder.getIntNTy(typeSize.getFixedValue());
+        call = builder.CreateBitOrPointerCast(call, intNTy);
+        call = builder.CreateZExtOrTrunc(call, function->getReturnType());
+        builder.CreateRet(call);
+    }
+    debugInfoBuilder.finalize();
+
+    return llvm::orc::ThreadSafeModule(std::move(module), std::move(context));
+}
+} // namespace
+
+llvm::Error jllvm::Interpreter2JITAdaptorDefinitionsGenerator::tryToGenerate(
+    llvm::orc::LookupState&, llvm::orc::LookupKind, llvm::orc::JITDylib& dylib, llvm::orc::JITDylibLookupFlags,
+    const llvm::orc::SymbolLookupSet& symbolLookupSet)
+{
+    for (const llvm::orc::SymbolStringPtr& symbol : llvm::make_first_range(symbolLookupSet))
+    {
+        llvm::StringRef name = *symbol;
+        if (name.front() == m_dataLayout.getGlobalPrefix())
+        {
+            name = name.drop_front();
+        }
+
+        std::optional<llvm::orc::ThreadSafeModule> module = compileAdaptor(name, m_dataLayout);
+        if (!module)
+        {
+            continue;
+        }
+
+        llvm::Error error = m_baseLayer.add(dylib, std::move(*module));
+        if (error)
+        {
+            return error;
+        }
+    }
+
+    return llvm::Error::success();
+}

--- a/src/jllvm/materialization/Interpreter2JITAdaptorDefinitionsGenerator.hpp
+++ b/src/jllvm/materialization/Interpreter2JITAdaptorDefinitionsGenerator.hpp
@@ -1,0 +1,50 @@
+// Copyright (C) 2023 The JLLVM Contributors.
+//
+// This file is part of JLLVM.
+//
+// JLLVM is free software; you can redistribute it and/or modify it under  the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 3, or (at your option) any later version.
+//
+// JLLVM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with JLLVM; see the file LICENSE.txt.  If not
+// see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <llvm/ExecutionEngine/Orc/Core.h>
+#include <llvm/ExecutionEngine/Orc/Layer.h>
+
+namespace jllvm
+{
+
+/// Definitions generator lazily generating adaptor functions for converting from interpreter to JIT calling convention.
+/// Names of functions have to conform to the following grammar:
+/// <name> ::= '(' { <type> } ')' <ret-type>
+/// <type> ::= <basic-type-descriptor> | 'L'
+/// <ret-type> ::= <type> | 'V'
+///
+/// The name is designed to be derivable from a method type descriptor with the exception that 1) the 'this' parameter
+/// is part of the type and has to be explicitly added by adding an 'L' character and 2) all reference parameters
+/// including arrays are reduced to just 'L'.
+///
+/// All adaptors are callable as 'std::uint64_t(void*, const std::uint64_t*)' where the first parameter is a function
+/// pointer for the original method type and the second the argument array in interpreter calling convention.
+class Interpreter2JITAdaptorDefinitionsGenerator : public llvm::orc::DefinitionGenerator
+{
+    llvm::orc::IRLayer& m_baseLayer;
+    llvm::DataLayout m_dataLayout;
+
+public:
+    Interpreter2JITAdaptorDefinitionsGenerator(llvm::orc::IRLayer& baseLayer, const llvm::DataLayout& dataLayout)
+        : m_baseLayer(baseLayer), m_dataLayout(dataLayout)
+    {
+    }
+
+    llvm::Error tryToGenerate(llvm::orc::LookupState&, llvm::orc::LookupKind, llvm::orc::JITDylib& dylib,
+                              llvm::orc::JITDylibLookupFlags,
+                              const llvm::orc::SymbolLookupSet& symbolLookupSet) override;
+};
+
+} // namespace jllvm

--- a/src/jllvm/materialization/Interpreter2JITLayer.cpp
+++ b/src/jllvm/materialization/Interpreter2JITLayer.cpp
@@ -15,7 +15,6 @@
 
 #include <llvm/IR/IRBuilder.h>
 
-#include <jllvm/compiler/ByteCodeCompileUtils.hpp>
 #include <jllvm/compiler/ClassObjectStubMangling.hpp>
 #include <jllvm/materialization/LambdaMaterialization.hpp>
 

--- a/src/jllvm/materialization/Interpreter2JITLayer.cpp
+++ b/src/jllvm/materialization/Interpreter2JITLayer.cpp
@@ -1,0 +1,126 @@
+// Copyright (C) 2023 The JLLVM Contributors.
+//
+// This file is part of JLLVM.
+//
+// JLLVM is free software; you can redistribute it and/or modify it under  the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 3, or (at your option) any later version.
+//
+// JLLVM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with JLLVM; see the file LICENSE.txt.  If not
+// see <http://www.gnu.org/licenses/>.
+
+#include "Interpreter2JITLayer.hpp"
+
+#include <llvm/IR/IRBuilder.h>
+
+#include <jllvm/compiler/ByteCodeCompileUtils.hpp>
+#include <jllvm/compiler/ClassObjectStubMangling.hpp>
+#include <jllvm/materialization/LambdaMaterialization.hpp>
+
+#include "Interpreter2JITAdaptorDefinitionsGenerator.hpp"
+
+jllvm::Interpreter2JITLayer::Interpreter2JITLayer(llvm::orc::IRLayer& baseLayer, llvm::orc::MangleAndInterner& interner,
+                                                  const llvm::DataLayout& dataLayout)
+    : m_interner{interner},
+      m_baseLayer{baseLayer},
+      m_dataLayout{dataLayout},
+      m_i2jAdaptors{baseLayer.getExecutionSession().createBareJITDylib("<i2jAdaptors>")}
+{
+    m_i2jAdaptors.addGenerator(std::make_unique<Interpreter2JITAdaptorDefinitionsGenerator>(baseLayer, dataLayout));
+}
+
+namespace
+{
+using namespace jllvm;
+
+class Interpreter2JITMaterializationUnit : public llvm::orc::MaterializationUnit
+{
+    Interpreter2JITLayer& m_layer;
+    const Method& m_method;
+    llvm::orc::JITDylib& m_jitCCDylib;
+
+public:
+    Interpreter2JITMaterializationUnit(Interpreter2JITLayer& layer, const Method& method,
+                                       llvm::orc::JITDylib& jitCcDylib)
+        : llvm::orc::MaterializationUnit(
+              [&]
+              {
+                  llvm::orc::SymbolFlagsMap result;
+                  auto name = mangleDirectMethodCall(&method);
+                  result[layer.getInterner()(name)] = llvm::JITSymbolFlags::Exported | llvm::JITSymbolFlags::Callable;
+                  return llvm::orc::MaterializationUnit::Interface(std::move(result), nullptr);
+              }()),
+          m_layer(layer),
+          m_method(method),
+          m_jitCCDylib(jitCcDylib)
+    {
+    }
+
+    llvm::StringRef getName() const override
+    {
+        return "Interpreter2JITMaterializationUnit";
+    }
+
+    void materialize(std::unique_ptr<llvm::orc::MaterializationResponsibility> mr) override
+    {
+        m_layer.emit(std::move(mr), m_method, m_jitCCDylib);
+    }
+
+private:
+    void discard(const llvm::orc::JITDylib&, const llvm::orc::SymbolStringPtr&) override
+    {
+        llvm_unreachable("Should not be possible");
+    }
+};
+
+} // namespace
+
+llvm::Error jllvm::Interpreter2JITLayer::add(llvm::orc::JITDylib& dylib, const Method& method,
+                                             llvm::orc::JITDylib& jitCCDylib)
+{
+    return dylib.define(std::make_unique<Interpreter2JITMaterializationUnit>(*this, method, jitCCDylib));
+}
+
+void jllvm::Interpreter2JITLayer::emit(std::unique_ptr<llvm::orc::MaterializationResponsibility> mr,
+                                       const Method& method, llvm::orc::JITDylib& jitCCDylib)
+{
+    // Perform mangling from the method type to the adaptor names.
+    MethodType methodType = method.getType();
+    std::string mangling = "(";
+    if (!method.isStatic())
+    {
+        mangling += "L";
+    }
+    auto addToMangling = [&](FieldType fieldType)
+    {
+        if (fieldType.isReference())
+        {
+            mangling += "L";
+            return;
+        }
+        mangling += fieldType.textual();
+    };
+    llvm::for_each(methodType.parameters(), addToMangling);
+    mangling += ")";
+    addToMangling(methodType.returnType());
+
+    // Fetch both the adaptor and the callee in the JIT calling convention.
+    llvm::orc::ExecutionSession& session = mr->getExecutionSession();
+    llvm::JITTargetAddress adaptor =
+        llvm::cantFail(session.lookup({&m_i2jAdaptors}, m_interner(mangling))).getAddress();
+    std::string symbol = mangleDirectMethodCall(&method);
+    llvm::JITTargetAddress jitCCSymbol = llvm::cantFail(session.lookup({&jitCCDylib}, m_interner(symbol))).getAddress();
+
+    // Implement the interpreter calling convention symbol by creating a lambda that just forwards the arguments and
+    // JIT CC symbol to the adaptor.
+    llvm::cantFail(mr->replace(createLambdaMaterializationUnit(
+        symbol, m_baseLayer,
+        [=](const std::uint64_t* arguments) -> std::uint64_t
+        {
+            return reinterpret_cast<std::uint64_t (*)(void*, const std::uint64_t*)>(adaptor)(
+                reinterpret_cast<void*>(jitCCSymbol), arguments);
+        },
+        m_dataLayout, m_interner)));
+}

--- a/src/jllvm/materialization/Interpreter2JITLayer.hpp
+++ b/src/jllvm/materialization/Interpreter2JITLayer.hpp
@@ -1,0 +1,51 @@
+// Copyright (C) 2023 The JLLVM Contributors.
+//
+// This file is part of JLLVM.
+//
+// JLLVM is free software; you can redistribute it and/or modify it under  the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 3, or (at your option) any later version.
+//
+// JLLVM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with JLLVM; see the file LICENSE.txt.  If not
+// see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <llvm/ExecutionEngine/Orc/Layer.h>
+
+#include "ByteCodeLayer.hpp"
+
+namespace jllvm
+{
+
+/// Layer for creating adaptors allowing implementations using the JIT calling convention to be reused with the
+/// interpreter calling convention.
+class Interpreter2JITLayer
+{
+    llvm::orc::IRLayer& m_baseLayer;
+    llvm::DataLayout m_dataLayout;
+    llvm::orc::JITDylib& m_i2jAdaptors;
+    llvm::orc::MangleAndInterner& m_interner;
+
+public:
+    Interpreter2JITLayer(llvm::orc::IRLayer& baseLayer, llvm::orc::MangleAndInterner& interner,
+                         const llvm::DataLayout& dataLayout);
+
+    /// Registers an implementation of 'method' within 'dylib' conforming to the interpreter calling convention.
+    /// Any calls will be translated to the JIT calling convention and calls 'method' within 'jitCCDylib'.
+    /// If 'jitCCDylib' does not contain an implementation of 'method' using the JIT calling convention the behaviour
+    /// is undefined.
+    llvm::Error add(llvm::orc::JITDylib& dylib, const Method& method, llvm::orc::JITDylib& jitCCDylib);
+
+    llvm::orc::MangleAndInterner& getInterner() const
+    {
+        return m_interner;
+    }
+
+    void emit(std::unique_ptr<llvm::orc::MaterializationResponsibility> mr, const Method& method,
+              llvm::orc::JITDylib& jitCCDylib);
+};
+
+} // namespace jllvm

--- a/src/jllvm/object/ClassObject.cpp
+++ b/src/jllvm/object/ClassObject.cpp
@@ -284,7 +284,7 @@ bool canOverride(const jllvm::ClassObject* derivedClass, const jllvm::Method& ba
 }
 } // namespace
 
-const jllvm::Method& jllvm::ClassObject::methodSelection(const Method& resolvedMethod)
+const jllvm::Method& jllvm::ClassObject::methodSelection(const Method& resolvedMethod) const
 {
     // https://docs.oracle.com/javase/specs/jvms/se17/html/jvms-5.html#jvms-5.4.6 Step 1
     if (resolvedMethod.getVisibility() == jllvm::Visibility::Private)

--- a/src/jllvm/object/ClassObject.hpp
+++ b/src/jllvm/object/ClassObject.hpp
@@ -834,7 +834,7 @@ public:
     ///
     /// This is the process used by 'invokevirtual' to map a call to 'resolvedMethod' where the 'this' object of the
     /// invoke is an instance of this class object to the actual method that should be executed.
-    const Method& methodSelection(const Method& resolvedMethod);
+    const Method& methodSelection(const Method& resolvedMethod) const;
 
     /// Performs method resolution as described in the JVM Spec:
     /// https://docs.oracle.com/javase/specs/jvms/se17/html/jvms-5.html#jvms-5.4.3.3 This is the low level procedure

--- a/src/jllvm/vm/Executor.hpp
+++ b/src/jllvm/vm/Executor.hpp
@@ -41,6 +41,10 @@ public:
     /// Returns the dylib used for lookups when calling a given method with the JIT Calling Convention.
     /// All registered methods must be contained with the "direct-method-call" mangling.
     virtual llvm::orc::JITDylib& getJITCCDylib() = 0;
+
+    /// Returns the dylib used for lookups when calling a given method with the Interpreter Calling Convention.
+    /// All registered methods must be contained with the "direct-method-call" mangling.
+    virtual llvm::orc::JITDylib& getInterpreterCCDylib() = 0;
 };
 
 } // namespace jllvm

--- a/src/jllvm/vm/Executor.hpp
+++ b/src/jllvm/vm/Executor.hpp
@@ -31,7 +31,8 @@ public:
     Executor(Executor&&) = delete;
     Executor& operator=(Executor&&) = delete;
 
-    /// Registers a method within the executor, making it available in the dylib returned by 'getJITCCDylib'.
+    /// Registers a method within the executor, making it available in the dylib returned by 'getJITCCDylib'
+    /// and 'getInterpreterCCDylib'.
     /// This method assumes that 'canExecute' returned true for 'method'.
     virtual void add(const Method& method) = 0;
 

--- a/src/jllvm/vm/Interpreter.cpp
+++ b/src/jllvm/vm/Interpreter.cpp
@@ -22,6 +22,7 @@ jllvm::Interpreter::Interpreter(VirtualMachine& virtualMachine, bool enableOSR)
       m_enableOSR(enableOSR),
       m_jit2InterpreterSymbols(
           m_virtualMachine.getRuntime().getJITCCDylib().getExecutionSession().createBareJITDylib("<jit2interpreter>")),
+      m_interpreterCCSymbols(m_jit2InterpreterSymbols.getExecutionSession().createBareJITDylib("<interpreterSymbols>")),
       m_compiled2InterpreterLayer(virtualMachine.getRuntime().getInterner(),
                                   virtualMachine.getRuntime().getLLVMIRLayer(),
                                   virtualMachine.getRuntime().getDataLayout()),
@@ -677,12 +678,23 @@ std::uint64_t jllvm::Interpreter::executeMethod(const Method& method, std::uint1
     auto curr = ByteCodeIterator(codeArray.data(), offset);
     MethodType methodType = method.getType();
 
+    // Lazily fetches and caches the class object for 'Object'.
+    auto getObjectClass = [&, objectClass = static_cast<ClassObject*>(nullptr)]() mutable
+    {
+        if (!objectClass)
+        {
+            objectClass = &m_virtualMachine.getClassLoader().forName("Ljava/lang/Object;");
+        }
+        return objectClass;
+    };
+
     while (true)
     {
         // Update the current offset to the new instruction.
         offset = curr.getOffset();
+        ByteCodeOp operation = *curr;
         InstructionResult result = match(
-            *curr, MultiTypeImpls{m_virtualMachine, context},
+            operation, MultiTypeImpls{m_virtualMachine, context},
             [&](ANewArray aNewArray)
             {
                 auto count = context.pop<std::int32_t>();
@@ -856,6 +868,90 @@ std::uint64_t jllvm::Interpreter::executeMethod(const Method& method, std::uint1
             [&](IConstM1)
             {
                 context.push<std::int32_t>(-1);
+                return NextPC{};
+            },
+            [&](OneOf<InvokeStatic, InvokeSpecial, InvokeInterface, InvokeVirtual> invoke)
+            {
+                const RefInfo* refInfo = PoolIndex<RefInfo>{invoke.index}.resolve(classFile);
+
+                llvm::StringRef methodName =
+                    refInfo->nameAndTypeIndex.resolve(classFile)->nameIndex.resolve(classFile)->text;
+                MethodType descriptor(
+                    refInfo->nameAndTypeIndex.resolve(classFile)->descriptorIndex.resolve(classFile)->text);
+
+                // Initialize the class object if it's an 'invokestatic'. This has to be done before the call to
+                // 'viewAndPopArguments' as the arguments on the operand stack could otherwise be garbage collected.
+                ClassObject* classObject = getClassObject(classFile, refInfo->classIndex);
+                if (holds_alternative<InvokeStatic>(operation))
+                {
+                    m_virtualMachine.initialize(*classObject);
+                }
+
+                llvm::ArrayRef<std::uint64_t> arguments =
+                    context.viewAndPopArguments(descriptor, /*isStatic=*/holds_alternative<InvokeStatic>(operation));
+
+                // Find the callee with the resolution of the given call.
+                const Method* callee = match(
+                    operation,
+                    [&](InvokeStatic) -> const Method*
+                    {
+                        return classObject->isInterface() ?
+                                   classObject->interfaceMethodResolution(methodName, descriptor, getObjectClass()) :
+                                   classObject->methodResolution(methodName, descriptor);
+                    },
+                    [&](OneOf<InvokeInterface, InvokeVirtual>) -> const Method*
+                    {
+                        auto* thisArg = llvm::bit_cast<ObjectInterface*>(arguments.front());
+                        if (!thisArg)
+                        {
+                            m_virtualMachine.throwException("Ljava/lang/NullPointerException;", "()V");
+                        }
+
+                        // TODO: This is super unoptimized. V-Table and I-Table lookups could be introduced just for
+                        //       the interpreter, and inline-caching used.
+                        const Method* resolvedMethod;
+                        if (holds_alternative<InvokeVirtual>(operation))
+                        {
+                            resolvedMethod = classObject->methodResolution(methodName, descriptor);
+                        }
+                        else
+                        {
+                            resolvedMethod =
+                                classObject->interfaceMethodResolution(methodName, descriptor, getObjectClass());
+                        }
+
+                        // Fast path: If its known that the method has no table slot due to not being overridable, we
+                        // do not have to perform method selection.
+                        if (!resolvedMethod->getTableSlot())
+                        {
+                            return resolvedMethod;
+                        }
+
+                        // Select the correct method based on the dynamic type of the 'this' argument.
+                        return &thisArg->getClass()->methodSelection(*resolvedMethod);
+                    },
+                    [&](InvokeSpecial)
+                    {
+                        auto* thisArg = llvm::bit_cast<ObjectInterface*>(arguments.front());
+                        if (!thisArg)
+                        {
+                            m_virtualMachine.throwException("Ljava/lang/NullPointerException;", "()V");
+                        }
+
+                        return classObject->specialMethodResolution(methodName, descriptor, getObjectClass(),
+                                                                    method.getClassObject());
+                    },
+                    [&](...) -> const Method* { llvm_unreachable("unexpected op"); });
+
+                std::uint64_t returnValue =
+                    m_virtualMachine.getRuntime().lookupInterpreterCC(*callee)(arguments.data());
+
+                FieldType returnType = descriptor.returnType();
+                if (returnType != BaseType(BaseType::Void))
+                {
+                    context.push(returnValue, returnType);
+                }
+
                 return NextPC{};
             },
             [&](IInc iInc)
@@ -1181,4 +1277,13 @@ std::unique_ptr<std::uint64_t[]> Interpreter::createOSRBuffer(std::uint16_t byte
     outIter = std::copy_n(localsGCMask.words_begin(), localsGCMask.numWords(), outIter);
     std::copy_n(operandStackGCMask.words_begin(), operandStackGCMask.numWords(), outIter);
     return buffer;
+}
+
+void Interpreter::add(const Method& method)
+{
+    llvm::cantFail(m_compiled2InterpreterLayer.add(m_jit2InterpreterSymbols, &method));
+    // TODO: Forego Interpreter -> JIT -> Interpreter conversion by implementing an interpreter calling convention
+    //       entry.
+    llvm::cantFail(
+        m_virtualMachine.getRuntime().getInterpreter2JITLayer().add(m_interpreterCCSymbols, method, getJITCCDylib()));
 }

--- a/src/jllvm/vm/Interpreter.cpp
+++ b/src/jllvm/vm/Interpreter.cpp
@@ -904,7 +904,7 @@ std::uint64_t jllvm::Interpreter::executeMethod(const Method& method, std::uint1
                         auto* thisArg = llvm::bit_cast<ObjectInterface*>(arguments.front());
                         if (!thisArg)
                         {
-                            m_virtualMachine.throwException("Ljava/lang/NullPointerException;", "()V");
+                            m_virtualMachine.throwNullPointerException();
                         }
 
                         // TODO: This is super unoptimized. V-Table and I-Table lookups could be introduced just for
@@ -935,7 +935,7 @@ std::uint64_t jllvm::Interpreter::executeMethod(const Method& method, std::uint1
                         auto* thisArg = llvm::bit_cast<ObjectInterface*>(arguments.front());
                         if (!thisArg)
                         {
-                            m_virtualMachine.throwException("Ljava/lang/NullPointerException;", "()V");
+                            m_virtualMachine.throwNullPointerException();
                         }
 
                         return classObject->specialMethodResolution(methodName, descriptor, getObjectClass(),

--- a/src/jllvm/vm/JIT.cpp
+++ b/src/jllvm/vm/JIT.cpp
@@ -39,6 +39,8 @@ jllvm::JIT::JIT(VirtualMachine& virtualMachine)
           llvm::cantFail(virtualMachine.getRuntime().getCLibDylib().getExecutionSession().createJITDylib("<javaJIT>"))),
       m_javaJITImplDetails(
           llvm::cantFail(m_javaJITSymbols.getExecutionSession().createJITDylib("<javaJITImplDetails>"))),
+      m_interpreter2JITSymbols(
+          llvm::cantFail(m_javaJITSymbols.getExecutionSession().createJITDylib("<interpreter2jit>"))),
       m_byteCodeCompileLayer(virtualMachine.getRuntime().getLLVMIRLayer(), virtualMachine.getRuntime().getInterner(),
                              virtualMachine.getRuntime().getDataLayout()),
       m_byteCodeOSRCompileLayer(m_byteCodeCompileLayer.getBaseLayer(), m_byteCodeCompileLayer.getInterner(),
@@ -93,6 +95,8 @@ jllvm::JIT::JIT(VirtualMachine& virtualMachine)
 void jllvm::JIT::add(const Method& method)
 {
     llvm::cantFail(m_byteCodeCompileLayer.add(m_javaJITSymbols, &method));
+    llvm::cantFail(
+        m_virtualMachine.getRuntime().getInterpreter2JITLayer().add(m_interpreter2JITSymbols, method, getJITCCDylib()));
 }
 
 void* jllvm::JIT::getOSREntry(const jllvm::Method& method, std::uint16_t byteCodeOffset)

--- a/src/jllvm/vm/JIT.hpp
+++ b/src/jllvm/vm/JIT.hpp
@@ -55,6 +55,7 @@ class JIT : public OSRTarget
 
     llvm::orc::JITDylib& m_javaJITSymbols;
     llvm::orc::JITDylib& m_javaJITImplDetails;
+    llvm::orc::JITDylib& m_interpreter2JITSymbols;
 
     ByteCodeCompileLayer m_byteCodeCompileLayer;
     ByteCodeOSRCompileLayer m_byteCodeOSRCompileLayer;
@@ -75,6 +76,11 @@ public:
     llvm::orc::JITDylib& getJITCCDylib() override
     {
         return m_javaJITSymbols;
+    }
+
+    llvm::orc::JITDylib& getInterpreterCCDylib() override
+    {
+        return m_interpreter2JITSymbols;
     }
 
     void* getOSREntry(const Method& method, std::uint16_t byteCodeOffset) override;

--- a/src/jllvm/vm/JNIBridge.hpp
+++ b/src/jllvm/vm/JNIBridge.hpp
@@ -25,7 +25,10 @@ namespace jllvm
 /// generation for the Java Native Interface (JNI).
 class JNIBridge : public Executor
 {
+    VirtualMachine& m_virtualMachine;
+
     llvm::orc::JITDylib& m_jniSymbols;
+    llvm::orc::JITDylib& m_interpreter2JNISymbols;
 
     JNIImplementationLayer m_jniImplementationLayer;
 
@@ -50,10 +53,7 @@ public:
             m_jniImplementationLayer.getInterner()));
     }
 
-    void add(const Method& method) override
-    {
-        llvm::cantFail(m_jniImplementationLayer.add(m_jniSymbols, &method));
-    }
+    void add(const Method& method) override;
 
     bool canExecute(const Method& method) const override
     {
@@ -63,6 +63,11 @@ public:
     llvm::orc::JITDylib& getJITCCDylib() override
     {
         return m_jniSymbols;
+    }
+
+    llvm::orc::JITDylib& getInterpreterCCDylib() override
+    {
+        return m_interpreter2JNISymbols;
     }
 };
 


### PR DESCRIPTION
This PR largely builds on the runtime refactor to introduce a new interface to all executors, allowing all methods to be called with the so-called interpreter calling convention as well.

The interpreter calling convention allows easily calling the resolved method using a reference to the operand stack. A special adaptor layer has been implemented to translate from the interpreter calling convention to the JIT calling convention, allowing the interpreter to call methods implemented in the JIT as well.

Note that this PR is only the minimal working version and is not very optimized. In particular, the interpreter does not cache any method resolutions or selections, nor does it yet directly implement the interpreter calling convention yet, instead relying on the adaptor.
These are seen as optimizations for future PRs.

Depends on https://github.com/JLLVM/JLLVM/pull/294