### PR TITLE
[support] Fix UB in BitArrayRef

### DIFF
--- a/src/jllvm/support/BitArrayRef.hpp
+++ b/src/jllvm/support/BitArrayRef.hpp
@@ -31,6 +31,7 @@ protected:
     std::size_t m_size;
 
     constexpr static std::size_t numBits = std::numeric_limits<IntegerType>::digits;
+    constexpr static IntegerType one = static_cast<IntegerType>(1);
 
 public:
 
@@ -49,7 +50,7 @@ public:
 
         bool operator*() const
         {
-            return this->getBase()[this->getIndex() / numBits] & (1 << (this->getIndex() % numBits));
+            return this->getBase()[this->getIndex() / numBits] & (one << (this->getIndex() % numBits));
         }
     };
 
@@ -113,18 +114,18 @@ class MutableBitArrayRef : public BitArrayRef<IntegerType>
 
         operator bool() const
         {
-            return m_bits[m_index / Base::numBits] & (1 << (m_index % Base::numBits));
+            return m_bits[m_index / Base::numBits] & (Base::one << (m_index % Base::numBits));
         }
 
         const Proxy& operator=(bool value) const
         {
             if (value)
             {
-                m_bits[m_index / Base::numBits] |= 1 << m_index % Base::numBits;
+                m_bits[m_index / Base::numBits] |= Base::one << m_index % Base::numBits;
             }
             else
             {
-                m_bits[m_index / Base::numBits] &= ~(1 << m_index % Base::numBits);
+                m_bits[m_index / Base::numBits] &= ~(Base::one << m_index % Base::numBits);
             }
             return *this;
         }
@@ -163,6 +164,11 @@ public:
     {
         assert(index < this->m_size);
         return *std::next(begin(), index);
+    }
+
+    Proxy back() const
+    {
+        return (*this)[this->m_size - 1];
     }
 };
 

--- a/unittests/BitArrayRefTests.cpp
+++ b/unittests/BitArrayRefTests.cpp
@@ -22,7 +22,7 @@ using namespace jllvm;
 using namespace Catch::Matchers;
 
 TEMPLATE_PRODUCT_TEST_CASE("BitArrayRef", "[BitArrayRef]", (BitArrayRef, MutableBitArrayRef),
-                           (std::uint32_t, std::uint64_t))
+                           (std::uint8_t, std::uint16_t, std::uint32_t, std::uint64_t))
 {
     typename TestType::value_type value{};
     TestType ref(&value, /*size=*/5);
@@ -43,9 +43,14 @@ TEMPLATE_PRODUCT_TEST_CASE("BitArrayRef", "[BitArrayRef]", (BitArrayRef, Mutable
 
     CHECK_THAT(llvm::make_range(ref.words_begin(), ref.words_end()),
                RangeEquals(std::initializer_list<decltype(value)>{value}));
+
+    int size = std::numeric_limits<typename TestType::value_type>::digits;
+    ref = TestType(&value, size);
+    CHECK(ref[size - 1] == false);
 }
 
-TEMPLATE_TEST_CASE("MutableBitArrayRef", "[MutableBitArrayRef]", std::uint32_t, std::uint64_t)
+TEMPLATE_TEST_CASE("MutableBitArrayRef", "[MutableBitArrayRef]", std::uint8_t, std::uint16_t, std::uint32_t,
+                   std::uint64_t)
 {
     TestType value{};
     MutableBitArrayRef ref(&value, /*size=*/5);


### PR DESCRIPTION
The code triggers UB in the case that the index used is 32 or larger. The reason is the use of the `1` constant which defaults to `int` in C++. Shifting that constant by more than 31 bits is UB and triggered an assertion when built with UBSAN.

This PR fixes that by creating a nicely named constant which is the value 1 cast to the integer type.