### PR TITLE
[interpreter] Optimize interpreter calls into the interpreter

### DIFF
--- a/src/jllvm/compiler/CodeGenerator.cpp
+++ b/src/jllvm/compiler/CodeGenerator.cpp
@@ -163,7 +163,7 @@ ArrayInfo resolveNewArrayInfo(BaseType::Values componentType, llvm::IRBuilder<>&
 
 } // namespace
 
-void CodeGenerator::generateBody(PrologueGenFn generatePrologue, std::uint16_t offset)
+llvm::Value* CodeGenerator::generateBody(PrologueGenFn generatePrologue, std::uint16_t offset)
 {
     TrivialDebugInfoBuilder debugInfoBuilder(m_function);
 
@@ -196,6 +196,20 @@ void CodeGenerator::generateBody(PrologueGenFn generatePrologue, std::uint16_t o
                                                     iter->second.variableState.begin());
     }
 
+    // Create the return block regardless of return type to allow running any epilogue code.
+    m_returnBlock = llvm::BasicBlock::Create(m_builder.getContext(), "", m_function);
+    FieldType returnType = m_method.getType().returnType();
+    if (returnType != BaseType(BaseType::Void))
+    {
+        // If we do have a return value, a phi collecting all the incoming return value is used and returned by this
+        // method.
+        llvm::IRBuilder<>::InsertPointGuard guard{m_builder};
+        m_builder.SetInsertPoint(m_returnBlock);
+
+        m_returnValue = m_builder.CreatePHI(descriptorToType(returnType, m_builder.getContext()),
+                                            /*NumReservedValues=*/1);
+    }
+
     generateCodeBody(offset);
 
     // 'createBasicBlocks' conservatively creates all basic blocks of the code even if some are not reachable if
@@ -207,6 +221,10 @@ void CodeGenerator::generateBody(PrologueGenFn generatePrologue, std::uint16_t o
             basicBlockData.block->eraseFromParent();
         }
     }
+
+    // Move the return block to the very back, purely to improve the readability of textual IR.
+    m_returnBlock->moveAfter(&m_function->back());
+    return m_returnValue ? static_cast<llvm::Value*>(m_returnValue) : static_cast<llvm::Value*>(m_returnBlock);
 }
 
 void CodeGenerator::createBasicBlocks(const ByteCodeTypeChecker& checker)
@@ -434,13 +452,14 @@ bool CodeGenerator::generateInstruction(ByteCodeOp operation)
                     {
                         value = m_builder.CreateAnd(value, m_builder.getInt32(1));
                     }
-                    if (m_function->getReturnType() != value->getType())
+                    if (m_returnValue->getType() != value->getType())
                     {
-                        value = m_builder.CreateTrunc(value, m_function->getReturnType());
+                        value = m_builder.CreateTrunc(value, m_returnValue->getType());
                     }
                 });
 
-            m_builder.CreateRet(value);
+            m_returnValue->addIncoming(value, m_builder.GetInsertBlock());
+            m_builder.CreateBr(m_returnBlock);
             fallsThrough = false;
         },
         [&](ArrayLength)
@@ -1345,7 +1364,7 @@ bool CodeGenerator::generateInstruction(ByteCodeOp operation)
         [&](Ret ret) { generateRet(ret); },
         [&](Return)
         {
-            m_builder.CreateRetVoid();
+            m_builder.CreateBr(m_returnBlock);
             fallsThrough = false;
         },
         [&](SIPush siPush) { m_operandStack.push_back(m_builder.getInt32(siPush.value)); },

--- a/src/jllvm/compiler/CodeGenerator.cpp
+++ b/src/jllvm/compiler/CodeGenerator.cpp
@@ -163,7 +163,8 @@ ArrayInfo resolveNewArrayInfo(BaseType::Values componentType, llvm::IRBuilder<>&
 
 } // namespace
 
-llvm::Value* CodeGenerator::generateBody(PrologueGenFn generatePrologue, std::uint16_t offset)
+llvm::PointerUnion<llvm::PHINode*, llvm::BasicBlock*> CodeGenerator::generateBody(PrologueGenFn generatePrologue,
+                                                                                  std::uint16_t offset)
 {
     TrivialDebugInfoBuilder debugInfoBuilder(m_function);
 
@@ -224,7 +225,11 @@ llvm::Value* CodeGenerator::generateBody(PrologueGenFn generatePrologue, std::ui
 
     // Move the return block to the very back, purely to improve the readability of textual IR.
     m_returnBlock->moveAfter(&m_function->back());
-    return m_returnValue ? static_cast<llvm::Value*>(m_returnValue) : static_cast<llvm::Value*>(m_returnBlock);
+    if (m_returnValue)
+    {
+        return m_returnValue;
+    }
+    return m_returnBlock;
 }
 
 void CodeGenerator::createBasicBlocks(const ByteCodeTypeChecker& checker)

--- a/src/jllvm/compiler/CodeGenerator.hpp
+++ b/src/jllvm/compiler/CodeGenerator.hpp
@@ -43,6 +43,10 @@ class CodeGenerator
     OperandStack m_operandStack;
     LocalVariables m_locals;
     llvm::DenseMap<std::uint16_t, BasicBlockData> m_basicBlocks;
+
+    llvm::PHINode* m_returnValue{};
+    llvm::BasicBlock* m_returnBlock{};
+
     ByteCodeTypeChecker::PossibleRetsMap m_retToMap;
     llvm::SmallSetVector<std::uint16_t, 8> m_workList;
 
@@ -138,19 +142,22 @@ public:
     /// This function must be only called once. 'generatePrologue' is used to initialize the local variables and
     /// operand stack at the start of the method. 'offset' is the bytecode offset at which compilation should start and
     /// must refer to a JVM instruction.
-    void generateBody(PrologueGenFn generatePrologue, std::uint16_t offset = 0);
+    llvm::Value* generateBody(PrologueGenFn generatePrologue, std::uint16_t offset = 0);
 };
 
 /// Generates new LLVM code at the back of 'function' from the JVM Bytecode in 'method'.
 /// 'generatePrologue' is called by the function to initialize the operand stack and local variables at the beginning of
 /// the newly created code. 'offset' is the bytecode offset at which compilation should start and must refer to a JVM
 /// instruction.
-inline void compileMethodBody(llvm::Function* function, const Method& method,
-                              CodeGenerator::PrologueGenFn generatePrologue, std::uint16_t offset = 0)
+/// A basic block without a terminator is created that all return instructions branch to instead of calling return.
+/// If the method returns void, this basic block is returned. Otherwise, a PHI instruction within the basic block
+/// containing the value that should be returned is returned instead.
+inline llvm::Value* compileMethodBody(llvm::Function* function, const Method& method,
+                                      CodeGenerator::PrologueGenFn generatePrologue, std::uint16_t offset = 0)
 {
     CodeGenerator codeGenerator{function, method};
 
-    codeGenerator.generateBody(generatePrologue, offset);
+    return codeGenerator.generateBody(generatePrologue, offset);
 }
 
 } // namespace jllvm

--- a/src/jllvm/compiler/CodeGenerator.hpp
+++ b/src/jllvm/compiler/CodeGenerator.hpp
@@ -142,7 +142,8 @@ public:
     /// This function must be only called once. 'generatePrologue' is used to initialize the local variables and
     /// operand stack at the start of the method. 'offset' is the bytecode offset at which compilation should start and
     /// must refer to a JVM instruction.
-    llvm::Value* generateBody(PrologueGenFn generatePrologue, std::uint16_t offset = 0);
+    llvm::PointerUnion<llvm::PHINode*, llvm::BasicBlock*> generateBody(PrologueGenFn generatePrologue,
+                                                                       std::uint16_t offset = 0);
 };
 
 /// Generates new LLVM code at the back of 'function' from the JVM Bytecode in 'method'.
@@ -152,8 +153,9 @@ public:
 /// A basic block without a terminator is created that all return instructions branch to instead of calling return.
 /// If the method returns void, this basic block is returned. Otherwise, a PHI instruction within the basic block
 /// containing the value that should be returned is returned instead.
-inline llvm::Value* compileMethodBody(llvm::Function* function, const Method& method,
-                                      CodeGenerator::PrologueGenFn generatePrologue, std::uint16_t offset = 0)
+inline llvm::PointerUnion<llvm::PHINode*, llvm::BasicBlock*>
+    compileMethodBody(llvm::Function* function, const Method& method, CodeGenerator::PrologueGenFn generatePrologue,
+                      std::uint16_t offset = 0)
 {
     CodeGenerator codeGenerator{function, method};
 

--- a/src/jllvm/compiler/Compiler.cpp
+++ b/src/jllvm/compiler/Compiler.cpp
@@ -25,10 +25,10 @@ llvm::Function* jllvm::compileMethod(llvm::Module& module, const Method& method)
     auto* function = llvm::Function::Create(
         descriptorToType(method.getType(), methodInfo.isStatic(), module.getContext()),
         llvm::GlobalValue::ExternalLinkage, mangleDirectMethodCall(methodInfo, *classFile), module);
-    addJavaMethodMetadata(function, &method, JavaMethodMetadata::Kind::JIT);
+    addJavaJITMethodMetadata(function, &method, CallingConvention::JIT);
     applyABIAttributes(function);
 
-    compileMethodBody(
+    llvm::Value* ret = compileMethodBody(
         function, method,
         [&](llvm::IRBuilder<>& builder, LocalVariables& locals, OperandStack&, const ByteCodeTypeChecker::TypeInfo&)
         {
@@ -53,22 +53,34 @@ llvm::Function* jllvm::compileMethod(llvm::Module& module, const Method& method)
             }
         });
 
+    if (auto* bb = llvm::dyn_cast<llvm::BasicBlock>(ret))
+    {
+        llvm::IRBuilder<> builder(bb);
+        builder.CreateRetVoid();
+    }
+    else
+    {
+        llvm::IRBuilder<> builder(llvm::cast<llvm::Instruction>(ret)->getParent());
+        builder.CreateRet(ret);
+    }
+
     return function;
 }
 
-llvm::Function* jllvm::compileOSRMethod(llvm::Module& module, std::uint16_t offset, const Method& method)
+llvm::Function* jllvm::compileOSRMethod(llvm::Module& module, std::uint16_t offset, const Method& method,
+                                        CallingConvention callingConvention)
 {
     const MethodInfo& methodInfo = method.getMethodInfo();
 
     auto* function =
-        llvm::Function::Create(osrMethodSignature(method.getType(), module.getContext()),
+        llvm::Function::Create(osrMethodSignature(method.getType(), callingConvention, module.getContext()),
                                llvm::GlobalValue::ExternalLinkage, mangleOSRMethod(&method, offset), module);
-    addJavaMethodMetadata(function, &method, JavaMethodMetadata::Kind::JIT);
+    addJavaJITMethodMetadata(function, &method, callingConvention);
     applyABIAttributes(function);
 
     llvm::Value* osrState = function->getArg(0);
 
-    compileMethodBody(
+    llvm::Value* result = compileMethodBody(
         function, method,
         [&](llvm::IRBuilder<>& builder, LocalVariables& locals, OperandStack& operandStack,
             const ByteCodeTypeChecker::TypeInfo& typeInfo)
@@ -121,6 +133,16 @@ llvm::Function* jllvm::compileOSRMethod(llvm::Module& module, std::uint16_t offs
             builder.CreateCall(callee, osrState);
         },
         offset);
+
+    llvm::Value* returnValue = nullptr;
+    auto* basicBlock = llvm::dyn_cast<llvm::BasicBlock>(result);
+    if (!basicBlock)
+    {
+        basicBlock = llvm::cast<llvm::Instruction>(result)->getParent();
+        returnValue = result;
+    }
+    llvm::IRBuilder<> builder(basicBlock);
+    emitReturn(builder, returnValue, callingConvention);
 
     return function;
 }

--- a/src/jllvm/compiler/Compiler.hpp
+++ b/src/jllvm/compiler/Compiler.hpp
@@ -18,6 +18,8 @@
 #include <jllvm/class/ClassFile.hpp>
 #include <jllvm/object/ClassObject.hpp>
 
+#include "ByteCodeCompileUtils.hpp"
+
 namespace jllvm
 {
 
@@ -25,6 +27,8 @@ namespace jllvm
 llvm::Function* compileMethod(llvm::Module& module, const Method& method);
 
 /// Compiles 'method' to a LLVM function suitable for OSR entry at the bytecode offset 'offset'. The function is placed
-/// into 'module' and returned.
-llvm::Function* compileOSRMethod(llvm::Module& module, std::uint16_t offset, const Method& method);
+/// into 'module' and returned. The return type of the function is suitable for replacing the method with the given
+/// calling convention.
+llvm::Function* compileOSRMethod(llvm::Module& module, std::uint16_t offset, const Method& method,
+                                 CallingConvention callingConvention);
 } // namespace jllvm

--- a/src/jllvm/llvm/ClassObjectStubImportPass.cpp
+++ b/src/jllvm/llvm/ClassObjectStubImportPass.cpp
@@ -21,7 +21,10 @@
 llvm::PreservedAnalyses jllvm::ClassObjectStubImportPass::run(llvm::Module& module, llvm::ModuleAnalysisManager&)
 {
     ClassObject* objectClass = m_classLoader.forNameLoaded(ObjectType("java/lang/Object"));
-    assert(objectClass && "java/lang/Object must have been loaded prior to any code ever executing");
+    if (!objectClass)
+    {
+        return llvm::PreservedAnalyses::all();
+    }
 
     // Early increment range as 'function' is potentially deleted.
     for (llvm::Function& function : llvm::make_early_inc_range(module.functions()))

--- a/src/jllvm/materialization/ByteCodeOSRCompileLayer.cpp
+++ b/src/jllvm/materialization/ByteCodeOSRCompileLayer.cpp
@@ -16,7 +16,8 @@
 #include "jllvm/compiler/Compiler.hpp"
 
 void jllvm::ByteCodeOSRCompileLayer::emit(std::unique_ptr<llvm::orc::MaterializationResponsibility> mr,
-                                          const jllvm::Method* method, std::uint16_t offset)
+                                          const jllvm::Method* method, std::uint16_t offset,
+                                          CallingConvention callingConvention)
 {
     auto context = std::make_unique<llvm::LLVMContext>();
     auto module = std::make_unique<llvm::Module>("name", *context);
@@ -24,7 +25,7 @@ void jllvm::ByteCodeOSRCompileLayer::emit(std::unique_ptr<llvm::orc::Materializa
     module->setDataLayout(m_dataLayout);
     module->setTargetTriple(LLVM_HOST_TRIPLE);
 
-    compileOSRMethod(*module, offset, *method);
+    compileOSRMethod(*module, offset, *method, callingConvention);
 
     m_baseLayer.emit(std::move(mr), llvm::orc::ThreadSafeModule(std::move(module), std::move(context)));
 }

--- a/src/jllvm/materialization/ByteCodeOSRCompileLayer.hpp
+++ b/src/jllvm/materialization/ByteCodeOSRCompileLayer.hpp
@@ -15,6 +15,8 @@
 
 #include <llvm/ExecutionEngine/Orc/Layer.h>
 
+#include <jllvm/compiler/Compiler.hpp>
+
 #include "ByteCodeOSRLayer.hpp"
 
 namespace jllvm
@@ -32,7 +34,7 @@ public:
     {
     }
 
-    void emit(std::unique_ptr<llvm::orc::MaterializationResponsibility> mr, const Method* method,
-              std::uint16_t offset) override;
+    void emit(std::unique_ptr<llvm::orc::MaterializationResponsibility> mr, const Method* method, std::uint16_t offset,
+              CallingConvention callingConvention) override;
 };
 } // namespace jllvm

--- a/src/jllvm/materialization/ByteCodeOSRLayer.hpp
+++ b/src/jllvm/materialization/ByteCodeOSRLayer.hpp
@@ -16,6 +16,7 @@
 #include <llvm/ExecutionEngine/Orc/Mangling.h>
 
 #include <jllvm/class/ClassFile.hpp>
+#include <jllvm/compiler/Compiler.hpp>
 #include <jllvm/object/ClassObject.hpp>
 
 namespace jllvm
@@ -42,10 +43,11 @@ public:
 
     /// Method called by the JIT to emit the requested symbols.
     virtual void emit(std::unique_ptr<llvm::orc::MaterializationResponsibility> mr, const Method* method,
-                      std::uint16_t byteCodeOffset) = 0;
+                      std::uint16_t byteCodeOffset, CallingConvention callingConvention) = 0;
 
     /// Adds a materialization unit for the given method at the given bytecode offset to 'dylib'.
-    llvm::Error add(llvm::orc::JITDylib& dylib, const Method* method, std::uint16_t byteCodeOffset);
+    llvm::Error add(llvm::orc::JITDylib& dylib, const Method* method, std::uint16_t byteCodeOffset,
+                    CallingConvention callingConvention);
 };
 
 } // namespace jllvm

--- a/src/jllvm/materialization/Interpreter2JITLayer.cpp
+++ b/src/jllvm/materialization/Interpreter2JITLayer.cpp
@@ -116,7 +116,7 @@ void jllvm::Interpreter2JITLayer::emit(std::unique_ptr<llvm::orc::Materializatio
     // JIT CC symbol to the adaptor.
     llvm::cantFail(mr->replace(createLambdaMaterializationUnit(
         symbol, m_baseLayer,
-        [=](const std::uint64_t* arguments) -> std::uint64_t
+        [=](const Method*, const std::uint64_t* arguments) -> std::uint64_t
         {
             return reinterpret_cast<std::uint64_t (*)(void*, const std::uint64_t*)>(adaptor)(
                 reinterpret_cast<void*>(jitCCSymbol), arguments);

--- a/src/jllvm/materialization/InterpreterEntry.cpp
+++ b/src/jllvm/materialization/InterpreterEntry.cpp
@@ -51,7 +51,7 @@ llvm::Value* jllvm::generateInterpreterEntry(
     llvm::CallInst* callInst = builder.CreateCall(
         module.getOrInsertFunction("jllvm_interpreter",
                                    llvm::FunctionType::get(builder.getInt64Ty(), types, /*isVarArg=*/false)),
-        arguments, llvm::OperandBundleDef("deopt", llvm::ArrayRef(arguments).drop_front()));
+        arguments, llvm::OperandBundleDef("deopt", arguments));
 
     llvm::Type* returnType = descriptorToType(method.getType().returnType(), builder.getContext());
     if (returnType->isVoidTy())

--- a/src/jllvm/materialization/InterpreterOSRLayer.hpp
+++ b/src/jllvm/materialization/InterpreterOSRLayer.hpp
@@ -32,7 +32,7 @@ public:
     {
     }
 
-    void emit(std::unique_ptr<llvm::orc::MaterializationResponsibility> mr, const Method* method,
-              std::uint16_t offset) override;
+    void emit(std::unique_ptr<llvm::orc::MaterializationResponsibility> mr, const Method* method, std::uint16_t offset,
+              CallingConvention callingConvention) override;
 };
 } // namespace jllvm

--- a/src/jllvm/materialization/JIT2InterpreterLayer.cpp
+++ b/src/jllvm/materialization/JIT2InterpreterLayer.cpp
@@ -38,7 +38,7 @@ void jllvm::JIT2InterpreterLayer::emit(std::unique_ptr<llvm::orc::Materializatio
 
     applyABIAttributes(function, method->getType(), method->isStatic());
     function->clearGC();
-    addJavaMethodMetadata(function, method, JavaMethodMetadata::Kind::Interpreter);
+    addJavaInterpreterMethodMetadata(function, CallingConvention::JIT);
 
     llvm::IRBuilder<> builder(llvm::BasicBlock::Create(*context, "entry", function));
 

--- a/src/jllvm/materialization/JNIImplementationLayer.cpp
+++ b/src/jllvm/materialization/JNIImplementationLayer.cpp
@@ -112,7 +112,7 @@ void jllvm::JNIImplementationLayer::emit(std::unique_ptr<llvm::orc::Materializat
 
     applyABIAttributes(function, methodType, method->isStatic());
     function->clearGC();
-    addJavaMethodMetadata(function, method, JavaMethodMetadata::Kind::Native);
+    addJavaNativeMethodMetadata(function, method);
 
     llvm::IRBuilder<> builder(llvm::BasicBlock::Create(*context, "entry", function));
     builder.SetCurrentDebugLocation(debugInfoBuilder.getNoopLoc());

--- a/src/jllvm/vm/Interpreter.cpp
+++ b/src/jllvm/vm/Interpreter.cpp
@@ -43,7 +43,161 @@ jllvm::Interpreter::Interpreter(VirtualMachine& virtualMachine, bool enableOSR)
                                                  localVariablesGCMask);
                       return executeMethod(*method, *byteCodeOffset, context);
                   }},
+        std::pair{"jllvm_interpreter_frame_sizes",
+                  [](const Method* method, std::uint16_t* numLocals, std::uint16_t* numOperands)
+                  {
+                      Code* code = method->getMethodInfo().getAttributes().find<Code>();
+                      *numLocals = code->getMaxLocals();
+                      *numOperands = code->getMaxStack();
+                  }},
+        std::pair{
+            "jllvm_interpreter_init_locals",
+            [](const Method* method, const std::uint64_t* arguments, std::uint64_t* locals, std::uint64_t* localsGCMask)
+            {
+                std::size_t argumentIndex = 0;
+                if (!method->isStatic())
+                {
+                    locals[argumentIndex] = arguments[argumentIndex];
+                    MutableBitArrayRef<>(localsGCMask, argumentIndex + 1)[argumentIndex] = true;
+                    argumentIndex++;
+                }
+
+                for (FieldType fieldType : method->getType().parameters())
+                {
+                    locals[argumentIndex] = arguments[argumentIndex];
+                    if (fieldType.isReference())
+                    {
+                        MutableBitArrayRef<>(localsGCMask, argumentIndex + 1)[argumentIndex] = true;
+                    }
+                    argumentIndex++;
+                    if (fieldType.isWide())
+                    {
+                        argumentIndex++;
+                    }
+                }
+            }},
         std::pair{"jllvm_osr_frame_delete", [](const std::uint64_t* osrFrame) { delete[] osrFrame; }});
+
+    // Reuse the linking order of the JIT CC interpreter entries for now.
+    m_jit2InterpreterSymbols.withLinkOrderDo([&](const llvm::orc::JITDylibSearchOrder& linkOrder)
+                                             { m_interpreterCCSymbols.setLinkOrder(linkOrder); });
+    generateInterpreterEntry();
+}
+
+void jllvm::Interpreter::generateInterpreterEntry()
+{
+    auto context = std::make_unique<llvm::LLVMContext>();
+    auto module = std::make_unique<llvm::Module>("module", *context);
+    module->setDataLayout(m_compiled2InterpreterLayer.getDataLayout());
+    module->setTargetTriple(LLVM_HOST_TRIPLE);
+
+    llvm::StringRef functionName = "Interpreter Entry";
+    auto* pointer = llvm::PointerType::get(*context, 0);
+    auto* function = llvm::Function::Create(
+        llvm::FunctionType::get(llvm::Type::getInt64Ty(*context), {pointer, pointer}, /*isVarArg=*/false),
+        llvm::GlobalValue::ExternalLinkage, functionName, module.get());
+
+    TrivialDebugInfoBuilder debugInfoBuilder(function);
+
+    applyABIAttributes(function);
+    function->clearGC();
+    addJavaInterpreterMethodMetadata(function, CallingConvention::Interpreter);
+
+    llvm::IRBuilder<> builder(llvm::BasicBlock::Create(*context, "entry", function));
+
+    builder.SetCurrentDebugLocation(debugInfoBuilder.getNoopLoc());
+
+    llvm::Value* methodRef = function->getArg(0);
+    llvm::Value* callerArguments = function->getArg(1);
+
+    llvm::AllocaInst* byteCodeOffset = builder.CreateAlloca(builder.getInt16Ty());
+    llvm::AllocaInst* topOfStack = builder.CreateAlloca(builder.getInt16Ty());
+
+    // Get the number local variable and operand stack slots from the runtime.
+    // The method uses two out parameters rather than a struct of two as the latter does not automatically adhere to the
+    // C ABI in LLVM.
+    llvm::AllocaInst* numLocalsPtr = builder.CreateAlloca(builder.getInt16Ty());
+    llvm::AllocaInst* numOperandsPtr = builder.CreateAlloca(builder.getInt16Ty());
+    builder.CreateCall(
+        module->getOrInsertFunction(
+            "jllvm_interpreter_frame_sizes",
+            llvm::FunctionType::get(builder.getVoidTy(),
+                                    {methodRef->getType(), numLocalsPtr->getType(), numOperandsPtr->getType()},
+                                    /*isVarArg=*/false)),
+        {methodRef, numLocalsPtr, numOperandsPtr});
+
+    llvm::Value* numLocals =
+        builder.CreateZExt(builder.CreateLoad(builder.getInt16Ty(), numLocalsPtr), builder.getInt32Ty());
+    llvm::Value* numOperands =
+        builder.CreateZExt(builder.CreateLoad(builder.getInt16Ty(), numOperandsPtr), builder.getInt32Ty());
+
+    auto divideCeil = [&](llvm::Value* value, llvm::Value* rhs)
+    {
+        // This is a 'ceil(value / rhs)' operation implemented in IR as "value / rhs + ((value % rhs) != 0)".
+        llvm::Value* remainder = builder.CreateURem(value, rhs);
+        value = builder.CreateUDiv(value, rhs);
+        return builder.CreateAdd(
+            value, builder.CreateZExt(builder.CreateICmpNE(remainder, llvm::ConstantInt::get(value->getType(), 0)),
+                                      value->getType()));
+    };
+
+    // Allocate the stack variables now that we know their sizes.
+    llvm::AllocaInst* operandStack = builder.CreateAlloca(builder.getInt64Ty(), numOperands);
+    llvm::AllocaInst* operandGCMask =
+        builder.CreateAlloca(builder.getInt64Ty(), divideCeil(numOperands, builder.getInt32(64)));
+    llvm::AllocaInst* localVariables = builder.CreateAlloca(builder.getInt64Ty(), numLocals);
+    llvm::AllocaInst* localVariablesGCMask =
+        builder.CreateAlloca(builder.getInt64Ty(), divideCeil(numLocals, builder.getInt32(64)));
+
+    builder.CreateMemSet(byteCodeOffset, builder.getInt8(0), sizeof(std::uint16_t), std::nullopt);
+    builder.CreateMemSet(topOfStack, builder.getInt8(0), sizeof(std::uint16_t), std::nullopt);
+
+    // These three technically do not have to be zeroed, but we do so anyway for ease of debugging and security.
+    // Can be changed in the future for performance.
+    builder.CreateMemSet(operandStack, builder.getInt8(0),
+                         builder.CreateMul(numOperands, builder.getInt32(sizeof(std::uint64_t))), std::nullopt);
+    builder.CreateMemSet(operandGCMask, builder.getInt8(0),
+                         builder.CreateMul(operandGCMask->getArraySize(), builder.getInt32(sizeof(std::uint64_t))),
+                         std::nullopt);
+    builder.CreateMemSet(localVariables, builder.getInt8(0),
+                         builder.CreateMul(numLocals, builder.getInt32(sizeof(std::uint64_t))), std::nullopt);
+
+    builder.CreateMemSet(
+        localVariablesGCMask, builder.getInt8(0),
+        builder.CreateMul(localVariablesGCMask->getArraySize(), builder.getInt32(sizeof(std::uint64_t))), std::nullopt);
+
+    // Initialize the local variables from the argument array.
+    builder.CreateCall(module->getOrInsertFunction(
+                           "jllvm_interpreter_init_locals",
+                           llvm::FunctionType::get(builder.getVoidTy(),
+                                                   {methodRef->getType(), callerArguments->getType(),
+                                                    localVariables->getType(), localVariablesGCMask->getType()},
+                                                   /*isVarArg=*/false)),
+                       {methodRef, callerArguments, localVariables, localVariablesGCMask});
+
+    std::array<llvm::Value*, 7> arguments = {methodRef,     byteCodeOffset, topOfStack,          operandStack,
+                                             operandGCMask, localVariables, localVariablesGCMask};
+    std::array<llvm::Type*, 7> types{};
+    llvm::transform(arguments, types.begin(), std::mem_fn(&llvm::Value::getType));
+
+    // Deopt all values used as context during interpretation. This makes it possible for the unwinder to read the
+    // method, local variables, the operand stack, the bytecode offset and where GC pointers are contained during
+    // unwinding.
+    llvm::CallInst* callInst = builder.CreateCall(
+        module->getOrInsertFunction("jllvm_interpreter",
+                                    llvm::FunctionType::get(builder.getInt64Ty(), types, /*isVarArg=*/false)),
+        arguments, llvm::OperandBundleDef("deopt", arguments));
+    builder.CreateRet(callInst);
+
+    debugInfoBuilder.finalize();
+
+    Runtime& runtime = m_virtualMachine.getRuntime();
+    llvm::cantFail(runtime.getLLVMIRLayer().add(m_interpreterCCSymbols,
+                                                llvm::orc::ThreadSafeModule(std::move(module), std::move(context))));
+
+    m_interpreterEntry = reinterpret_cast<decltype(m_interpreterEntry)>(
+        llvm::cantFail(runtime.getSession().lookup({&m_interpreterCCSymbols}, runtime.getInterner()(functionName)))
+            .getAddress());
 }
 
 namespace
@@ -1227,11 +1381,12 @@ std::uint64_t jllvm::Interpreter::executeMethod(const Method& method, std::uint1
     }
 }
 
-void* Interpreter::getOSREntry(const Method& method, std::uint16_t byteCodeOffset)
+void* Interpreter::getOSREntry(const Method& method, std::uint16_t byteCodeOffset, CallingConvention callingConvention)
 {
     llvm::orc::SymbolStringPtr mangledName =
         m_interpreterOSRLayer.getInterner()(mangleOSRMethod(&method, byteCodeOffset));
-    allowDuplicateDefinitions(m_interpreterOSRLayer.add(m_jit2InterpreterSymbols, &method, byteCodeOffset));
+    allowDuplicateDefinitions(
+        m_interpreterOSRLayer.add(m_jit2InterpreterSymbols, &method, byteCodeOffset, callingConvention));
 
     llvm::JITEvaluatedSymbol osrMethod =
         llvm::cantFail(m_virtualMachine.getRuntime().getSession().lookup({&m_jit2InterpreterSymbols}, mangledName));
@@ -1282,8 +1437,8 @@ std::unique_ptr<std::uint64_t[]> Interpreter::createOSRBuffer(std::uint16_t byte
 void Interpreter::add(const Method& method)
 {
     llvm::cantFail(m_compiled2InterpreterLayer.add(m_jit2InterpreterSymbols, &method));
-    // TODO: Forego Interpreter -> JIT -> Interpreter conversion by implementing an interpreter calling convention
-    //       entry.
-    llvm::cantFail(
-        m_virtualMachine.getRuntime().getInterpreter2JITLayer().add(m_interpreterCCSymbols, method, getJITCCDylib()));
+    // All methods in the interpreter calling convention simply reuse the single entry.
+    llvm::cantFail(m_interpreterCCSymbols.define(
+        llvm::orc::absoluteSymbols({{m_compiled2InterpreterLayer.getInterner()(mangleDirectMethodCall(&method)),
+                                     llvm::JITEvaluatedSymbol::fromPointer(m_interpreterEntry)}})));
 }

--- a/src/jllvm/vm/Interpreter.hpp
+++ b/src/jllvm/vm/Interpreter.hpp
@@ -210,6 +210,9 @@ class Interpreter : public OSRTarget
     /// Enable OSR from the interpreter into the JIT if the method is hot enough.
     bool m_enableOSR;
 
+    /// Single entry for use in 'm_interpreterCCSymbols' as an implementation for ALL methods.
+    std::uint64_t (*m_interpreterEntry)(const Method*, const std::uint64_t*){};
+
     llvm::orc::JITDylib& m_jit2InterpreterSymbols;
     llvm::orc::JITDylib& m_interpreterCCSymbols;
 
@@ -241,6 +244,9 @@ class Interpreter : public OSRTarget
     /// Returns the result of the method bitcast to an uint64_t.
     std::uint64_t executeMethod(const Method& method, std::uint16_t& offset, InterpreterContext& context);
 
+    /// Initializes 'm_interpreterEntry' by generating LLVM IR.
+    void generateInterpreterEntry();
+
 public:
     explicit Interpreter(VirtualMachine& virtualMachine, bool enableOSR);
 
@@ -261,7 +267,7 @@ public:
         return !(method.isNative() || method.isAbstract());
     }
 
-    void* getOSREntry(const Method& method, std::uint16_t byteCodeOffset) override;
+    void* getOSREntry(const Method& method, std::uint16_t byteCodeOffset, CallingConvention callingConvention) override;
 
     OSRState createOSRStateFromInterpreterFrame(InterpreterFrame frame) override;
 

--- a/src/jllvm/vm/JIT.cpp
+++ b/src/jllvm/vm/JIT.cpp
@@ -99,11 +99,13 @@ void jllvm::JIT::add(const Method& method)
         m_virtualMachine.getRuntime().getInterpreter2JITLayer().add(m_interpreter2JITSymbols, method, getJITCCDylib()));
 }
 
-void* jllvm::JIT::getOSREntry(const jllvm::Method& method, std::uint16_t byteCodeOffset)
+void* jllvm::JIT::getOSREntry(const jllvm::Method& method, std::uint16_t byteCodeOffset,
+                              CallingConvention callingConvention)
 {
     llvm::orc::SymbolStringPtr mangledName =
         m_byteCodeOSRCompileLayer.getInterner()(mangleOSRMethod(&method, byteCodeOffset));
-    allowDuplicateDefinitions(m_byteCodeOSRCompileLayer.add(m_javaJITSymbols, &method, byteCodeOffset));
+    allowDuplicateDefinitions(
+        m_byteCodeOSRCompileLayer.add(m_javaJITSymbols, &method, byteCodeOffset, callingConvention));
 
     llvm::JITEvaluatedSymbol osrMethod =
         llvm::cantFail(m_virtualMachine.getRuntime().getSession().lookup({&m_javaJITSymbols}, mangledName));

--- a/src/jllvm/vm/JIT.hpp
+++ b/src/jllvm/vm/JIT.hpp
@@ -83,7 +83,7 @@ public:
         return m_interpreter2JITSymbols;
     }
 
-    void* getOSREntry(const Method& method, std::uint16_t byteCodeOffset) override;
+    void* getOSREntry(const Method& method, std::uint16_t byteCodeOffset, CallingConvention callingConvention) override;
 
     OSRState createOSRStateFromInterpreterFrame(InterpreterFrame frame) override;
 

--- a/src/jllvm/vm/JavaFrame.hpp
+++ b/src/jllvm/vm/JavaFrame.hpp
@@ -56,15 +56,18 @@ public:
         return m_javaMethodMetadata->isNative();
     }
 
+    /// Returns the calling convention used by this frame.
+    CallingConvention getCallingConvention() const
+    {
+        return m_javaMethodMetadata->getCallingConvention();
+    }
+
     /// Returns the bytecode offset of the frame currently being executed.
     /// Returns an empty optional if the method being executed is native and therefore does not have a bytecode offset.
     std::optional<std::uint16_t> getByteCodeOffset() const;
 
     /// Returns the method object currently being executed.
-    const Method* getMethod() const
-    {
-        return m_javaMethodMetadata->getMethod();
-    }
+    const Method* getMethod() const;
 
     /// Returns the enclosing class object of the method currently being executed.
     const ClassObject* getClassObject() const

--- a/src/jllvm/vm/OSRState.hpp
+++ b/src/jllvm/vm/OSRState.hpp
@@ -29,11 +29,13 @@ class OSRState;
 class OSRTarget : public Executor
 {
 public:
-    /// Returns an OSR version for 'method' starting at the given 'byteCodeOffset'.
-    /// The method must have the signature '<original-ret-type>(uint64_t*)' where the 'uint64_t*' is the buffer the
+    /// Returns an OSR version for 'method' starting at the given 'byteCodeOffset' with the given calling convention.
+    /// The method must have the signature '<cc-ret-type>(uint64_t*)' where the 'uint64_t*' is the buffer the
     /// 'OSRState's are initialized with by the 'createOSRState*' methods below. This buffer should be used to
-    /// initialize the abstract machine state at the given 'byteCodeOffset'.
-    virtual void* getOSREntry(const Method& method, std::uint16_t byteCodeOffset) = 0;
+    /// initialize the abstract machine state at the given 'byteCodeOffset'. The 'cc-ret-type' is the return type as
+    /// specified by the given calling convention.
+    virtual void* getOSREntry(const Method& method, std::uint16_t byteCodeOffset,
+                              CallingConvention callingConvention) = 0;
 
     /// Methods creating an 'OSRState' method suitable for use by functions returned by 'getOSREntry' and initializing
     /// it from their given parameters.

--- a/src/jllvm/vm/Runtime.cpp
+++ b/src/jllvm/vm/Runtime.cpp
@@ -318,7 +318,8 @@ void jllvm::Runtime::prepare(ClassObject& classObject)
 
 void jllvm::Runtime::doOnStackReplacement(JavaFrame frame, OSRState&& state)
 {
-    void* entry = state.getTarget().getOSREntry(*frame.getMethod(), state.getByteCodeOffset());
+    void* entry =
+        state.getTarget().getOSREntry(*frame.getMethod(), state.getByteCodeOffset(), frame.getCallingConvention());
     frame.getUnwindFrame().resumeExecutionAtFunction(reinterpret_cast<void (*)(std::uint64_t*)>(entry),
                                                      state.release());
 }

--- a/src/jllvm/vm/Runtime.hpp
+++ b/src/jllvm/vm/Runtime.hpp
@@ -197,14 +197,15 @@ public:
         return reinterpret_cast<Fn*>(lookupJITCC(className, methodName, descriptor));
     }
 
-    /// Interpreter calling convention. The one parameter is the array of arguments where all values are bitcast to
-    /// 'std::uint64_t'. Values of type 'long' or 'double' occupy two slots on the argument array with the actual
-    /// value contained in the first of the two slots.
-    using InterpreterCC = std::uint64_t(const std::uint64_t*);
+    /// Interpreter calling convention. The first parameter is the method that should be interpreted while the second
+    /// parameter is the array of arguments where all values are bitcast to 'std::uint64_t'. Values of type 'long' or
+    /// 'double' occupy two slots on the argument array with the actual value contained in the first of the two slots.
+    using InterpreterCC = std::uint64_t(const Method*, const std::uint64_t*);
 
     /// Returns a function pointer for calling 'method' using the interpreter calling convention.
+    /// For convenience, the first parameter is already bound to 'method'.
     /// Returns null if the method is not callable.
-    InterpreterCC* lookupInterpreterCC(const Method& method)
+    llvm::unique_function<std::uint64_t(const std::uint64_t*)> lookupInterpreterCC(const Method& method)
     {
         llvm::Expected<llvm::JITEvaluatedSymbol> symbol =
             m_session->lookup({&m_interpreterCCStubs}, m_interner(mangleDirectMethodCall(&method)));
@@ -213,7 +214,8 @@ public:
             llvm::consumeError(symbol.takeError());
             return nullptr;
         }
-        return reinterpret_cast<InterpreterCC*>(symbol->getAddress());
+        return [&method, address = symbol->getAddress()](const std::uint64_t* arguments)
+        { return reinterpret_cast<InterpreterCC*>(address)(&method, arguments); };
     }
 
     /// Returns the metadata associated with any Java method.

--- a/tools/jllvm-jvmc/main.cpp
+++ b/tools/jllvm-jvmc/main.cpp
@@ -161,7 +161,7 @@ int main(int argc, char** argv)
             llvm::errs() << "invalid integer '" << ref << "' as argument to '--osr'\n";
             return -1;
         }
-        compileOSRMethod(module, offset, *method);
+        compileOSRMethod(module, offset, *method, jllvm::CallingConvention::JIT);
     }
     else
     {


### PR DESCRIPTION
Our VM currently uses two calling conventions: The JIT calling convention and the Interpreter calling convention. The latter is used by the interpreter to make calls to other methods.

Prior to this PR, if the interpreter called another method in the interpreter-tier an inefficiency occurred: The interpreter currently only implements the JIT calling convention and made use of adaptors to translate between the interpreter and JIT calling convention. The JIT CC interpreter entry then translated back from the JIT calling convention to the interpreter state.

This PR fixes that by creating a new entry method into the interpreter. It is implemented in LLVM IR compiled only once on startup and is callable with just a method object and an arguments array. This entry is then used for ALL methods when using the interpreter CC, meaning no LLVM IR or adaptors have to ever be generated for interpreter to interpreter calls.

The entry uses the same method metadata and deopt operands as interpreter entries generated so far to remain compatible with the rest of the VM.

The only larger sideeffect of this change is that OSR had to now also be implemented for the interpreter calling convention. This was not needed so far as all the methods being replaced have followed the JIT calling convention. The method metadata now additionally contains the calling convention used and was reworked a bit to be more memory efficient, easier to use and work with the new single interpreter entry.