### PR TITLE
[interpreter] Implement `dcmp`, `fcmp` and `lcmp`

### DIFF
--- a/src/jllvm/class/ByteCodeIterator.hpp
+++ b/src/jllvm/class/ByteCodeIterator.hpp
@@ -254,9 +254,9 @@ concept IsIfCmp =
 template <class T>
 concept IsIf = llvm::is_one_of<T, IfEq, IfNe, IfLt, IfGe, IfGt, IfLe, IfNull, IfNonNull>::value;
 
-/// Satisfied when 'T' performs a floating point comparison.
+/// Satisfied when 'T' performs a comparison.
 template <class T>
-concept IsFPCmp = llvm::is_one_of<T, DCmpG, DCmpL, FCmpG, FCmpL>::value;
+concept IsCmp = llvm::is_one_of<T, DCmpG, DCmpL, FCmpG, FCmpL, LCmp>::value;
 
 /// Satisfied when 'T' is a load operation.
 template <class T>
@@ -364,7 +364,7 @@ concept OperatesOnDouble = llvm::is_one_of<T, DLoad, DLoad0, DLoad1, DLoad2, DLo
 template <class T>
 concept OperatesOnLong = llvm::is_one_of<T, LLoad, LLoad0, LLoad1, LLoad2, LLoad3, LStore, LStore0, LStore1, LStore2,
                                          LStore3, LAdd, LSub, LMul, LDiv, LRem, LNeg, LReturn, LALoad, LAStore, LConst0,
-                                         LConst1, LOr, LAnd, LXor, LShl, LShr, LUShr, L2D, L2F, L2I>::value;
+                                         LConst1, LOr, LAnd, LXor, LShl, LShr, LUShr, L2D, L2F, L2I, LCmp>::value;
 
 /// Satisfied when 'T' may throw an exception.
 template <class T>

--- a/src/jllvm/class/ByteCodeIterator.hpp
+++ b/src/jllvm/class/ByteCodeIterator.hpp
@@ -254,6 +254,10 @@ concept IsIfCmp =
 template <class T>
 concept IsIf = llvm::is_one_of<T, IfEq, IfNe, IfLt, IfGe, IfGt, IfLe, IfNull, IfNonNull>::value;
 
+/// Satisfied when 'T' performs a floating point comparison.
+template <class T>
+concept IsFPCmp = llvm::is_one_of<T, DCmpG, DCmpL, FCmpG, FCmpL>::value;
+
 /// Satisfied when 'T' is a load operation.
 template <class T>
 concept IsLoad = llvm::is_one_of<T, ILoad, ALoad, FLoad, DLoad, LLoad>::value;
@@ -346,15 +350,15 @@ concept OperatesOnReferences =
 
 /// Satisfied when 'T' operates on 'float' operands.
 template <class T>
-concept OperatesOnFloat =
-    llvm::is_one_of<T, FLoad, FLoad0, FLoad1, FLoad2, FLoad3, FStore, FStore0, FStore1, FStore2, FStore3, FAdd, FSub,
-                    FMul, FDiv, FRem, FNeg, FReturn, FALoad, FAStore, FConst0, FConst1, FConst2, F2D, F2I, F2L>::value;
+concept OperatesOnFloat = llvm::is_one_of<T, FLoad, FLoad0, FLoad1, FLoad2, FLoad3, FStore, FStore0, FStore1, FStore2,
+                                          FStore3, FAdd, FSub, FMul, FDiv, FRem, FNeg, FReturn, FALoad, FAStore,
+                                          FConst0, FConst1, FConst2, F2D, F2I, F2L, FCmpG, FCmpL>::value;
 
 /// Satisfied when 'T' operates on 'double' operands.
 template <class T>
-concept OperatesOnDouble =
-    llvm::is_one_of<T, DLoad, DLoad0, DLoad1, DLoad2, DLoad3, DStore, DStore0, DStore1, DStore2, DStore3, DAdd, DSub,
-                    DMul, DDiv, DRem, DNeg, DReturn, DALoad, DAStore, DConst0, DConst1, D2F, D2I, D2L>::value;
+concept OperatesOnDouble = llvm::is_one_of<T, DLoad, DLoad0, DLoad1, DLoad2, DLoad3, DStore, DStore0, DStore1, DStore2,
+                                           DStore3, DAdd, DSub, DMul, DDiv, DRem, DNeg, DReturn, DALoad, DAStore,
+                                           DConst0, DConst1, D2F, D2I, D2L, DCmpG, DCmpL>::value;
 
 /// Satisfied when 'T' operates on 'long' operands.
 template <class T>

--- a/src/jllvm/vm/Interpreter.cpp
+++ b/src/jllvm/vm/Interpreter.cpp
@@ -497,7 +497,7 @@ struct MultiTypeImpls
         return NextPC{};
     }
 
-    template <IsFPCmp T>
+    template <IsCmp T>
     NextPC operator()(T) const
     {
         auto value2 = context.pop<typename InstructionElementType<T>::type>();
@@ -893,24 +893,6 @@ std::uint64_t jllvm::Interpreter::executeMethod(const Method& method, std::uint1
 
                 ClassObject* classObject = getClassObject(classFile, instanceOf.index);
                 context.push<std::int32_t>(object->instanceOf(classObject));
-                return NextPC{};
-            },
-            [&](LCmp)
-            {
-                auto value2 = context.pop<std::int64_t>();
-                auto value1 = context.pop<std::int64_t>();
-                if (value1 > value2)
-                {
-                    context.push<std::int32_t>(1);
-                }
-                else if (value1 == value2)
-                {
-                    context.push<std::int32_t>(0);
-                }
-                else
-                {
-                    context.push<std::int32_t>(-1);
-                }
                 return NextPC{};
             },
             [&](OneOf<LDC, LDCW, LDC2W> ldc)

--- a/src/jllvm/vm/Interpreter.cpp
+++ b/src/jllvm/vm/Interpreter.cpp
@@ -913,16 +913,6 @@ std::uint64_t jllvm::Interpreter::executeMethod(const Method& method, std::uint1
                 }
                 return NextPC{};
             },
-            [&](LConst0)
-            {
-                context.push<std::int64_t>(0);
-                return NextPC{};
-            },
-            [&](LConst1)
-            {
-                context.push<std::int64_t>(1);
-                return NextPC{};
-            },
             [&](OneOf<LDC, LDCW, LDC2W> ldc)
             {
                 PoolIndex<IntegerInfo, FloatInfo, LongInfo, DoubleInfo, StringInfo, ClassInfo, MethodRefInfo,


### PR DESCRIPTION
These are the last arithmetic instructions left unimplemented in the interpreter. While `lcmp` is straight forward, `fcmp` and `dcmp` have two variants which differ in behavior when an operand is a NaN.