### PR TITLE
[interpreter] Fix bug in `lcmp` implementation using unsigned comparison

### DIFF
--- a/src/jllvm/vm/Interpreter.cpp
+++ b/src/jllvm/vm/Interpreter.cpp
@@ -500,8 +500,8 @@ struct MultiTypeImpls
     template <IsCmp T>
     NextPC operator()(T) const
     {
-        auto value2 = context.pop<typename InstructionElementType<T>::type>();
-        auto value1 = context.pop<typename InstructionElementType<T>::type>();
+        auto value2 = context.pop<typename InstructionElementType<T>::signed_type>();
+        auto value1 = context.pop<typename InstructionElementType<T>::signed_type>();
         if (value1 > value2)
         {
             context.push<std::int32_t>(1);

--- a/tests/Execution/land-lor-lxor-lcmp.java
+++ b/tests/Execution/land-lor-lxor-lcmp.java
@@ -16,6 +16,9 @@ class Test
         long z = 5l;
 
         //CHECK: 1
+        print(min < max);
+
+        //CHECK: 1
         print(x & max);
         //CHECK: 0
         print(x & min);
@@ -44,8 +47,6 @@ class Test
 
         // CHECK: 1
         print(max == Long.MAX_VALUE);
-        //CHECK: 1
-        print(min < max);
         //CHECK: 0
         print(y > z);
     }


### PR DESCRIPTION
The spec explicitly requires using signed comparison. This slipped through due to OSR being performed in the test when a `print` call is performed but becomes an issue once rebased on the PR implementing `invoke*` ops.