### PR TITLE
[class] Optimize `*switch` instruction representations

### DIFF
--- a/src/jllvm/class/ByteCode.def
+++ b/src/jllvm/class/ByteCode.def
@@ -237,13 +237,33 @@ GENERATE_SELECTOR(
         std::int8_t byte{};
     },
     parseIInc, 3, 0x84)
-GENERATE_SELECTOR(LookupSwitch, SwitchOp, {}, parseLookupSwitch, lookupSwitchSize(m_current, m_offset), 0xab)
+GENERATE_SELECTOR(
+    LookupSwitch, SwitchOp,
+    {
+        BigEndianArrayRef<std::uint64_t> rawPairs;
+
+        auto matchOffsetPairs() const
+        {
+            return llvm::map_range(
+                rawPairs,
+                [](std::uint64_t value) {
+                    return std::pair{static_cast<std::int32_t>(value >> 32), static_cast<std::int32_t>(value)};
+                });
+        }
+    },
+    parseLookupSwitch, lookupSwitchSize(m_current, m_offset), 0xab)
 GENERATE_SELECTOR(
     MultiANewArray, PoolIndexedOp, { std::uint8_t dimensions; }, parseMultiANewArray, 4, 0xc5)
 GENERATE_SELECTOR(NewArray, ArrayOp, {}, parseNewArray, 2, 0xbc)
 GENERATE_SELECTOR(
     SIPush, ByteCodeBase, { std::int16_t value{}; }, parseSIPush, 3, 0x11)
-GENERATE_SELECTOR(TableSwitch, SwitchOp, {}, parseTableSwitch, tableSwitchSize(m_current, m_offset), 0xaa)
+GENERATE_SELECTOR(
+    TableSwitch, SwitchOp,
+    {
+        std::int32_t low;
+        BigEndianArrayRef<std::int32_t> jumpTable;
+    },
+    parseTableSwitch, tableSwitchSize(m_current, m_offset), 0xaa)
 GENERATE_SELECTOR_END(
     Wide, ByteCodeBase,
     {

--- a/src/jllvm/class/ByteCodeIterator.hpp
+++ b/src/jllvm/class/ByteCodeIterator.hpp
@@ -16,6 +16,7 @@
 #include <llvm/ADT/ArrayRef.h>
 #include <llvm/ADT/iterator.h>
 
+#include <jllvm/support/BigEndianArrayRef.hpp>
 #include <jllvm/support/Variant.hpp>
 
 #include <cstdint>
@@ -66,7 +67,6 @@ struct ArrayOp : ByteCodeBase
 
 struct SwitchOp : ByteCodeBase
 {
-    std::vector<std::pair<std::int32_t, std::int32_t>> matchOffsetsPairs;
     std::int32_t defaultOffset;
 };
 

--- a/src/jllvm/support/BigEndianArrayRef.hpp
+++ b/src/jllvm/support/BigEndianArrayRef.hpp
@@ -1,0 +1,116 @@
+// Copyright (C) 2023 The JLLVM Contributors.
+//
+// This file is part of JLLVM.
+//
+// JLLVM is free software; you can redistribute it and/or modify it under  the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 3, or (at your option) any later version.
+//
+// JLLVM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with JLLVM; see the file LICENSE.txt.  If not
+// see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <llvm/ADT/ArrayRef.h>
+#include <llvm/Support/Endian.h>
+
+#include <concepts>
+
+namespace jllvm
+{
+
+/// Special version of 'llvm::ArrayRef' operating on raw bytes and interpreting each value as a big-endian encoding of
+/// 'T'.
+template <std::integral T>
+class BigEndianArrayRef
+{
+    const char* m_data;
+    std::size_t m_size;
+
+    class ConstProxy
+    {
+    protected:
+        const char* m_data;
+
+    public:
+        explicit ConstProxy(const char* data) : m_data(data) {}
+
+        operator T() const
+        {
+            return llvm::support::endian::read<T, llvm::support::big, /*alignment=*/1>(m_data);
+        }
+    };
+
+public:
+    BigEndianArrayRef(const char* data, size_t size) : m_data(data), m_size(size) {}
+
+    /// Returns the index-th value in the array.
+    ConstProxy operator[](std::size_t index) const
+    {
+        assert(index < size());
+        return *std::next(begin(), index);
+    }
+
+    class iterator : public llvm::iterator_facade_base<iterator, std::random_access_iterator_tag, T, std::ptrdiff_t,
+                                                       ConstProxy, ConstProxy>
+    {
+        const char* m_data{};
+
+    public:
+        iterator() = default;
+
+        explicit iterator(const char* data) : m_data(data) {}
+
+        bool operator==(iterator rhs) const
+        {
+            return m_data == rhs.m_data;
+        }
+
+        bool operator<(iterator rhs) const
+        {
+            return m_data < rhs.m_data;
+        }
+
+        ConstProxy operator*() const
+        {
+            return ConstProxy(m_data);
+        }
+
+        std::ptrdiff_t operator-(iterator rhs) const
+        {
+            return (m_data - rhs.m_data) / sizeof(T);
+        }
+
+        iterator& operator+=(std::ptrdiff_t rhs)
+        {
+            m_data += rhs * sizeof(T);
+            return *this;
+        }
+
+        iterator& operator-=(std::ptrdiff_t rhs)
+        {
+            m_data -= rhs * sizeof(T);
+            return *this;
+        }
+    };
+
+    /// Returns the number of elements in the array.
+    std::size_t size() const
+    {
+        return m_size;
+    }
+
+    auto begin() const
+    {
+        return iterator(m_data);
+    }
+
+    auto end() const
+    {
+        return iterator(m_data + m_size * sizeof(T));
+    }
+};
+
+} // namespace jllvm


### PR DESCRIPTION
`LookupSwitch` and `TableSwitch` were the only two non-trivial types in the bytecode leading to the variant as a whole to be non-trivial. Furthermore, representing TableSwitch as a LookupSwitch made the former `O(log n)` in the interpreter rather than `O(1)` now.

This PR fixes these issues by getting rid of the `std::vector` used in both instructions and replacing it with a `BigEndianArrayRef` implemented as part of this PR that refers to the storage in the `Code` object for the tables.

While I failed to measure any performance benefit in startup, the executable size of a release build with debug info did reduce by 2 MB. I suspect this is partly due to the removal of a few exception handlers in the interpreter loop