### PR TITLE
[native] Add all and implement most native methods for `Thread`

### DIFF
--- a/tests/System/thread.java
+++ b/tests/System/thread.java
@@ -6,7 +6,7 @@ class Test
     public static native void print(long l);
     public static native void print(boolean b);
 
-    public static void main(String[] args)
+    public static void main(String[] args) throws InterruptedException
     {
         var t = Thread.currentThread();
         // CHECK: 1
@@ -14,5 +14,21 @@ class Test
 
         // CHECK: 1
         print(t.getState() == Thread.State.RUNNABLE);
+
+        Thread.yield();
+
+        Thread.sleep(1000);
+
+        new Thread().start();
+
+        var o = new Test();
+
+        synchronized (o)
+        {
+            // CHECK: 1
+            print(Thread.holdsLock(o));
+        }
+
+
     }
 }


### PR DESCRIPTION
This PR adds all native methods for `Thread` leaving some as TODOs.
The implementation of the rest imitate thread lifecycle of a multi-threaded system on the current single-threaded vm.

Fixes: #296 