### PR TITLE
[interpreter] Implement `newarray` and `multianewarray` operations

### DIFF
--- a/src/jllvm/class/ByteCodeIterator.cpp
+++ b/src/jllvm/class/ByteCodeIterator.cpp
@@ -90,7 +90,7 @@ template <std::same_as<NewArray>>
 ByteCodeOp parseNewArray(const char* bytes, std::size_t offset)
 {
     consume<OpCodes>(bytes);
-    return NewArray{offset, consume<ArrayOp::ArrayType>(bytes)};
+    return NewArray{offset, consume<BaseType::Values>(bytes)};
 }
 
 template <std::same_as<IInc>>

--- a/src/jllvm/class/ByteCodeIterator.hpp
+++ b/src/jllvm/class/ByteCodeIterator.hpp
@@ -22,6 +22,8 @@
 
 #include <swl/variant.hpp>
 
+#include "Descriptors.hpp"
+
 namespace jllvm
 {
 /// All JVM OpCodes that exist in version 17 with their identifying byte values.
@@ -59,19 +61,7 @@ struct BranchOffsetOp : ByteCodeBase
 
 struct ArrayOp : ByteCodeBase
 {
-    enum class ArrayType : std::uint8_t
-    {
-        TBoolean = 4,
-        TChar = 5,
-        TFloat = 6,
-        TDouble = 7,
-        TByte = 8,
-        TShort = 9,
-        TInt = 10,
-        TLong = 11
-    };
-
-    ArrayType atype{};
+    BaseType::Values componentType{};
 };
 
 struct SwitchOp : ByteCodeBase

--- a/src/jllvm/compiler/CodeGenerator.cpp
+++ b/src/jllvm/compiler/CodeGenerator.cpp
@@ -148,7 +148,7 @@ ArrayInfo resolveNewArrayInfo(BaseType::Values componentType, llvm::IRBuilder<>&
         case Type::Boolean:
             return {builder.getInt8Ty(), sizeof(std::uint8_t), Array<std::uint8_t>::arrayElementsOffset()};
         case Type::Char:
-            return {builder.getInt16Ty(), sizeof(std::uint16_t), jllvm::Array<std::uint16_t>::arrayElementsOffset()};
+            return {builder.getInt16Ty(), sizeof(std::uint16_t), Array<std::uint16_t>::arrayElementsOffset()};
         case Type::Float: return {builder.getFloatTy(), sizeof(float), Array<float>::arrayElementsOffset()};
         case Type::Double: return {builder.getDoubleTy(), sizeof(double), Array<double>::arrayElementsOffset()};
         case Type::Byte: return {builder.getInt8Ty(), sizeof(std::uint8_t), Array<std::uint8_t>::arrayElementsOffset()};

--- a/src/jllvm/compiler/CodeGenerator.hpp
+++ b/src/jllvm/compiler/CodeGenerator.hpp
@@ -85,8 +85,6 @@ class CodeGenerator
 
     void generateNegativeArraySizeCheck(std::uint16_t byteCodeOffset, llvm::Value* size);
 
-    void generateExceptionThrow(std::uint16_t byteCodeOffset, llvm::Value* exception);
-
     llvm::Value* loadClassObjectFromPool(std::uint16_t offset, PoolIndex<ClassInfo> index);
 
     llvm::Value* generateAllocArray(std::uint16_t offset, ArrayType descriptor, llvm::Value* classObject,

--- a/src/jllvm/gc/GarbageCollector.hpp
+++ b/src/jllvm/gc/GarbageCollector.hpp
@@ -265,30 +265,8 @@ public:
     AbstractArray* allocate(const ClassObject* classObject, std::uint32_t length)
     {
         assert(classObject->isArray());
-        std::size_t sizeOf = classObject->getComponentType()->getDescriptor().sizeOf();
-        void* allocation = allocate(classObject->getInstanceSize() + sizeOf * length);
-        // Try really hard to adhere to C++ type aliasing rules. All of these are technically identical in semantics
-        // except the type being returned. TODO: Figure out in the future whether there is a smarter way to do this
-        //  type aliasing wise.
-        return match(
-            classObject->getComponentType()->getDescriptor(),
-            [&](BaseType baseType) -> AbstractArray*
-            {
-                switch (baseType.getValue())
-                {
-                    case BaseType::Boolean: return new (allocation) Array<bool>(classObject, length);
-                    case BaseType::Char: return new (allocation) Array<std::uint16_t>(classObject, length);
-                    case BaseType::Float: return new (allocation) Array<float>(classObject, length);
-                    case BaseType::Double: return new (allocation) Array<double>(classObject, length);
-                    case BaseType::Byte: return new (allocation) Array<std::int8_t>(classObject, length);
-                    case BaseType::Short: return new (allocation) Array<std::int16_t>(classObject, length);
-                    case BaseType::Int: return new (allocation) Array<std::int32_t>(classObject, length);
-                    case BaseType::Long: return new (allocation) Array<std::int64_t>(classObject, length);
-                    case BaseType::Void: break;
-                }
-                llvm_unreachable("not possible");
-            },
-            [&](...) -> AbstractArray* { return new (allocation) Array<ObjectInterface*>(classObject, length); });
+        return selectForJVMType(classObject->getComponentType()->getDescriptor(),
+                                [&]<class C>(C) -> AbstractArray* { return allocate<Array<C>>(classObject, length); });
     }
 
     /// Pushes a new local frame onto the internal stack, making it the currently active frame.

--- a/src/jllvm/object/ClassObject.hpp
+++ b/src/jllvm/object/ClassObject.hpp
@@ -874,7 +874,7 @@ struct ClassGraph
 /// Calls the relevant overload of 'f' based on which C++ type the FieldType 'type' corresponds to
 /// The argument to 'f' is a default constructed value of the relevant type
 template <class F>
-inline auto selectForJVMType(jllvm::FieldType type, F&& f)
+decltype(auto) selectForJVMType(FieldType type, F&& f)
 {
     return match(
         type,

--- a/src/jllvm/object/ClassObject.hpp
+++ b/src/jllvm/object/ClassObject.hpp
@@ -871,6 +871,31 @@ struct ClassGraph
     const ClassObject* root;
 };
 
+// TODO: name
+template <class F>
+inline auto selectForJVMType(jllvm::FieldType type, F&& f)
+{
+    return match(
+        type,
+        [&](BaseType baseType)
+        {
+            switch (baseType.getValue())
+            {
+                case BaseType::Boolean: return f(std::uint8_t{});
+                case BaseType::Char: return f(std::uint16_t{});
+                case BaseType::Byte: return f(std::uint8_t{});
+                case BaseType::Short: return f(std::int16_t{});
+                case BaseType::Int: return f(std::int32_t{});
+                case BaseType::Float: return f(float{});
+                case BaseType::Double: return f(double{});
+                case BaseType::Long: return f(std::int64_t{});
+                case BaseType::Void: break;
+            }
+            llvm_unreachable("void parameter is not possible");
+        },
+        [&](auto) { return f((ObjectInterface*){}); });
+}
+
 } // namespace jllvm
 
 template <>

--- a/src/jllvm/object/ClassObject.hpp
+++ b/src/jllvm/object/ClassObject.hpp
@@ -871,7 +871,8 @@ struct ClassGraph
     const ClassObject* root;
 };
 
-// TODO: name
+/// Calls the relevant overload of 'f' based on which C++ type the FieldType 'type' corresponds to
+/// The argument to 'f' is a default constructed value of the relevant type
 template <class F>
 inline auto selectForJVMType(jllvm::FieldType type, F&& f)
 {

--- a/src/jllvm/object/Object.hpp
+++ b/src/jllvm/object/Object.hpp
@@ -95,12 +95,12 @@ public:
     /// Returns the length of the array.
     std::uint32_t size() const
     {
-        struct Layout
+        struct ArrayHeader
         {
             ObjectHeader header;
             std::uint32_t length{};
         };
-        return *reinterpret_cast<const std::uint32_t*>(reinterpret_cast<const char*>(this) + offsetof(Layout, length));
+        return reinterpret_cast<const ArrayHeader*>(this)->length;
     }
 };
 

--- a/src/jllvm/object/Object.hpp
+++ b/src/jllvm/object/Object.hpp
@@ -92,15 +92,16 @@ concept JavaCompatible =
 class AbstractArray : public ObjectInterface
 {
 public:
+    struct ArrayHeader
+    {
+        ObjectHeader header;
+        std::uint32_t length{};
+    };
+
     /// Returns the length of the array.
     std::uint32_t size() const
     {
-        struct Layout
-        {
-            ObjectHeader header;
-            std::uint32_t length{};
-        };
-        return *reinterpret_cast<const std::uint32_t*>(reinterpret_cast<const char*>(this) + offsetof(Layout, length));
+        return reinterpret_cast<const ArrayHeader*>(this)->length;
     }
 };
 
@@ -109,14 +110,13 @@ public:
 template <JavaCompatible T = ObjectInterface*>
 class Array : public AbstractArray
 {
-    ObjectHeader m_header;
-    std::uint32_t m_length;
+    AbstractArray::ArrayHeader m_header;
     // GCC and Clang extension allowing to place and index into an array placed right after the object
     // without introducing any padding inbetween.
     T m_trailing[];
 
 public:
-    Array(const ClassObject* classObject, std::uint32_t length) : m_header{classObject}, m_length{length} {}
+    Array(const ClassObject* classObject, std::uint32_t length) : m_header{ObjectHeader{classObject}, length} {}
 
     using value_type = T;
 
@@ -138,13 +138,13 @@ public:
     /// Returns the array element with the given index.
     T& operator[](std::uint32_t index)
     {
-        assert(index < m_length);
+        assert(index < m_header.length);
         return m_trailing[index];
     }
 
     T operator[](std::uint32_t index) const
     {
-        assert(index < m_length);
+        assert(index < m_header.length);
         return m_trailing[index];
     }
 
@@ -173,12 +173,12 @@ public:
     /// Returns the end iterator of the array.
     T* end()
     {
-        return m_trailing + m_length;
+        return m_trailing + m_header.length;
     }
 
     const T* end() const
     {
-        return m_trailing + m_length;
+        return m_trailing + m_header.length;
     }
 };
 

--- a/src/jllvm/vm/Interpreter.cpp
+++ b/src/jllvm/vm/Interpreter.cpp
@@ -48,11 +48,7 @@ using InstructionResult = swl::variant<SetPC, NextPC, ReturnValue>;
 jllvm::ClassObject* jllvm::Interpreter::getClassObject(const ClassFile& classFile, PoolIndex<ClassInfo> index)
 {
     llvm::StringRef className = index.resolve(classFile)->nameIndex.resolve(classFile)->text;
-    if (className.front() == '[')
-    {
-        return &m_virtualMachine.getClassLoader().forName(FieldType(className));
-    }
-    return &m_virtualMachine.getClassLoader().forName(ObjectType(className));
+    return &m_virtualMachine.getClassLoader().forName(FieldType::fromMangled(className));
 }
 
 std::tuple<jllvm::ClassObject*, llvm::StringRef, jllvm::FieldType>
@@ -633,11 +629,61 @@ std::uint64_t jllvm::Interpreter::executeMethod(const Method& method, std::uint1
                 }
                 return SetPC{static_cast<std::uint16_t>(switchOp.offset + result->second)};
             },
+            [&](MultiANewArray multiANewArray)
+            {
+                ClassObject* classObject = getClassObject(classFile, multiANewArray.index);
+                std::vector<std::int32_t> counts(multiANewArray.dimensions);
+
+                std::generate(counts.rbegin(), counts.rend(), [&] { return context.pop<std::int32_t>(); });
+
+                for (std::int32_t count : counts)
+                {
+                    if (count < 0)
+                    {
+                        m_virtualMachine.throwNegativeArraySizeException(count);
+                    }
+                };
+
+                auto generateArray = [&](llvm::ArrayRef<std::int32_t> counts, ArrayType currentType,
+                                         const auto generator) -> ObjectInterface*
+                {
+                    std::int32_t count = counts.front();
+                    counts = counts.drop_front();
+                    ClassObject& arrayType = m_virtualMachine.getClassLoader().forName(currentType);
+                    auto* array = m_virtualMachine.getGC().allocate<AbstractArray>(&arrayType, count);
+                    if (!counts.empty())
+                    {
+                        auto* outerArray = static_cast<Array<>*>(array);
+                        auto componentType = get<ArrayType>(currentType.getComponentType());
+                        std::generate(outerArray->begin(), outerArray->end(),
+                                      [&]() { return generator(counts, componentType, generator); });
+                    }
+                    return array;
+                };
+
+                context.push(generateArray(counts, get<ArrayType>(classObject->getDescriptor()), generateArray));
+
+                return NextPC{};
+            },
             [&](New newInst)
             {
                 ClassObject* classObject = getClassObject(classFile, newInst.index);
                 m_virtualMachine.initialize(*classObject);
                 context.push(m_virtualMachine.getGC().allocate(classObject));
+                return NextPC{};
+            },
+            [&](NewArray newArray)
+            {
+                auto count = context.pop<std::int32_t>();
+                if (count < 0)
+                {
+                    m_virtualMachine.throwNegativeArraySizeException(count);
+                }
+
+                ClassObject& arrayType =
+                    m_virtualMachine.getClassLoader().forName(ArrayType{BaseType{newArray.componentType}});
+                auto* array = m_virtualMachine.getGC().allocate<AbstractArray>(&arrayType, count);
+                context.push(array);
                 return NextPC{};
             },
             [&](Nop) { return NextPC{}; },


### PR DESCRIPTION
This PR implements the rest of the array operations for the interpreter.
It also refactors the the relevant part of `CodeGenerator` and allocate for `AbstractArray` in `GarbageCollector`.