### PR TITLE
[native] Implement `clinit` of `FileInputStream`

### DIFF
--- a/src/jllvm/vm/NativeImplementation.cpp
+++ b/src/jllvm/vm/NativeImplementation.cpp
@@ -28,5 +28,5 @@ void jllvm::registerJavaClasses(VirtualMachine& virtualMachine)
     addModels<ObjectModel, ClassModel, ClassLoaderModel, ThrowableModel, FloatModel, DoubleModel, SystemModel,
               ReflectionModel, CDSModel, UnsafeModel, VMModel, ReferenceModel, SystemPropsRawModel, RuntimeModel,
               FileDescriptorModel, ScopedMemoryAccessModel, SignalModel, ThreadModel, AccessControllerModel,
-              FileOutputStreamModel, StringUTF16Model>(virtualMachine);
+              FileInputStreamModel, FileOutputStreamModel, StringUTF16Model>(virtualMachine);
 }

--- a/src/jllvm/vm/native/IO.hpp
+++ b/src/jllvm/vm/native/IO.hpp
@@ -85,4 +85,18 @@ public:
         std::make_tuple(&FileOutputStreamModel::initIDs, &FileOutputStreamModel::writeBytes);
 };
 
+class FileInputStreamModel : public ModelBase<>
+{
+public:
+    using Base::Base;
+
+    static void initIDs(GCRootRef<ClassObject>)
+    {
+        // Noop at this point in time.
+    }
+
+    constexpr static llvm::StringLiteral className = "java/io/FileInputStream";
+    constexpr static auto methods = std::make_tuple(&FileInputStreamModel::initIDs);
+};
+
 } // namespace jllvm::io

--- a/tests/Execution/file-input-stream-clinit.java
+++ b/tests/Execution/file-input-stream-clinit.java
@@ -1,0 +1,13 @@
+// RUN: javac %s -d %t
+// RUN: jllvm %t/Test.class
+
+import java.io.FileInputStream;
+
+class Test
+{
+    public static void main(String[] args) throws ClassNotFoundException
+    {
+        var clazz = FileInputStream.class;
+        Class.forName(clazz.getName(), /*initialize=*/true, clazz.getClassLoader());
+    }
+}


### PR DESCRIPTION
This is required by the startup sequence of `System` as it calls `new` on `FileInputStream`.

This has so far not been an issue due to a bug in the JIT compiler where `new` does not trigger class object initialization. The interpreter does implement this correctly and therefore requires class initialization of `FileInputStream` to succeed.