### PR TITLE
[interpreter] implement `checkcast` and `instanceof`

### DIFF
--- a/src/jllvm/vm/Interpreter.hpp
+++ b/src/jllvm/vm/Interpreter.hpp
@@ -186,6 +186,10 @@ class Interpreter
     /// Returns the class object referred to by 'index' within 'classFile', loading it if necessary.
     ClassObject* getClassObject(const ClassFile& classFile, PoolIndex<ClassInfo> index);
 
+    /// Returns the class object referred to by 'index' within 'classFile' if it has been loaded already.
+    /// Returns null otherwise.
+    ClassObject* getClassObjectLoaded(const ClassFile& classFile, PoolIndex<ClassInfo> index);
+
     /// Returns the class object, field name and type referred to by 'index' within 'classFile'.
     std::tuple<ClassObject*, llvm::StringRef, FieldType> getFieldInfo(const ClassFile& classFile,
                                                                       PoolIndex<FieldRefInfo> index);

--- a/src/jllvm/vm/VirtualMachine.hpp
+++ b/src/jllvm/vm/VirtualMachine.hpp
@@ -163,6 +163,10 @@ public:
     /// and the length of the array.
     [[noreturn]] void throwArrayIndexOutOfBoundsException(std::int32_t indexAccessed, std::int32_t arrayLength);
 
+    /// Construct and throws an 'ClassCastException' with a message created from the object being cast and the class
+    /// object of the type that was attempted to be cast to.
+    [[noreturn]] void throwClassCastException(ObjectInterface* object, ClassObject* classObject);
+
     /// Construct and throws a 'NegativeArraySizeException' with a message created from the length that the array was
     /// attempted to be constructed with.
     [[noreturn]] void throwNegativeArraySizeException(std::int32_t arrayLength);


### PR DESCRIPTION
These two are very similar instructions, only differing slightly in case of `null` and the result they produce.