### PR TITLE
[ci][cmake] Workaround "bug" in LLD

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -77,8 +77,10 @@ jobs:
             $sanitizer_arg = '-DCMAKE_CXX_FLAGS="-g1 -fsanitize=${{matrix.sanitizer}} -fno-sanitize-recover=all"'
           }
           
+          # Don't use LLD in a fully optimized build as it currently contains bugs related to exception handling.
+          # See https://github.com/llvm/llvm-project/issues/61434
           $use_lld = ''
-          if (!$IsMacOs) {
+          if (!$IsMacOs -and '${{matrix.sanitizer}}') {
             $use_lld = '-DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld"'
           }
           

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,13 @@ if (JLLVM_ENABLE_ASSERTIONS)
     endif()
 endif ()
 
+if (CMAKE_BUILD_TYPE STREQUAL "Release")
+    if (CMAKE_EXE_LINKER_FLAGS MATCHES "-fuse-ld=lld")
+        message(WARNING "LLD does not currently handle exception handling correctly in optimized code. Use LD instead."
+                "See https://github.com/llvm/llvm-project/issues/61434")
+    endif ()
+endif ()
+
 set(JLLVM_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(JLLVM_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
 set(JLLVM_TOOLS_DIR ${CMAKE_BINARY_DIR}/bin)


### PR DESCRIPTION
The combination of exception handling, optimizations creating empty functions and using LLD exposes an upstream issue in the toolchain which leads to `libgcc` and `libunwind` crashing on malformed data: https://github.com/llvm/llvm-project/issues/61434

This has also lead to our CI crashing: https://github.com/JLLVM/JLLVM/actions/runs/7346263904/job/20000726099

The issue is most easily worked around by not using LLD in release builds. Other fixes such as reducing our use of `llvm_unreachable` or checking whether there are compiler options to avoid emitting zero-sized functions can be considered in the future.

Until this issue is fixed upstream, change our CI to not use LLD in fully optimized builds and add code to cmake to warn when using release builds with LLD to avoid the issue.