### PR TITLE
[object] Refactor `GCRootRef`

### DIFF
--- a/src/jllvm/materialization/LambdaMaterialization.hpp
+++ b/src/jllvm/materialization/LambdaMaterialization.hpp
@@ -69,7 +69,7 @@ struct CppToLLVMType<void>
 
 /// Specialization for any pointer type.
 template <class T>
-requires(!std::is_base_of_v<ObjectInterface, T>) struct CppToLLVMType<T*>
+requires(!JavaObject<T>) struct CppToLLVMType<T*>
 {
     static llvm::Type* get(llvm::LLVMContext* context)
     {
@@ -78,7 +78,7 @@ requires(!std::is_base_of_v<ObjectInterface, T>) struct CppToLLVMType<T*>
 };
 
 /// Specialization for Objects type.
-template <std::derived_from<ObjectInterface> T>
+template <JavaObject T>
 struct CppToLLVMType<T*>
 {
     static llvm::Type* get(llvm::LLVMContext* context)

--- a/src/jllvm/object/ClassLoader.cpp
+++ b/src/jllvm/object/ClassLoader.cpp
@@ -134,8 +134,7 @@ jllvm::ClassObject& jllvm::ClassLoader::add(std::unique_ptr<llvm::MemoryBuffer>&
             {
                 void* staticAddress = fields.back().getAddressOfStatic();
                 match(
-                    constantValue->value_index.resolve(classFile),
-                    [&](const IntegerInfo* intInfo)
+                    constantValue->value_index.resolve(classFile), [&](const IntegerInfo* intInfo)
                     { std::memcpy(staticAddress, &intInfo->value, sizeof(intInfo->value)); },
                     [&](const FloatInfo* floatInfo)
                     { std::memcpy(staticAddress, &floatInfo->value, sizeof(floatInfo->value)); },
@@ -271,7 +270,7 @@ jllvm::ClassObject& jllvm::ClassLoader::forName(FieldType fieldType)
 
 jllvm::ClassLoader::ClassLoader(StringInterner& stringInterner, std::vector<std::string>&& classPaths,
                                 llvm::unique_function<void(ClassObject&)>&& prepareClassObject,
-                                llvm::unique_function<void**()> allocateStatic)
+                                llvm::unique_function<GCRootRef<ObjectInterface>()> allocateStatic)
     : m_stringInterner{stringInterner},
       m_classPaths{std::move(classPaths)},
       m_prepareClassObject{std::move(prepareClassObject)},

--- a/src/jllvm/object/ClassLoader.hpp
+++ b/src/jllvm/object/ClassLoader.hpp
@@ -44,7 +44,7 @@ class ClassLoader
 
     std::vector<std::string> m_classPaths;
     llvm::unique_function<void(ClassObject&)> m_prepareClassObject;
-    llvm::unique_function<void**()> m_allocateStatic;
+    llvm::unique_function<GCRootRef<ObjectInterface>()> m_allocateStatic;
     std::size_t m_interfaceIdCounter = 0;
 
     ClassObject m_byte{sizeof(std::uint8_t), "B"};
@@ -69,7 +69,7 @@ public:
     /// 'stringInterner' is used to intern strings that are values of constant fields
     ClassLoader(StringInterner& stringInterner, std::vector<std::string>&& classPaths,
                 llvm::unique_function<void(ClassObject&)>&& prepareClassObject,
-                llvm::unique_function<void**()> allocateStatic);
+                llvm::unique_function<GCRootRef<ObjectInterface>()> allocateStatic);
 
     ~ClassLoader();
 

--- a/src/jllvm/object/ClassObject.hpp
+++ b/src/jllvm/object/ClassObject.hpp
@@ -175,7 +175,7 @@ class Field
     {
         std::uint16_t m_offset;
         char m_primitiveStorage[sizeof(double)];
-        void** m_reference;
+        GCRootRef<ObjectInterface> m_reference;
     };
     AccessFlag m_accessFlags;
 
@@ -192,7 +192,7 @@ public:
 
     /// Creates a new static field of a reference type with the given name, type descriptor and a pointer to where the
     /// static reference is allocated.
-    Field(llvm::StringRef name, FieldType type, void** reference, AccessFlag accessFlags)
+    Field(llvm::StringRef name, FieldType type, GCRootRef<ObjectInterface> reference, AccessFlag accessFlags)
         : m_name(name), m_type(type), m_reference(reference), m_accessFlags(accessFlags)
     {
     }
@@ -246,7 +246,7 @@ public:
         assert(isStatic());
         if (m_type.isReference())
         {
-            return m_reference;
+            return m_reference.data();
         }
         return reinterpret_cast<const void*>(m_primitiveStorage);
     }

--- a/src/jllvm/object/GCRootRef.hpp
+++ b/src/jllvm/object/GCRootRef.hpp
@@ -1,0 +1,312 @@
+// Copyright (C) 2024 The JLLVM Contributors.
+//
+// This file is part of JLLVM.
+//
+// JLLVM is free software; you can redistribute it and/or modify it under  the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 3, or (at your option) any later version.
+//
+// JLLVM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with JLLVM; see the file LICENSE.txt.  If not
+// see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include "Object.hpp"
+
+namespace jllvm
+{
+
+/// CRTP trait allowing injecting extra methods into 'GCRootRef' based on its template parameter.
+template <class Self>
+struct GCRootRefTrait
+{
+};
+
+/// Class used to refer to a so called "root" allocated by a 'RootFreeList', usually by the garbage collectors.
+/// This class can be seen as a GC-Safe equivalent to a pointer for C++ code, allowing one to refer to an object
+/// and continue referring to the object even after the object has been relocated by the garbage collector.
+/// It also has the important role of keeping the object it refers to alive, preventing it from being deleted by the
+/// garbage collector.
+///
+/// Most importantly, this class does not manage the lifetime of the root but relies on an outside mechanism to keep
+/// the underlying root alive.
+/// Rather its a lightweight reference type that should be passed by value, analogous to what 'std::string_view'
+/// is to 'std::string' (the equivalent of 'std::string' being 'GCUniqueRoot' in this analogy).
+/// The primary mechanism to create roots are by using the 'root' method of the 'GarbageCollector'.
+///
+/// See its documentation as to when to use 'GCRootRef', 'GCUniqueRoot' or a plain 'T*'.
+///
+/// 'T' is the memory layout of the Java object that should be used when retrieving it.
+template <JavaObject T = ObjectInterface>
+class GCRootRef : public GCRootRefTrait<GCRootRef<T>>
+{
+    ObjectInterface** m_root = nullptr;
+
+    template <JavaObject U>
+    friend class GCRootRef;
+
+    T* get() const
+    {
+        if (!hasRoot())
+        {
+            return nullptr;
+        }
+        return static_cast<T*>(*m_root);
+    }
+
+public:
+    /// Creates a new 'GCRootRef' from a root. The lifetime of the root must be valid throughout the use of the
+    /// 'GCRootRef'.
+    explicit GCRootRef(ObjectInterface** root) : m_root(root) {}
+
+    /// Creates a 'GCRootRef' with no root. 'GCRootRef' without roots are for all intents and purposes equal to
+    /// 'GCRootRef's that refer to a null reference with the exception of NOT being able to assign an object to it.
+    /// Prefer assignment from another 'GCRootRef' instead.
+    GCRootRef() = default;
+
+    /// Allows implicit construction of a 'GCRootRef' without a root from a nullptr.
+    GCRootRef(std::nullptr_t) : GCRootRef() {}
+
+    /// Creates a new 'GCRootRef' from a derived 'GCRootRef', referring to the same root.
+    template <std::derived_from<T> U>
+    GCRootRef(GCRootRef<U> rhs) requires(!std::is_same_v<T, U>) : m_root(rhs.m_root)
+    {
+    }
+
+    /// Assignment operator from a derived 'GCRootRef'.
+    template <std::derived_from<T> U>
+    GCRootRef& operator=(GCRootRef<U> rhs) requires(!std::is_same_v<T, U>)
+    {
+        *this = static_cast<GCRootRef<T>>(rhs);
+        return *this;
+    }
+
+    /// Explicit cast to a 'GCRootRef' of another type. This allows both up and down casting and does not perform any
+    /// validity checks. It is therefore up to the user to make sure the cast is valid.
+    template <class U>
+    explicit operator GCRootRef<U>() const
+    {
+        return GCRootRef<U>(m_root);
+    }
+
+    /// Explicit cast to 'T*'. This operation should generally be avoided in favour of just using the 'GCRootRef' as
+    /// intended.
+    explicit operator T*() const
+    {
+        return get();
+    }
+
+    /// Returns true if this 'GCRootRef' has a root.
+    bool hasRoot() const
+    {
+        return m_root;
+    }
+
+    /// Assign an object to the root of this 'GCRootRef'. This is only a valid operation if the 'GCRootRef' is not
+    /// empty i.e. refers to a root.
+    void assign(T* object)
+    {
+        assert(hasRoot() && "GCRootRef must have a root");
+        *m_root = const_cast<std::remove_const_t<T>*>(object);
+    }
+
+    /// Returns true if 'lhs' and 'rhs' refer to the same object.
+    template <class U>
+    friend bool operator==(GCRootRef<T> lhs, GCRootRef<U> rhs)
+    {
+        return lhs.get() == static_cast<U*>(rhs);
+    }
+
+    friend bool operator==(GCRootRef<T> lhs, const T* rhs)
+    {
+        return lhs.get() == rhs;
+    }
+
+    /// Returns true if this root contains a reference to an object.
+    explicit operator bool() const
+    {
+        return get();
+    }
+
+    /// Returns true if this root does not contain a reference to an object.
+    bool operator!() const
+    {
+        return !static_cast<bool>(*this);
+    }
+
+    /// Allows using a 'GCRootRef<T>' with the same syntax as you would a 'T*'
+    T* operator->() const
+    {
+        return get();
+    }
+
+    T& operator*() const
+    {
+        return *get();
+    }
+
+    /// Returns the address of the Java object.
+    /// The address is only valid until the next garbage collection.
+    T* address() const
+    {
+        return get();
+    }
+
+    /// Returns the underlying root referred to by this 'GCRootRef'.
+    ObjectInterface** data() const
+    {
+        return m_root;
+    }
+};
+
+/// Trait for 'GCRootRef's of array type. Adds a GC safe indexing operator and iterators.
+template <JavaCompatible T>
+struct GCRootRefTrait<GCRootRef<Array<T>>>
+{
+    using Self = GCRootRef<Array<T>>;
+
+    /// Proxy object representing an element within an array.
+    /// Assigning or reading the element is GC safe at all times.
+    class GCRootArrayElementRef
+    {
+        Self m_root;
+        std::size_t m_index;
+
+    public:
+        GCRootArrayElementRef(Self root, std::size_t index) : m_root(root), m_index(index) {}
+
+        operator T() const
+        {
+            return (*m_root)[m_index];
+        }
+
+        const GCRootArrayElementRef& operator=(T value) const
+        {
+            // Assign to the actual underlying array object.
+            (*m_root)[m_index] = value;
+            return *this;
+        }
+    };
+
+    class iterator : public llvm::indexed_accessor_iterator<iterator, Self, GCRootArrayElementRef>
+    {
+        using Base = llvm::indexed_accessor_iterator<iterator, Self, GCRootArrayElementRef>;
+
+    public:
+        iterator(Self base, ptrdiff_t index) : Base(base, index) {}
+
+        GCRootArrayElementRef operator*() const
+        {
+            return this->getBase()[this->getIndex()];
+        }
+    };
+
+    /// Returns an iterator to the first element in the array.
+    iterator begin() const
+    {
+        return iterator(static_cast<const Self&>(*this), 0);
+    }
+
+    /// Returns an iterator past the last element in the array.
+    iterator end() const
+    {
+        return iterator(static_cast<const Self&>(*this), static_cast<const Self&>(*this)->size());
+    }
+
+    /// Accesses an element in the array with the given index.
+    /// Reading the element or assigning to it is safe against any garbage collection.
+    GCRootArrayElementRef operator[](std::size_t index) const
+    {
+        return GCRootArrayElementRef(static_cast<const Self&>(*this), index);
+    }
+};
+
+/// Adaptor class for functions to accept both 'T*' and 'GCRootRef<T>' parameters.
+/// It does so by supporting implicit conversions from both of these types and implicit conversion to 'T*'.
+template <JavaObject T>
+class GCRootRefOrPointer
+{
+    T* m_pointer;
+
+public:
+    /// Implicit construction from 'T*'. Makes it possible for the compiler to deduce 'T' as well.
+    /*implicit*/ GCRootRefOrPointer(T* pointer) : m_pointer(pointer) {}
+
+    /// Implicit construction from a pointer to a type derived from 'T'.
+    template <std::derived_from<T> U>
+    /*implicit*/ GCRootRefOrPointer(U* pointer) requires(!std::same_as<T, U>) : m_pointer(pointer)
+    {
+    }
+
+    /// Implicit construction from 'GCRootRef<T>'. Makes it possible for the compiler to deduce 'T' as well.
+    /*implicit*/ GCRootRefOrPointer(GCRootRef<T> ref) : m_pointer(ref.address()) {}
+
+    /// Implicit construction from a 'GCRootRef' to a type derived from 'T'.
+    template <std::derived_from<T> U>
+    /*implicit*/ GCRootRefOrPointer(GCRootRef<U> ref) requires(!std::same_as<T, U>) : m_pointer(ref.address())
+    {
+    }
+
+    /// Implicit construction from another 'GCRootRefOrPointer' to a type derived from 'T'.
+    template <std::derived_from<T> U>
+    /*implicit*/ GCRootRefOrPointer(GCRootRefOrPointer<U> ref) requires(!std::same_as<T, U>) : m_pointer(ref)
+    {
+    }
+
+    /// Allows using pointer member access syntax.
+    T* operator->() const
+    {
+        return m_pointer;
+    }
+
+    /// Implicitly convert to 'T*'.
+    operator T*() const
+    {
+        return m_pointer;
+    }
+};
+
+/// Adaptor class for returning a 'T*&'.
+/// Makes it possible to also assign a 'GCRootRef' to the pointer.
+template <JavaObject T>
+class ObjectPointerRef
+{
+    T*& m_reference;
+
+public:
+    /// Constructs 'ObjectPointerRef' from a 'T*&'.
+    explicit ObjectPointerRef(T*& pointer) : m_reference(pointer) {}
+
+    /// Implicit conversion to 'T*' for reading.
+    operator T*() const
+    {
+        return m_reference;
+    }
+
+    /// Implicit conversion to any 'GCRootRefOrPointer' of a super type of 'T'.
+    template <class U>
+    operator GCRootRefOrPointer<U>() const requires std::is_base_of_v<U, T>
+    {
+        return m_reference;
+    }
+
+    /// Allow assignment to the reference from any super type of 'T'.
+    template <class U>
+    const ObjectPointerRef& operator=(U* object) const requires std::is_base_of_v<U, T>
+    {
+        m_reference = object;
+        return *this;
+    }
+
+    /// Allow assignment to the reference from any super type of 'T'.
+    template <class U>
+    const ObjectPointerRef& operator=(GCRootRef<U> object) const requires std::is_base_of_v<U, T>
+    {
+        m_reference = object.address();
+        return *this;
+    }
+};
+
+} // namespace jllvm

--- a/src/jllvm/object/Object.hpp
+++ b/src/jllvm/object/Object.hpp
@@ -81,12 +81,19 @@ public:
 
 static_assert(std::is_standard_layout_v<Object>);
 
+/// Concept for any Java object aka subtypes of 'ObjectInterface'.
+template <class T>
+concept JavaObject = std::is_base_of_v<ObjectInterface, T>;
+
+/// Concept for a Java reference. This is a pointer to Java object in C++.
+template <class T>
+concept JavaReference = std::is_pointer_v<T> && JavaObject<std::remove_pointer_t<T>>;
+
 /// Concept for any type that is compatible with Java objects in their object representation.
 /// This should be used in places when doing interop that require the storage/value to be identical to the corresponding
 /// Java type.
 template <class T>
-concept JavaCompatible =
-    std::is_arithmetic_v<T> || std::is_void_v<T> || std::is_base_of_v<ObjectInterface, std::remove_pointer_t<T>>;
+concept JavaCompatible = std::is_arithmetic_v<T> || std::is_void_v<T> || JavaReference<T>;
 
 /// Base class for all arrays allowing access to fields of the array common to all instances.
 class AbstractArray : public ObjectInterface

--- a/src/jllvm/vm/InteropHelpers.hpp
+++ b/src/jllvm/vm/InteropHelpers.hpp
@@ -34,6 +34,10 @@ T javaConvertedType(T);
 template <class T>
 T* javaConvertedType(GCRootRef<T>);
 
+// GCRootRefOrPointer convert to their contained object.
+template <class T>
+T* javaConvertedType(GCRootRefOrPointer<T>);
+
 } // namespace detail
 
 /// Type alias returning the 'JavaCompatible' type a 'JavaConvertible' type implicitly converts to.
@@ -49,7 +53,7 @@ concept JavaConvertible = !std::is_void_v<T> && JavaCompatible<JavaConvertedType
 template <JavaCompatible Ret, JavaConvertible... Args>
 Ret invokeJava(void* fnPtr, Args... args)
 {
-    return reinterpret_cast<Ret (*)(JavaConvertedType<Args>...)>(fnPtr)(args...);
+    return reinterpret_cast<Ret (*)(JavaConvertedType<Args>...)>(fnPtr)(static_cast<JavaConvertedType<Args>>(args)...);
 }
 
 } // namespace jllvm

--- a/src/jllvm/vm/Interpreter.hpp
+++ b/src/jllvm/vm/Interpreter.hpp
@@ -44,8 +44,7 @@ concept InterpreterPrimitive = llvm::is_one_of<T, std::int32_t, std::uint32_t, f
 /// Possible types of values in the interpreter. These are all the primitive types with the addition of pointers to
 /// Java objects (references).
 template <class T>
-concept InterpreterValue =
-    InterpreterPrimitive<T> || (std::is_pointer_v<T> && std::derived_from<std::remove_pointer_t<T>, ObjectInterface>);
+concept InterpreterValue = InterpreterPrimitive<T> || JavaReference<T>;
 
 /// Context used in the execution of one Java frame. It incorporates and contains convenience methods for interacting
 /// with local variables and the operand stack.

--- a/src/jllvm/vm/NativeImplementation.hpp
+++ b/src/jllvm/vm/NativeImplementation.hpp
@@ -55,8 +55,8 @@ struct ModelState
 /// Use case for this type is the ability to persist state between function calls within a Model. This is commonly
 /// used to create and then use 'InstanceFieldRef' or 'StaticFieldRef's without having to look them up on every call.
 ///
-/// The second optional template parameter describes the type that should be used as object representation for any 'this'
-/// object coming from Java. By default it is simply 'Object'.
+/// The second optional template parameter describes the type that should be used as object representation for any
+/// 'this' object coming from Java. By default it is simply 'Object'.
 ///
 /// The model subclass may then simply implement member functions with the EXACT same name as the 'native' method in
 /// Java. Function parameters from Java can easily be translated to C++ types: For integer types simply use signed
@@ -82,7 +82,7 @@ struct ModelState
 ///    being modelled
 /// *  'auto methods = std::make_tuple(&ModelClass::aNativeMethod, ...)' which is a tuple that should list ALL
 ///    implementations of 'native' methods that should be registered in the VM.
-template <std::derived_from<ModelState> StateType = ModelState, std::derived_from<ObjectInterface> JavaObject = Object>
+template <std::derived_from<ModelState> StateType = ModelState, JavaObject JavaObject = Object>
 class ModelBase
 {
 protected:
@@ -174,7 +174,8 @@ auto createMethodBridge(typename Model::State& state,
 
 // Static 'State&, VirtualMachine&, Args...' method.
 template <class Model, class Ret, class... Args, auto ptr>
-auto createMethodBridge(typename Model::State& state,
+auto createMethodBridge(
+    typename Model::State& state,
     std::integral_constant<Ret (*)(typename Model::State&, VirtualMachine&, GCRootRef<ClassObject>, Args...), ptr>)
 {
     return [&state](JNIEnv* env, GCRootRef<ClassObject> classObject, Args... args)
@@ -304,7 +305,8 @@ void addModel(VirtualMachine& virtualMachine)
             {
                 constexpr auto fn = std::get<idxs>(methods);
                 constexpr std::string_view methodName = detail::functionName<fn>();
-                virtualMachine.getJNIBridge().addJNISymbol(formJNIMethodName(Model::className, methodName),
+                virtualMachine.getJNIBridge().addJNISymbol(
+                    formJNIMethodName(Model::className, methodName),
                     detail::createMethodBridge<Model>(state,
                                                       std::integral_constant<std::remove_const_t<decltype(fn)>, fn>{}));
             }(),

--- a/src/jllvm/vm/VirtualMachine.cpp
+++ b/src/jllvm/vm/VirtualMachine.cpp
@@ -104,12 +104,12 @@ jllvm::VirtualMachine::VirtualMachine(BootOptions&& bootOptions)
 
     ClassObject& threadGroup = m_classLoader.forName("Ljava/lang/ThreadGroup;");
     initialize(threadGroup);
-    m_mainThreadGroup = m_gc.allocate(&threadGroup);
+    m_mainThreadGroup.assign(m_gc.allocate(&threadGroup));
     executeObjectConstructor(m_mainThreadGroup, "()V");
 
     ClassObject& thread = m_classLoader.forName("Ljava/lang/Thread;");
     initialize(thread);
-    m_mainThread = m_gc.allocate(&thread);
+    m_mainThread.assign(m_gc.allocate(&thread));
 
     // These have to be set prior to the constructor for the constructor not to fail.
     thread.getInstanceField<std::int32_t>("priority", "I")(m_mainThread) = 1;

--- a/src/jllvm/vm/VirtualMachine.cpp
+++ b/src/jllvm/vm/VirtualMachine.cpp
@@ -27,9 +27,8 @@
 
 jllvm::VirtualMachine::VirtualMachine(BootOptions&& bootOptions)
     : m_classLoader(
-        m_stringInterner, std::move(bootOptions.classPath),
-        [this, bootOptions](ClassObject& classObject) { m_runtime.add(&classObject, getDefaultExecutor()); },
-        [&] { return reinterpret_cast<void**>(m_gc.allocateStatic().data()); }),
+          m_stringInterner, std::move(bootOptions.classPath), [this, bootOptions](ClassObject& classObject)
+          { m_runtime.add(&classObject, getDefaultExecutor()); }, [&] { return m_gc.allocateStatic(); }),
       m_runtime(*this, {&m_jit, &m_interpreter, &m_jni}),
       m_jit(*this),
       m_interpreter(*this, /*enableOSR=*/bootOptions.executionMode != ExecutionMode::Interpreter),

--- a/src/jllvm/vm/VirtualMachine.hpp
+++ b/src/jllvm/vm/VirtualMachine.hpp
@@ -183,7 +183,7 @@ public:
 
     /// Calls the constructor of 'object' with the types described by 'methodDescriptor' using 'args'.
     template <JavaConvertible... Args>
-    void executeObjectConstructor(ObjectInterface* object, MethodType methodDescriptor, Args... args)
+    void executeObjectConstructor(GCRootRefOrPointer<ObjectInterface> object, MethodType methodDescriptor, Args... args)
     {
         void* addr = m_runtime.lookupJITCC(object->getClass()->getClassName(), "<init>", methodDescriptor);
         assert(addr);
@@ -214,9 +214,9 @@ public:
     template <JavaConvertible... Args>
     [[noreturn]] void throwException(FieldType exceptionType, MethodType constructor, Args... args)
     {
-        GCUniqueRoot exception = m_gc.root(m_gc.allocate<Throwable>(&m_classLoader.forName(exceptionType)));
-        executeObjectConstructor(exception, constructor, args...);
-        throwJavaException(exception);
+        GCUniqueRoot exception = m_gc.rootAndAllocate<Throwable>(&m_classLoader.forName(exceptionType));
+        executeObjectConstructor(exception.address(), constructor, args...);
+        throwJavaException(exception.address());
     }
 
     /// Construct and throws an 'ArrayIndexOutOfBoundsException' with a message created from the index that was accessed

--- a/src/jllvm/vm/native/JDK.hpp
+++ b/src/jllvm/vm/native/JDK.hpp
@@ -149,59 +149,59 @@ public:
 
     bool compareAndSetByte(GCRootRef<Object> object, std::uint64_t offset, std::int8_t expected, std::int8_t desired)
     {
-        return compareAndSet(object, offset, expected, desired);
+        return compareAndSet(object.address(), offset, expected, desired);
     }
 
     bool compareAndSetShort(GCRootRef<Object> object, std::uint64_t offset, std::int16_t expected, std::int16_t desired)
     {
-        return compareAndSet(object, offset, expected, desired);
+        return compareAndSet(object.address(), offset, expected, desired);
     }
 
     bool compareAndSetChar(GCRootRef<Object> object, std::uint64_t offset, std::uint16_t expected,
                            std::uint16_t desired)
     {
-        return compareAndSet(object, offset, expected, desired);
+        return compareAndSet(object.address(), offset, expected, desired);
     }
 
     bool compareAndSetBoolean(GCRootRef<Object> object, std::uint64_t offset, bool expected, bool desired)
     {
-        return compareAndSet(object, offset, expected, desired);
+        return compareAndSet(object.address(), offset, expected, desired);
     }
 
     bool compareAndSetInt(GCRootRef<Object> object, std::uint64_t offset, std::int32_t expected, std::int32_t desired)
     {
-        return compareAndSet(object, offset, expected, desired);
+        return compareAndSet(object.address(), offset, expected, desired);
     }
 
     bool compareAndSetLong(GCRootRef<Object> object, std::uint64_t offset, std::int64_t expected, std::int64_t desired)
     {
-        return compareAndSet(object, offset, expected, desired);
+        return compareAndSet(object.address(), offset, expected, desired);
     }
 
     bool compareAndSetReference(GCRootRef<Object> object, std::uint64_t offset, GCRootRef<Object> expected,
                                 GCRootRef<Object> desired)
     {
-        return compareAndSet(object, offset, expected.address(), desired.address());
+        return compareAndSet(object.address(), offset, expected.address(), desired.address());
     }
 
     Object* getReferenceVolatile(GCRootRef<Object> object, std::uint64_t offset)
     {
-        return getVolatile<Object*>(object, offset);
+        return getVolatile<Object*>(object.address(), offset);
     }
 
     std::int32_t getIntVolatile(GCRootRef<Object> object, std::uint64_t offset)
     {
-        return getVolatile<std::int32_t>(object, offset);
+        return getVolatile<std::int32_t>(object.address(), offset);
     }
 
     void putReferenceVolatile(GCRootRef<Object> object, std::uint64_t offset, GCRootRef<Object> value)
     {
-        putVolatile(object, offset, value.address());
+        putVolatile(object.address(), offset, value.address());
     }
 
     void putIntVolatile(GCRootRef<Object> object, std::uint64_t offset, std::int32_t value)
     {
-        putVolatile(object, offset, value);
+        putVolatile(object.address(), offset, value);
     }
 
     constexpr static llvm::StringLiteral className = "jdk/internal/misc/Unsafe";

--- a/src/jllvm/vm/native/Lang.hpp
+++ b/src/jllvm/vm/native/Lang.hpp
@@ -85,7 +85,7 @@ public:
         {
             return false;
         }
-        return object->instanceOf(javaThis);
+        return object->instanceOf(javaThis.address());
     }
 
     bool isAssignableFrom(const ClassObject* cls)
@@ -94,7 +94,7 @@ public:
         {
             virtualMachine.throwNullPointerException();
         }
-        return cls->wouldBeInstanceOf(javaThis);
+        return cls->wouldBeInstanceOf(javaThis.address());
     }
 
     bool isInterface()

--- a/tools/jllvm-jvmc/main.cpp
+++ b/tools/jllvm-jvmc/main.cpp
@@ -126,7 +126,7 @@ int main(int argc, char** argv)
 
     jllvm::ClassLoader loader(
         stringInterner, std::move(classPath), [](jllvm::ClassObject&) {},
-        [&]() -> void** { return new (allocator.Allocate<void*>()) void* {}; });
+        [&]() { return jllvm::GCRootRef<jllvm::ObjectInterface>(allocator.Allocate<jllvm::ObjectInterface*>()); });
 
     loader.loadBootstrapClasses();
 

--- a/unittests/GarbageCollectorTests.cpp
+++ b/unittests/GarbageCollectorTests.cpp
@@ -101,7 +101,7 @@ SCENARIO_METHOD(GarbageCollectorFixture, "GCUniqueRoot Behaviour", "[GCUniqueRoo
 
         AND_WHEN("reassigned")
         {
-            root = nullptr;
+            root.assign(nullptr);
             THEN("refers to the new reference")
             {
                 CHECK(root == nullptr);
@@ -129,6 +129,56 @@ SCENARIO_METHOD(GarbageCollectorFixture, "GCUniqueRoot Behaviour", "[GCUniqueRoo
             {
                 gc.garbageCollect();
                 CHECK(ref->getClass() == &emptyTestObject);
+            }
+            THEN("it no longer has a root")
+            {
+                CHECK(root.data() == nullptr);
+            }
+        }
+
+        AND_WHEN("assigned null")
+        {
+            root = nullptr;
+            THEN("it no longer has a root")
+            {
+                CHECK(root.data() == nullptr);
+            }
+        }
+
+        AND_WHEN("moved from through assignment")
+        {
+            GCUniqueRoot other = gc.root(object);
+            other = std::move(root);
+            THEN("it no longer has a root")
+            {
+                // NOLINTNEXTLINE(*-use-after-move)
+                CHECK_FALSE(root.hasRoot());
+            }
+            AND_WHEN("reassigned")
+            {
+                root = std::move(other);
+                THEN("the root refers to the object again")
+                {
+                    CHECK(root == object);
+                }
+            }
+        }
+
+        AND_WHEN("moved through construction")
+        {
+            GCUniqueRoot other = std::move(root);
+            THEN("it no longer has a root")
+            {
+                // NOLINTNEXTLINE(*-use-after-move)
+                CHECK_FALSE(root.hasRoot());
+            }
+            AND_WHEN("reassigned")
+            {
+                root = std::move(other);
+                THEN("the root refers to the object again")
+                {
+                    CHECK(root == object);
+                }
             }
         }
     }

--- a/unittests/RootFreeListTests.cpp
+++ b/unittests/RootFreeListTests.cpp
@@ -38,13 +38,13 @@ TEST_CASE("Free, optimised pattern", "[RootFreeList]")
 
     // Allocate some more roots to require more than one slab.
     GCRootRef first = list.allocate();
-    first = reinterpret_cast<ObjectInterface*>(1);
+    first.assign(reinterpret_cast<ObjectInterface*>(1));
     GCRootRef second = list.allocate();
-    second = reinterpret_cast<ObjectInterface*>(2);
+    second.assign(reinterpret_cast<ObjectInterface*>(2));
     GCRootRef third = list.allocate();
-    third = reinterpret_cast<ObjectInterface*>(3);
+    third.assign(reinterpret_cast<ObjectInterface*>(3));
     GCRootRef fourth = list.allocate();
-    fourth = reinterpret_cast<ObjectInterface*>(4);
+    fourth.assign(reinterpret_cast<ObjectInterface*>(4));
 
     list.free(fourth);
     list.free(third);
@@ -64,13 +64,13 @@ TEST_CASE("Free, not optimal pattern", "[RootFreeList]")
 
     // Allocate some more roots to require more than one slab.
     GCRootRef first = list.allocate();
-    first = reinterpret_cast<ObjectInterface*>(1);
+    first.assign(reinterpret_cast<ObjectInterface*>(1));
     GCRootRef second = list.allocate();
-    second = reinterpret_cast<ObjectInterface*>(2);
+    second.assign(reinterpret_cast<ObjectInterface*>(2));
     GCRootRef third = list.allocate();
-    third = reinterpret_cast<ObjectInterface*>(3);
+    third.assign(reinterpret_cast<ObjectInterface*>(3));
     GCRootRef fourth = list.allocate();
-    fourth = reinterpret_cast<ObjectInterface*>(4);
+    fourth.assign(reinterpret_cast<ObjectInterface*>(4));
 
     list.free(third);
     list.free(second);
@@ -91,7 +91,7 @@ TEST_CASE("Free, not optimal pattern", "[RootFreeList]")
     list.allocate();
     list.allocate();
     GCRootRef last = list.allocate();
-    last = reinterpret_cast<ObjectInterface*>(8);
+    last.assign(reinterpret_cast<ObjectInterface*>(8));
 
     CHECK(std::distance(list.begin(), list.end()) == 7);
 }


### PR DESCRIPTION
Key motivations for this PR are a few deficiencies when using 'GCRootRef':
* It is not default-constructible or constructible from a nullptr. This is sadly required to make `GCRootRef` equal to `jobject` in the JNI.
* Using `GCRootRef<Array>` is hard to use as it's cumbersome to access the array elements.
* `GCRootRef` is implicitly convertible to `T*` which has some nasty effects during operator overloading. More concretely, it makes e.g. `operator[]` impossible to implement due to ambiguity.

This PR addresses all three of these issues.

For the first, `GCRootRef`s have a new state where it does not have a root. This is similar to the state of a moved from `GCUniqueRoot` previously. From a user-perspective a rootless `GCRootRef` is equivalent to a root containing a nullptr with the only exception of object reassignment. Assigning a `T*` to a `GCRootRef` is only possible if it contains a root. The `operator=` that previously did object reassignment has therefore been changed to an explicit method to make this clearer.

For array types a new `GCRootRefTrait` was introduced which injects extra `begin`, `end` and `operator[]` methods when `T` is an array. Through the use of a proxy they can be safely used regardless of any GCs inbetween.

Regarding implicit pointer conversions: The implicit pointer conversion was originally introduced as a matter of ergonomics and reuse. It was simply cumbersome to have to decide whether a method should take a `T*` or `GCRootRef` and it was decided that the former is a more canonical former that the latter converts to. Given various nasty issues with pointer types in C++, I believe this to nowadays be more problematic than useful. To nevertheless address the parameter type issue, adaptor classes were introduced which can be implicitly constructed from both pointers and `GCRootRef`s. APIs commonly used with kinds can use these as parameters to make both kinds of calls work. In a sense these adaptors can be thought of as a "opt-in implicit pointer conversion" for `GCRootRef` as opposed to the "always implicit pointer conversion" from before.

As part of this refactoring `GCRootRef` has also been moved to the "object"s library. Layering wise one could argue this being problematic as "object should not be aware of garbage collection being a thing", but I don't think there is currently a better alternative.

I hope that both the layering the new adaptor classes are hopefully-only-temporary solution until we have a better object design (I am currently thinking about a nice wrapper class for `ObjectInterface*` that would get rid of all our type-based aliasing, pointer vs reference + nullability inconsistencies around objects).