### PR TITLE
[interpreter] Fix UB in `*neg` implementations

### DIFF
--- a/src/jllvm/vm/Interpreter.cpp
+++ b/src/jllvm/vm/Interpreter.cpp
@@ -211,7 +211,7 @@ struct MultiTypeImpls
     template <IsNeg T>
     NextPC operator()(T) const
     {
-        context.push(-context.pop<typename InstructionElementType<T>::signed_type>());
+        context.push(-context.pop<typename InstructionElementType<T>::unsigned_type>());
         return {};
     }
 

--- a/tests/Execution/interpreter-ineg-ub.j
+++ b/tests/Execution/interpreter-ineg-ub.j
@@ -1,0 +1,24 @@
+; RUN: jasmin %s -d %t
+; RUN: jllvm -Xint %t/Test.class | FileCheck %s
+
+.class public Test
+.super java/lang/Object
+
+.method public <init>()V
+    aload_0
+    invokespecial java/lang/Object/<init>()V
+    return
+.end method
+
+.method public static native print(I)V
+.end method
+
+.method public static main([Ljava/lang/String;)V
+.limit locals 1
+.limit stack 1
+    getstatic java/lang/Integer/MIN_VALUE I
+    ineg
+    ; CHECK: -2147483648
+    invokestatic Test.print(I)V
+    return
+.end method


### PR DESCRIPTION
The implementations of `ineg` and `lneg` incorrectly used the signed type when performing the negation. In C++ signed overflow is undefined behavior which is luckily caught by UB sanitizer.

This PR fixes that issue by simply using the unsigned type to perform the negation. Negation on unsigned is specified to behave the same as signed but without the undefined behavior.