### PR TITLE
[JNI] Create basic unit testing for JNI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,23 @@ set(LLVM_TABLEGEN_EXE "llvm-tblgen")
 
 find_package(Java 17 COMPONENTS Development REQUIRED)
 
+set(JAVA_INCLUDE_PATH "${JAVA_HOME}/../include")
+find_path(JNI_INCLUDE_PATH1 jni.h REQUIRED PATHS ${JAVA_INCLUDE_PATH})
+find_path(JNI_INCLUDE_PATH2 NAMES jni_md.h jniport.h REQUIRED
+        PATHS ${JAVA_INCLUDE_PATH}
+        ${JAVA_INCLUDE_PATH}/darwin
+        ${JAVA_INCLUDE_PATH}/win32
+        ${JAVA_INCLUDE_PATH}/linux
+        ${JAVA_INCLUDE_PATH}/freebsd
+        ${JAVA_INCLUDE_PATH}/openbsd
+        ${JAVA_INCLUDE_PATH}/solaris
+        ${JAVA_INCLUDE_PATH}/hp-ux
+        ${JAVA_INCLUDE_PATH}/alpha
+        ${JAVA_INCLUDE_PATH}/aix
+)
+add_library(jni_headers INTERFACE)
+target_include_directories(jni_headers INTERFACE ${JNI_INCLUDE_PATH1} ${JNI_INCLUDE_PATH2})
+
 get_filename_component(REAL_JAVAC ${Java_JAVAC_EXECUTABLE} REALPATH)
 cmake_path(GET REAL_JAVAC PARENT_PATH JAVA_HOME)
 if (NOT EXISTS ${CMAKE_BINARY_DIR}/lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,11 +16,11 @@ project(JLLVM)
 
 set(CMAKE_CXX_STANDARD 20)
 
-if( NOT uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG" )
+if (NOT uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG")
     option(JLLVM_ENABLE_ASSERTIONS "Enable assertions" OFF)
-else()
+else ()
     option(JLLVM_ENABLE_ASSERTIONS "Enable assertions" ON)
-endif()
+endif ()
 
 option(JLLVM_BUILD_DOCS "Build documentation" OFF)
 
@@ -31,24 +31,11 @@ link_libraries(Threads::Threads)
 find_package(LLVM REQUIRED CONFIG)
 set(LLVM_TABLEGEN_EXE "llvm-tblgen")
 
-find_package(Java 17 COMPONENTS Development REQUIRED)
+find_package(Java 17 EXACT COMPONENTS Development REQUIRED)
+find_package(JNI 17 EXACT REQUIRED)
 
-set(JAVA_INCLUDE_PATH "${JAVA_HOME}/../include")
-find_path(JNI_INCLUDE_PATH1 jni.h REQUIRED PATHS ${JAVA_INCLUDE_PATH})
-find_path(JNI_INCLUDE_PATH2 NAMES jni_md.h jniport.h REQUIRED
-        PATHS ${JAVA_INCLUDE_PATH}
-        ${JAVA_INCLUDE_PATH}/darwin
-        ${JAVA_INCLUDE_PATH}/win32
-        ${JAVA_INCLUDE_PATH}/linux
-        ${JAVA_INCLUDE_PATH}/freebsd
-        ${JAVA_INCLUDE_PATH}/openbsd
-        ${JAVA_INCLUDE_PATH}/solaris
-        ${JAVA_INCLUDE_PATH}/hp-ux
-        ${JAVA_INCLUDE_PATH}/alpha
-        ${JAVA_INCLUDE_PATH}/aix
-)
 add_library(jni_headers INTERFACE)
-target_include_directories(jni_headers INTERFACE ${JNI_INCLUDE_PATH1} ${JNI_INCLUDE_PATH2})
+target_include_directories(jni_headers INTERFACE ${JNI_INCLUDE_DIRS})
 
 get_filename_component(REAL_JAVAC ${Java_JAVAC_EXECUTABLE} REALPATH)
 cmake_path(GET REAL_JAVAC PARENT_PATH JAVA_HOME)
@@ -75,7 +62,7 @@ endif ()
 if (JLLVM_ENABLE_ASSERTIONS)
     # On non-Debug builds cmake automatically defines NDEBUG, so we
     # explicitly undefine it:
-    if( NOT uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG" )
+    if (NOT uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG")
         # NOTE: use `add_compile_options` rather than `add_definitions` since
         # `add_definitions` does not support generator expressions.
         add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-UNDEBUG>)
@@ -88,11 +75,11 @@ if (JLLVM_ENABLE_ASSERTIONS)
                     CMAKE_C_FLAGS_RELEASE
                     CMAKE_C_FLAGS_RELWITHDEBINFO
                     CMAKE_C_FLAGS_MINSIZEREL)
-                string (REGEX REPLACE "(^| )[/-]D *NDEBUG($| )" " "
+                string(REGEX REPLACE "(^| )[/-]D *NDEBUG($| )" " "
                         "${flags_var_to_scrub}" "${${flags_var_to_scrub}}")
-            endforeach()
-        endif()
-    endif()
+            endforeach ()
+        endif ()
+    endif ()
 endif ()
 
 if (CMAKE_BUILD_TYPE STREQUAL "Release")

--- a/src/jllvm/main/CMakeLists.txt
+++ b/src/jllvm/main/CMakeLists.txt
@@ -17,9 +17,7 @@ set(LLVM_TARGET_DEFINITIONS Opts.td)
 tablegen(LLVM Opts.inc -gen-opt-parser-defs)
 add_public_tablegen_target(JLLVMMainOptsTableGen)
 
-llvm_map_components_to_libnames(llvm_native_libs ${LLVM_NATIVE_ARCH})
-
 add_library(JLLVMMain Main.cpp CommandLine.cpp CommandLine.hpp)
-target_link_libraries(JLLVMMain PUBLIC LLVMSupport PRIVATE ${llvm_native_libs} LLVMOption JLLVMVirtualMachine)
+target_link_libraries(JLLVMMain PUBLIC LLVMSupport PRIVATE LLVMOption JLLVMVirtualMachine)
 target_include_directories(JLLVMMain PUBLIC ${PROJECT_BINARY_DIR}/src)
 add_dependencies(JLLVMMain JLLVMMainOptsTableGen)

--- a/src/jllvm/vm/CMakeLists.txt
+++ b/src/jllvm/vm/CMakeLists.txt
@@ -11,6 +11,8 @@
 # You should have received a copy of the GNU General Public License along with JLLVM; see the file LICENSE.txt.  If not
 # see <http://www.gnu.org/licenses/>.
 
+llvm_map_components_to_libnames(llvm_native_libs ${LLVM_NATIVE_ARCH})
+
 add_library(JLLVMVirtualMachine VirtualMachine.cpp JIT.cpp StackMapRegistrationPlugin.cpp
         JNIImplementation.cpp NativeImplementation.cpp JavaFrame.cpp native/IO.cpp
         native/Lang.cpp native/JDK.cpp native/Security.cpp
@@ -19,24 +21,8 @@ add_library(JLLVMVirtualMachine VirtualMachine.cpp JIT.cpp StackMapRegistrationP
         JNIBridge.cpp
 )
 target_link_libraries(JLLVMVirtualMachine
-        PRIVATE JLLVMLLVMPasses LLVMTargetParser LLVMOrcTargetProcess LLVMScalarOpts LLVMAnalysis
+        PRIVATE JLLVMLLVMPasses LLVMTargetParser LLVMOrcTargetProcess LLVMScalarOpts LLVMAnalysis ${llvm_native_libs}
+        jni_headers
         PUBLIC JLLVMClassParser JLLVMObject JLLVMGC JLLVMMaterialization JLLVMUnwinder LLVMExecutionEngine LLVMOrcJIT
         LLVMJITLink LLVMOrcShared
         )
-
-set(JAVA_INCLUDE_PATH "${JAVA_HOME}/../include")
-find_path(JNI_INCLUDE_PATH1 jni.h REQUIRED PATHS ${JAVA_INCLUDE_PATH})
-find_path(JNI_INCLUDE_PATH2 NAMES jni_md.h jniport.h REQUIRED
-        PATHS ${JAVA_INCLUDE_PATH}
-        ${JAVA_INCLUDE_PATH}/darwin
-        ${JAVA_INCLUDE_PATH}/win32
-        ${JAVA_INCLUDE_PATH}/linux
-        ${JAVA_INCLUDE_PATH}/freebsd
-        ${JAVA_INCLUDE_PATH}/openbsd
-        ${JAVA_INCLUDE_PATH}/solaris
-        ${JAVA_INCLUDE_PATH}/hp-ux
-        ${JAVA_INCLUDE_PATH}/alpha
-        ${JAVA_INCLUDE_PATH}/aix
-        )
-
-target_include_directories(JLLVMVirtualMachine PRIVATE ${JNI_INCLUDE_PATH1} ${JNI_INCLUDE_PATH2})

--- a/src/jllvm/vm/JNIImplementation.cpp
+++ b/src/jllvm/vm/JNIImplementation.cpp
@@ -30,7 +30,7 @@ jllvm::VirtualMachine::JNINativeInterfaceUPtr jllvm::VirtualMachine::createJNIEn
     {
         VirtualMachine& virtualMachine = virtualMachineFromJNIEnv(env);
         ClassObject& classObject = virtualMachine.getClassLoader().forName(FieldType::fromMangled(name));
-        return std::bit_cast<jclass>(virtualMachine.getGC().root(&classObject).release());
+        return llvm::bit_cast<jclass>(virtualMachine.getGC().root(&classObject).release());
     };
 
     return JNINativeInterfaceUPtr(result, +[](JNINativeInterface_* ptr) { delete ptr; });

--- a/src/jllvm/vm/NativeImplementation.hpp
+++ b/src/jllvm/vm/NativeImplementation.hpp
@@ -310,7 +310,7 @@ void addModel(VirtualMachine& virtualMachine)
             {
                 constexpr auto fn = std::get<idxs>(methods);
                 constexpr std::string_view methodName = detail::functionName<fn>();
-                virtualMachine.getJNI().addJNISymbol(formJNIMethodName(Model::className, methodName),
+                virtualMachine.getJNIBridge().addJNISymbol(formJNIMethodName(Model::className, methodName),
                     detail::createMethodBridge<Model>(state,
                                                       std::integral_constant<std::remove_const_t<decltype(fn)>, fn>{}));
             }(),

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -17,3 +17,48 @@ catch_discover_tests(SupportTests)
 add_executable(ClassTests DescriptorTests.cpp)
 target_link_libraries(ClassTests JLLVMClassParser Catch2::Catch2WithMain)
 catch_discover_tests(ClassTests)
+
+set(class_files)
+
+# Compiles 'source_file' in 'Inputs' to a class file. The source file is expected to contain contain a public class
+# with the same name as the source file. Producing a class file with the expected name is impossible otherwise.
+macro(compile_java_test_file source_file)
+    set(arg_source_file "${CMAKE_CURRENT_SOURCE_DIR}/Inputs/${source_file}")
+
+    set(out_file ${source_file})
+    cmake_path(REPLACE_EXTENSION out_file LAST_ONLY class)
+    cmake_path(GET out_file FILENAME out_file)
+    set(out_file ${CMAKE_CURRENT_BINARY_DIR}/${out_file})
+    list(APPEND class_files ${out_file})
+    cmake_path(RELATIVE_PATH out_file BASE_DIRECTORY ${CMAKE_BINARY_DIR} OUTPUT_VARIABLE out_file_message)
+    add_custom_command(
+            OUTPUT ${out_file}
+            COMMAND ${Java_JAVAC_EXECUTABLE}
+            -d ${CMAKE_CURRENT_BINARY_DIR}
+            -implicit:none
+            -encoding utf-8
+            ${arg_source_file}
+            COMMENT "Building JAVA object ${out_file_message}"
+            DEPENDS ${arg_source_file}
+    )
+endmacro()
+
+macro(compile_java_test_files)
+    foreach (file ${ARGN})
+        compile_java_test_file(${file})
+    endforeach ()
+endmacro()
+
+compile_java_test_files(
+        TestSimpleJNI.java
+)
+
+add_custom_target(jni-java-compile DEPENDS ${class_files})
+
+add_executable(JNITests JNITests.cpp)
+target_link_libraries(JNITests JLLVMVirtualMachine Catch2::Catch2WithMain jni_headers)
+target_compile_definitions(JNITests PRIVATE
+        "JAVA_BASE_PATH=\"${CMAKE_BINARY_DIR}/lib/java.base\""
+        "INPUTS_BASE_PATH=\"${CMAKE_CURRENT_BINARY_DIR}\"")
+catch_discover_tests(JNITests)
+add_dependencies(JNITests jni-java-compile)

--- a/unittests/Inputs/TestSimpleJNI.java
+++ b/unittests/Inputs/TestSimpleJNI.java
@@ -1,0 +1,5 @@
+
+public class TestSimpleJNI
+{
+
+}

--- a/unittests/JNITests.cpp
+++ b/unittests/JNITests.cpp
@@ -1,0 +1,57 @@
+// Copyright (C) 2024 The JLLVM Contributors.
+//
+// This file is part of JLLVM.
+//
+// JLLVM is free software; you can redistribute it and/or modify it under  the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 3, or (at your option) any later version.
+//
+// JLLVM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with JLLVM; see the file LICENSE.txt.  If not
+// see <http://www.gnu.org/licenses/>.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <llvm/Support/Path.h>
+
+#include <jllvm/vm/VirtualMachine.hpp>
+
+#include <jni.h>
+
+using namespace jllvm;
+
+namespace
+{
+class VirtualMachineFixture
+{
+protected:
+    VirtualMachine virtualMachine;
+    JNIEnv jniEnv;
+
+public:
+    VirtualMachineFixture()
+        : virtualMachine(VirtualMachine::create(
+              []
+              {
+                  BootOptions bootOptions;
+                  bootOptions.classPath = {JAVA_BASE_PATH, INPUTS_BASE_PATH};
+                  bootOptions.systemInitialization = false;
+                  bootOptions.javaHome = llvm::sys::path::parent_path(llvm::sys::path::parent_path(JAVA_BASE_PATH));
+                  return bootOptions;
+              }())),
+          jniEnv(virtualMachine.getJNINativeInterface())
+    {
+    }
+};
+} // namespace
+
+TEST_CASE_METHOD(VirtualMachineFixture, "JNI Get Version", "[JNI]")
+{
+    CHECK(jniEnv.GetVersion() == JNI_VERSION_10);
+}
+
+TEST_CASE_METHOD(VirtualMachineFixture, "JNI FindClass", "[JNI]")
+{
+    CHECK(jniEnv.FindClass("TestSimpleJNI") != nullptr);
+}

--- a/unittests/JNITests.cpp
+++ b/unittests/JNITests.cpp
@@ -40,7 +40,7 @@ public:
                   bootOptions.javaHome = llvm::sys::path::parent_path(llvm::sys::path::parent_path(JAVA_BASE_PATH));
                   return bootOptions;
               }())),
-          jniEnv(virtualMachine.getJNINativeInterface())
+          jniEnv{virtualMachine.getJNINativeInterface()}
     {
     }
 };


### PR DESCRIPTION
This PR creates the most basic test infrastructure for implementing the Java Native Interface. It basically consists of a fixture containing a `VirtualMachine` instance and a `JNIEnv` that tests interact with. For this purpose, `VirtualMachine` was made easily bootable from just a single static `create` method.

Furthermore, a cmake macro was created for compiling Java files to class files. These will be able to serve as interesting inputs for the JNI interfaces (e.g. for accessing fields).