### PR TITLE
[object] Store implementation function pointers within `Method`

### DIFF
--- a/src/jllvm/gc/RootFreeList.hpp
+++ b/src/jllvm/gc/RootFreeList.hpp
@@ -240,4 +240,8 @@ public:
         return llvm::filter_iterator<SlotsIterator, FilterPredicate>(end, end, {});
     }
 };
+
+// GCRootRefs convert to their contained object.
+template <class T>
+T* javaConvertedType(GCRootRef<T>);
 } // namespace jllvm

--- a/src/jllvm/materialization/Interpreter2JITAdaptorDefinitionsGenerator.hpp
+++ b/src/jllvm/materialization/Interpreter2JITAdaptorDefinitionsGenerator.hpp
@@ -28,9 +28,6 @@ namespace jllvm
 /// The name is designed to be derivable from a method type descriptor with the exception that 1) the 'this' parameter
 /// is part of the type and has to be explicitly added by adding an 'L' character and 2) all reference parameters
 /// including arrays are reduced to just 'L'.
-///
-/// All adaptors are callable as 'std::uint64_t(void*, const std::uint64_t*)' where the first parameter is a function
-/// pointer for the original method type and the second the argument array in interpreter calling convention.
 class Interpreter2JITAdaptorDefinitionsGenerator : public llvm::orc::DefinitionGenerator
 {
     llvm::orc::IRLayer& m_baseLayer;

--- a/src/jllvm/materialization/Interpreter2JITLayer.cpp
+++ b/src/jllvm/materialization/Interpreter2JITLayer.cpp
@@ -41,14 +41,7 @@ void jllvm::Interpreter2JITLayer::emit(std::unique_ptr<llvm::orc::Materializatio
         mangling += "L";
     }
     auto addToMangling = [&](FieldType fieldType)
-    {
-        if (fieldType.isReference())
-        {
-            mangling += "L";
-            return;
-        }
-        mangling += fieldType.textual();
-    };
+    { mangling += fieldType.isReference() ? "L" : fieldType.textual(); };
     llvm::for_each(methodType.parameters(), addToMangling);
     mangling += ")";
     addToMangling(methodType.returnType());

--- a/src/jllvm/materialization/Interpreter2JITLayer.hpp
+++ b/src/jllvm/materialization/Interpreter2JITLayer.hpp
@@ -22,30 +22,17 @@ namespace jllvm
 
 /// Layer for creating adaptors allowing implementations using the JIT calling convention to be reused with the
 /// interpreter calling convention.
-class Interpreter2JITLayer
+class Interpreter2JITLayer : public ByteCodeLayer
 {
     llvm::orc::IRLayer& m_baseLayer;
     llvm::DataLayout m_dataLayout;
     llvm::orc::JITDylib& m_i2jAdaptors;
-    llvm::orc::MangleAndInterner& m_interner;
 
 public:
     Interpreter2JITLayer(llvm::orc::IRLayer& baseLayer, llvm::orc::MangleAndInterner& interner,
                          const llvm::DataLayout& dataLayout);
 
-    /// Registers an implementation of 'method' within 'dylib' conforming to the interpreter calling convention.
-    /// Any calls will be translated to the JIT calling convention and calls 'method' within 'jitCCDylib'.
-    /// If 'jitCCDylib' does not contain an implementation of 'method' using the JIT calling convention the behaviour
-    /// is undefined.
-    llvm::Error add(llvm::orc::JITDylib& dylib, const Method& method, llvm::orc::JITDylib& jitCCDylib);
-
-    llvm::orc::MangleAndInterner& getInterner() const
-    {
-        return m_interner;
-    }
-
-    void emit(std::unique_ptr<llvm::orc::MaterializationResponsibility> mr, const Method& method,
-              llvm::orc::JITDylib& jitCCDylib);
+    void emit(std::unique_ptr<llvm::orc::MaterializationResponsibility> mr, const Method* method) override;
 };
 
 } // namespace jllvm

--- a/src/jllvm/object/InteropHelpers.hpp
+++ b/src/jllvm/object/InteropHelpers.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 The JLLVM Contributors.
+// Copyright (C) 2024 The JLLVM Contributors.
 //
 // This file is part of JLLVM.
 //
@@ -13,32 +13,28 @@
 
 #pragma once
 
-#include <llvm/ExecutionEngine/JITSymbol.h>
-
-#include <jllvm/gc/RootFreeList.hpp>
-#include <jllvm/object/ClassObject.hpp>
-
 #include <concepts>
 #include <type_traits>
 
 namespace jllvm
 {
 
-namespace detail
-{
+class ObjectInterface;
+
+/// Concept for any type that is compatible with Java objects in their object representation.
+/// This should be used in places when doing interop that require the storage/value to be identical to the corresponding
+/// Java type.
+template <class T>
+concept JavaCompatible =
+    std::is_arithmetic_v<T> || std::is_void_v<T> || std::is_base_of_v<ObjectInterface, std::remove_pointer_t<T>>;
+
 // JavaCompatible types convert to themselves.
 template <JavaCompatible T>
 T javaConvertedType(T);
 
-// GCRootRefs convert to their contained object.
-template <class T>
-T* javaConvertedType(GCRootRef<T>);
-
-} // namespace detail
-
 /// Type alias returning the 'JavaCompatible' type a 'JavaConvertible' type implicitly converts to.
 template <class T>
-using JavaConvertedType = decltype(detail::javaConvertedType(std::declval<T>()));
+using JavaConvertedType = decltype(javaConvertedType(std::declval<T>()));
 
 /// Concept for any type that is known to implicitly convert to a 'JavaCompatible' type.
 template <class T>

--- a/src/jllvm/object/Object.hpp
+++ b/src/jllvm/object/Object.hpp
@@ -16,12 +16,14 @@
 #include <llvm/ADT/BitmaskEnum.h>
 #include <llvm/Support/Allocator.h>
 
+#include <jllvm/support/Encoding.hpp>
+
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <type_traits>
 
-#include "jllvm/support/Encoding.hpp"
+#include "InteropHelpers.hpp"
 
 namespace jllvm
 {
@@ -80,13 +82,6 @@ public:
 };
 
 static_assert(std::is_standard_layout_v<Object>);
-
-/// Concept for any type that is compatible with Java objects in their object representation.
-/// This should be used in places when doing interop that require the storage/value to be identical to the corresponding
-/// Java type.
-template <class T>
-concept JavaCompatible =
-    std::is_arithmetic_v<T> || std::is_void_v<T> || std::is_base_of_v<ObjectInterface, std::remove_pointer_t<T>>;
 
 /// Base class for all arrays allowing access to fields of the array common to all instances.
 class AbstractArray : public ObjectInterface

--- a/src/jllvm/vm/Interpreter.cpp
+++ b/src/jllvm/vm/Interpreter.cpp
@@ -1122,9 +1122,7 @@ std::uint64_t jllvm::Interpreter::executeMethod(const Method& method, std::uint1
                     },
                     [&](...) -> const Method* { llvm_unreachable("unexpected op"); });
 
-                std::uint64_t returnValue =
-                    m_virtualMachine.getRuntime().lookupInterpreterCC(*callee)(arguments.data());
-
+                std::uint64_t returnValue = callee->callInterpreterCC(arguments.data());
                 FieldType returnType = descriptor.returnType();
                 if (returnType != BaseType(BaseType::Void))
                 {

--- a/src/jllvm/vm/JIT.cpp
+++ b/src/jllvm/vm/JIT.cpp
@@ -95,8 +95,7 @@ jllvm::JIT::JIT(VirtualMachine& virtualMachine)
 void jllvm::JIT::add(const Method& method)
 {
     llvm::cantFail(m_byteCodeCompileLayer.add(m_javaJITSymbols, &method));
-    llvm::cantFail(
-        m_virtualMachine.getRuntime().getInterpreter2JITLayer().add(m_interpreter2JITSymbols, method, getJITCCDylib()));
+    llvm::cantFail(m_virtualMachine.getRuntime().getInterpreter2JITLayer().add(m_interpreter2JITSymbols, &method));
 }
 
 void* jllvm::JIT::getOSREntry(const jllvm::Method& method, std::uint16_t byteCodeOffset,

--- a/src/jllvm/vm/JNIBridge.cpp
+++ b/src/jllvm/vm/JNIBridge.cpp
@@ -50,6 +50,5 @@ jllvm::JNIBridge::JNIBridge(VirtualMachine& virtualMachine, void* jniEnv)
 void jllvm::JNIBridge::add(const Method& method)
 {
     llvm::cantFail(m_jniImplementationLayer.add(m_jniSymbols, &method));
-    llvm::cantFail(
-        m_virtualMachine.getRuntime().getInterpreter2JITLayer().add(m_interpreter2JNISymbols, method, getJITCCDylib()));
+    llvm::cantFail(m_virtualMachine.getRuntime().getInterpreter2JITLayer().add(m_interpreter2JNISymbols, &method));
 }

--- a/src/jllvm/vm/Runtime.cpp
+++ b/src/jllvm/vm/Runtime.cpp
@@ -15,6 +15,7 @@
 
 #include <llvm/ADT/ScopeExit.h>
 #include <llvm/Analysis/AliasAnalysis.h>
+#include <llvm/Analysis/GlobalsModRef.h>
 #include <llvm/ExecutionEngine/JITLink/EHFrameSupport.h>
 #include <llvm/ExecutionEngine/Orc/CompileUtils.h>
 #include <llvm/ExecutionEngine/Orc/DebugObjectManagerPlugin.h>

--- a/src/jllvm/vm/Runtime.cpp
+++ b/src/jllvm/vm/Runtime.cpp
@@ -15,8 +15,6 @@
 
 #include <llvm/ADT/ScopeExit.h>
 #include <llvm/Analysis/AliasAnalysis.h>
-#include <llvm/Analysis/GlobalsModRef.h>
-#include <llvm/Analysis/LoopAnalysisManager.h>
 #include <llvm/ExecutionEngine/JITLink/EHFrameSupport.h>
 #include <llvm/ExecutionEngine/Orc/CompileUtils.h>
 #include <llvm/ExecutionEngine/Orc/DebugObjectManagerPlugin.h>

--- a/src/jllvm/vm/VirtualMachine.cpp
+++ b/src/jllvm/vm/VirtualMachine.cpp
@@ -197,7 +197,7 @@ void jllvm::VirtualMachine::initialize(ClassObject& classObject)
         initialize(*base);
     }
 
-    auto* classInitializer = classObject.getMethod("<clinit>", "()V");
+    const auto* classInitializer = classObject.getMethod("<clinit>", "()V");
     if (!classInitializer)
     {
         return;

--- a/src/jllvm/vm/VirtualMachine.hpp
+++ b/src/jllvm/vm/VirtualMachine.hpp
@@ -24,7 +24,6 @@
 #include <memory>
 #include <random>
 
-#include "InteropHelpers.hpp"
 #include "Interpreter.hpp"
 #include "JIT.hpp"
 #include "JNIBridge.hpp"
@@ -185,9 +184,9 @@ public:
     template <JavaConvertible... Args>
     void executeObjectConstructor(ObjectInterface* object, MethodType methodDescriptor, Args... args)
     {
-        void* addr = m_runtime.lookupJITCC(object->getClass()->getClassName(), "<init>", methodDescriptor);
-        assert(addr);
-        invokeJava<void>(addr, object, args...);
+        const Method* method = object->getClass()->getMethod("<init>", methodDescriptor);
+        assert(method);
+        method->call(object, args...);
     }
 
     /// Calls the static method 'methodName' with types 'methodDescriptor' within 'className' using 'args'.


### PR DESCRIPTION
Calling a method prior to this PR required mangling the method object followed by a lookup in the execution session. Calling the method multiple times often leads to redundantly performing the lookup multiple times.

This PR fixes that issue by now storing function pointers to both the JIT CC implementation and the interpreter CC implementations within the `Method` object. The lookups are performed once during class object preparation and reused after.

The largest performance benefits of doing this are 1) from the interpreter not requiring any lookups in the `invoke*` instructions and most importantly 2) the `Interpreter2JITLayer` implementation being heavily simplified. It no longer needs to compile a lambda materialization once per method. Instead, only the adaptor needs to be compiled once per method type (!).

This leads to a measured startup runtime speedup of roughly 15%:
![image](https://github.com/JLLVM/JLLVM/assets/6625526/45789aa4-be4a-45c0-9e1f-914f024a3a2d)

Future PRs will also leverage the self-containedness of `Method` to:
* Possibly optimize the VTable and ITables for the interpreter as well (storing `Method*` rather than `VTable*`)
* Creating strongly typed versions of `Method` in the presence of a compile-time constant `MethodType`
* Verifying calls to method objects using the `MethodType` in assertion builds
