### PR TITLE
[interpreter] Implement constant instructions

### DIFF
--- a/src/jllvm/vm/Interpreter.hpp
+++ b/src/jllvm/vm/Interpreter.hpp
@@ -186,6 +186,8 @@ class Interpreter
     /// Returns the class object referred to by 'index' within 'classFile', loading it if necessary.
     ClassObject* getClassObject(const ClassFile& classFile, PoolIndex<ClassInfo> index);
 
+    ClassObject* getClassObject(const ClassFile& classFile, ClassInfo classInfo);
+
     /// Returns the class object referred to by 'index' within 'classFile' if it has been loaded already.
     /// Returns null otherwise.
     ClassObject* getClassObjectLoaded(const ClassFile& classFile, PoolIndex<ClassInfo> index);

--- a/src/jllvm/vm/JIT.cpp
+++ b/src/jllvm/vm/JIT.cpp
@@ -140,6 +140,7 @@ jllvm::JIT::JIT(std::unique_ptr<llvm::orc::ExecutionSession>&& session,
         {m_interner("memset"), llvm::JITEvaluatedSymbol::fromPointer(memset)},
         {m_interner("memcpy"), llvm::JITEvaluatedSymbol::fromPointer(memcpy)},
         {m_interner("fmodf"), llvm::JITEvaluatedSymbol::fromPointer(fmodf)},
+        {m_interner("fmod"), llvm::JITEvaluatedSymbol::fromPointer(fmod)},
         {m_interner("__gxx_personality_v0"), llvm::JITEvaluatedSymbol::fromPointer(__gxx_personality_v0)},
         {m_interner("_Unwind_Resume"), llvm::JITEvaluatedSymbol::fromPointer(_Unwind_Resume)},
 #ifdef __APPLE__

--- a/src/jllvm/vm/JIT.cpp
+++ b/src/jllvm/vm/JIT.cpp
@@ -140,7 +140,7 @@ jllvm::JIT::JIT(std::unique_ptr<llvm::orc::ExecutionSession>&& session,
         {m_interner("memset"), llvm::JITEvaluatedSymbol::fromPointer(memset)},
         {m_interner("memcpy"), llvm::JITEvaluatedSymbol::fromPointer(memcpy)},
         {m_interner("fmodf"), llvm::JITEvaluatedSymbol::fromPointer(fmodf)},
-        {m_interner("fmod"), llvm::JITEvaluatedSymbol::fromPointer(fmod)},
+        {m_interner("fmod"), llvm::JITEvaluatedSymbol::fromPointer(static_cast<double (*)(double, double)>(fmod))},
         {m_interner("__gxx_personality_v0"), llvm::JITEvaluatedSymbol::fromPointer(__gxx_personality_v0)},
         {m_interner("_Unwind_Resume"), llvm::JITEvaluatedSymbol::fromPointer(_Unwind_Resume)},
 #ifdef __APPLE__


### PR DESCRIPTION
This PR implements all instructions that push constants onto the operand stack. LDC variants only implement the info structs that the JIT implements as well.

Note that `fmod` was added in the JIT symbols due to LLVM generating a call to it when compiling an OSR version triggered by this patch.

Depends on https://github.com/JLLVM/JLLVM/pull/275 and https://github.com/JLLVM/JLLVM/pull/286