### PR TITLE
[interpreter] Undo loaded class optimization in `checkcast` and `instanceof`

### DIFF
--- a/src/jllvm/vm/Interpreter.cpp
+++ b/src/jllvm/vm/Interpreter.cpp
@@ -56,12 +56,6 @@ jllvm::ClassObject* jllvm::Interpreter::getClassObject(const ClassFile& classFil
     return &m_virtualMachine.getClassLoader().forName(FieldType::fromMangled(className));
 }
 
-jllvm::ClassObject* jllvm::Interpreter::getClassObjectLoaded(const ClassFile& classFile, PoolIndex<ClassInfo> index)
-{
-    llvm::StringRef className = index.resolve(classFile)->nameIndex.resolve(classFile)->text;
-    return m_virtualMachine.getClassLoader().forNameLoaded(FieldType::fromMangled(className));
-}
-
 std::tuple<jllvm::ClassObject*, llvm::StringRef, jllvm::FieldType>
     jllvm::Interpreter::getFieldInfo(const ClassFile& classFile, PoolIndex<FieldRefInfo> index)
 {
@@ -487,8 +481,8 @@ std::uint64_t jllvm::Interpreter::executeMethod(const Method& method, std::uint1
                     return NextPC{};
                 }
 
-                ClassObject* classObject = getClassObjectLoaded(classFile, checkCast.index);
-                if (classObject && object->instanceOf(classObject))
+                ClassObject* classObject = getClassObject(classFile, checkCast.index);
+                if (object->instanceOf(classObject))
                 {
                     return NextPC{};
                 }
@@ -681,14 +675,8 @@ std::uint64_t jllvm::Interpreter::executeMethod(const Method& method, std::uint1
                     return NextPC{};
                 }
 
-                if (ClassObject* classObject = getClassObjectLoaded(classFile, instanceOf.index))
-                {
-                    context.push<std::int32_t>(object->instanceOf(classObject));
-                }
-                else
-                {
-                    context.push<std::int32_t>(0);
-                }
+                ClassObject* classObject = getClassObject(classFile, instanceOf.index);
+                context.push<std::int32_t>(object->instanceOf(classObject));
                 return NextPC{};
             },
             [&](LConst0)

--- a/src/jllvm/vm/Interpreter.hpp
+++ b/src/jllvm/vm/Interpreter.hpp
@@ -188,10 +188,6 @@ class Interpreter
 
     ClassObject* getClassObject(const ClassFile& classFile, ClassInfo classInfo);
 
-    /// Returns the class object referred to by 'index' within 'classFile' if it has been loaded already.
-    /// Returns null otherwise.
-    ClassObject* getClassObjectLoaded(const ClassFile& classFile, PoolIndex<ClassInfo> index);
-
     /// Returns the class object, field name and type referred to by 'index' within 'classFile'.
     std::tuple<ClassObject*, llvm::StringRef, FieldType> getFieldInfo(const ClassFile& classFile,
                                                                       PoolIndex<FieldRefInfo> index);

--- a/tests/Execution/interpreter-checkcast-crash.j
+++ b/tests/Execution/interpreter-checkcast-crash.j
@@ -1,0 +1,28 @@
+; RUN: rm -rf %t && split-file %s %t
+; RUN: cd %t && jasmin %t/Test.j -d %t && jasmin %t/Other.j -d %t
+; RUN: not jllvm -Xint %t/Test.class 2>&1 | FileCheck %s
+
+;--- Test.j
+
+.class public Test
+.super java/lang/Object
+
+.method public <init>()V
+    aload_0
+    invokespecial java/lang/Object/<init>()V
+    return
+.end method
+
+.method public static main([Ljava/lang/String;)V
+.limit locals 1
+.limit stack 1
+    new Test
+    ; CHECK: class Test cannot be cast to class Other
+    checkcast Other
+    return
+.end method
+
+;--- Other.j
+
+.class public Other
+.super java/lang/Object


### PR DESCRIPTION
The optimization is sadly somewhat problematic in `checkcast` specifically as it makes it impossible/hard to create a proper error message for the exception in this case.

Furthermore, the spec arguably requires loading of the class and throwing any class loading related exceptions if it were to fail. This PR therefore undoes the optimization for the time being.