### PR TITLE
[interpreter] Implement OSR in hot loops

### DIFF
--- a/src/jllvm/main/Main.cpp
+++ b/src/jllvm/main/Main.cpp
@@ -110,6 +110,14 @@ int jllvm::main(llvm::StringRef executablePath, llvm::ArrayRef<char*> args)
         .debugLogging = argList.getLastArgValue(OPT_Xdebug_EQ).str(),
     };
 
+    if (llvm::opt::Arg* arg = argList.getLastArg(OPT_Xback_edge_threshold_EQ))
+    {
+        if (llvm::StringRef(arg->getValue()).getAsInteger(10, bootOptions.backEdgeThreshold))
+        {
+            llvm::report_fatal_error("Invalid command line argument '" + arg->getSpelling() + "'");
+        }
+    }
+
     auto vm = jllvm::VirtualMachine::create(std::move(bootOptions));
     if (argList.hasArg(OPT_Xenable_test_utils))
     {

--- a/src/jllvm/main/Opts.td
+++ b/src/jllvm/main/Opts.td
@@ -31,3 +31,6 @@ def Xsystem_init : F<"Xsystem-init", "Do System initialization (initPhase1 to 3)
 def Xenable_test_utils : F<"Xenable-test-utils", "Enables native test functions">, Group<grp_internal>;
 def Xint : F<"Xint", "Execute code only with Interpreter">, Group<grp_internal>;
 def Xjit : F<"Xjit", "Execute code only with JIT">, Group<grp_internal>;
+def Xback_edge_threshold_EQ : Joined<["-"], "Xback-edge-threshold=">,
+    HelpText<"Configure threshold for performing OSR on a backedge. Specify 0 to disable entirely.">,
+    Group<grp_internal>, MetaVarName<"<count>">;

--- a/src/jllvm/vm/Interpreter.cpp
+++ b/src/jllvm/vm/Interpreter.cpp
@@ -17,9 +17,9 @@
 
 #include "VirtualMachine.hpp"
 
-jllvm::Interpreter::Interpreter(VirtualMachine& virtualMachine, bool enableOSR)
+jllvm::Interpreter::Interpreter(VirtualMachine& virtualMachine, std::uint64_t backEdgeThreshold)
     : m_virtualMachine(virtualMachine),
-      m_enableOSR(enableOSR),
+      m_backEdgeThreshold(backEdgeThreshold),
       m_jit2InterpreterSymbols(
           m_virtualMachine.getRuntime().getJITCCDylib().getExecutionSession().createBareJITDylib("<jit2interpreter>")),
       m_interpreterCCSymbols(m_jit2InterpreterSymbols.getExecutionSession().createBareJITDylib("<interpreterSymbols>")),
@@ -956,6 +956,7 @@ std::uint64_t jllvm::Interpreter::executeMethod(const Method& method, std::uint1
     llvm::ArrayRef<char> codeArray = code->getCode();
     auto curr = ByteCodeIterator(codeArray.data(), offset);
     MethodType methodType = method.getType();
+    std::uint64_t backEdgeCounter = 0;
 
     // Lazily fetches and caches the class object for 'Object'.
     auto getObjectClass = [&, objectClass = static_cast<ClassObject*>(nullptr)]() mutable
@@ -1512,7 +1513,19 @@ std::uint64_t jllvm::Interpreter::executeMethod(const Method& method, std::uint1
 
         match(
             result, [](ReturnValue) {}, [&](NextPC) { ++curr; },
-            [&](SetPC setPc) { curr = ByteCodeIterator(codeArray.data(), setPc.newPC); });
+            [&](SetPC setPc)
+            {
+                // Backedge.
+                if (setPc.newPC < offset)
+                {
+                    backEdgeCounter++;
+                    if (backEdgeCounter == m_backEdgeThreshold)
+                    {
+                        escapeToJIT();
+                    }
+                }
+                curr = ByteCodeIterator(codeArray.data(), setPc.newPC);
+            });
     }
 }
 

--- a/src/jllvm/vm/Interpreter.hpp
+++ b/src/jllvm/vm/Interpreter.hpp
@@ -246,8 +246,8 @@ public:
 class Interpreter : public OSRTarget
 {
     VirtualMachine& m_virtualMachine;
-    /// Enable OSR from the interpreter into the JIT if the method is hot enough.
-    bool m_enableOSR;
+    /// Number of backedges before the Interpreter performs OSR into the JIT.
+    std::uint64_t m_backEdgeThreshold;
 
     /// Single entry for use in 'm_interpreterCCSymbols' as an implementation for ALL methods.
     std::uint64_t (*m_interpreterEntry)(const Method*, const std::uint64_t*){};
@@ -296,7 +296,7 @@ class Interpreter : public OSRTarget
     void* generateOSREntry(FieldType returnType, CallingConvention callingConvention);
 
 public:
-    explicit Interpreter(VirtualMachine& virtualMachine, bool enableOSR);
+    explicit Interpreter(VirtualMachine& virtualMachine, std::uint64_t backEdgeThreshold);
 
     void add(const Method& method) override;
 

--- a/src/jllvm/vm/VirtualMachine.cpp
+++ b/src/jllvm/vm/VirtualMachine.cpp
@@ -32,7 +32,7 @@ jllvm::VirtualMachine::VirtualMachine(BootOptions&& bootOptions)
         [&] { return reinterpret_cast<void**>(m_gc.allocateStatic().data()); }),
       m_runtime(*this, {&m_jit, &m_interpreter, &m_jni}),
       m_jit(*this),
-      m_interpreter(*this, /*enableOSR=*/bootOptions.executionMode != ExecutionMode::Interpreter),
+      m_interpreter(*this, /*backEdgeThreshold=*/bootOptions.backEdgeThreshold),
       m_jni(*this, m_jniEnv.get()),
       m_gc(/*random value for now*/ 1 << 20),
       // Seed from the C++ implementations entropy source.

--- a/src/jllvm/vm/VirtualMachine.cpp
+++ b/src/jllvm/vm/VirtualMachine.cpp
@@ -299,6 +299,12 @@ void jllvm::VirtualMachine::throwNullPointerException()
 
 jllvm::VirtualMachine jllvm::VirtualMachine::create(BootOptions&& options)
 {
+    // Disable OSR into the JIT if the JIT is disabled.
+    if (options.executionMode == ExecutionMode::Interpreter)
+    {
+        options.backEdgeThreshold = 0;
+    }
+
     // Setup the global state in LLVM as is required by our VM.
     llvm::InitializeNativeTarget();
     llvm::InitializeNativeTargetAsmPrinter();

--- a/src/jllvm/vm/VirtualMachine.hpp
+++ b/src/jllvm/vm/VirtualMachine.hpp
@@ -55,6 +55,11 @@ struct BootOptions
     bool systemInitialization = true;
     ExecutionMode executionMode = ExecutionMode::Mixed;
     std::string debugLogging;
+
+    // Runtime tuning parameters.
+
+    /// Number of backedges before the Interpreter performs OSR into the JIT.
+    std::uint64_t backEdgeThreshold = 50000;
 };
 
 struct ModelState;

--- a/tests/Main/backedge-threshold.java
+++ b/tests/Main/backedge-threshold.java
@@ -1,0 +1,5 @@
+// RUN: not --crash jllvm -Xback-edge-threshold=0x1 Test.class 2>&1 | FileCheck %s
+// RUN: not --crash jllvm -Xback-edge-threshold=aba Test.class 2>&1 | FileCheck %s
+// RUN: not --crash jllvm -Xback-edge-threshold=10a Test.class 2>&1 | FileCheck %s
+
+// CHECK: Invalid command line argument '-Xback-edge-threshold=


### PR DESCRIPTION
This PR implements the interpreter performing OSR into the JIT from within hot loops. Recognizing actual loops is not worth the effort so a simplification is made: The interpreter counts how many times a branch with a negative offset (a back edge) is taken and if taken often enough escapes into the JIT. One single back edge counter is used per method invocation. The threshold at which OSR is performed is configurable via a command line parameter.

Note that the current default value is straight up stolen from OpenJDK. I did not yet perform any "best-value" analysis and no such value exists that is perfect for every program