### PR TITLE
[compiler] Fix class initialization for `new` in JIT

### DIFF
--- a/src/jllvm/compiler/ByteCodeCompileUtils.hpp
+++ b/src/jllvm/compiler/ByteCodeCompileUtils.hpp
@@ -250,4 +250,8 @@ void applyABIAttributes(llvm::Function* function);
 /// Applies all ABI relevant attributes to the call which must call a function with the signature matching the output of
 /// 'descriptorToType' when called with the given 'methodType' and 'isStatic'.
 void applyABIAttributes(llvm::CallBase* call, MethodType methodType, bool isStatic);
+
+/// Initializes 'classObject' if it is still uninitialized. If 'addDeopt' is true, an empty deopt operand bundle is added.
+/// Returns a pointer to the call instruction of the initializer.
+llvm::CallBase* initializeClassObject(llvm::IRBuilder<>& builder, llvm::Value* classObject, bool addDeopt = true);
 } // namespace jllvm

--- a/src/jllvm/compiler/ClassObjectStubCodeGenerator.cpp
+++ b/src/jllvm/compiler/ClassObjectStubCodeGenerator.cpp
@@ -125,7 +125,7 @@ llvm::Function* jllvm::generateFieldAccessStub(llvm::Module& module, const Class
     // Static field accesses trigger class object initializations.
     if (field->isStatic() && classObject.isUnintialized())
     {
-        llvm::Value* classObjectLLVM = jllvm::classObjectGlobal(module, classObject.getDescriptor());
+        llvm::Value* classObjectLLVM = classObjectGlobal(module, classObject.getDescriptor());
         initializeClassObject(builder, classObjectLLVM);
     }
 
@@ -291,7 +291,7 @@ llvm::Function* jllvm::generateStaticCallStub(llvm::Module& module, const ClassO
 
     if (classObject.isUnintialized())
     {
-        llvm::Value* classObjectLLVM = jllvm::classObjectGlobal(module, classObject.getDescriptor());
+        llvm::Value* classObjectLLVM = classObjectGlobal(module, classObject.getDescriptor());
         initializeClassObject(builder, classObjectLLVM);
     }
 

--- a/src/jllvm/compiler/CodeGenerator.cpp
+++ b/src/jllvm/compiler/CodeGenerator.cpp
@@ -1231,7 +1231,7 @@ bool CodeGenerator::generateInstruction(ByteCodeOp operation)
         {
             llvm::Value* classObject = loadClassObjectFromPool(getOffset(operation), newOp.index);
 
-            llvm::CallBase* initializer = initializeClassObject(m_builder, classObject, /* addDeopt */ false);
+            llvm::CallBase* initializer = initializeClassObject(m_builder, classObject, /*addDeopt=*/false);
             // Initialization could throw Exceptions
             addExceptionHandlingDeopts(getOffset(operation), initializer);
 

--- a/tests/Execution/new-clinit.java
+++ b/tests/Execution/new-clinit.java
@@ -1,6 +1,7 @@
 // RUN: rm -rf %t && split-file %s %t
 // RUN: cd %t && javac %t/Test.java -d %t && javac %t/Other.java -d %t
-// RUN: jllvm %t/Test.class | FileCheck %s
+// RUN: jllvm -Xint %t/Test.class | FileCheck %s
+// RUN: jllvm -Xjit %t/Test.class | FileCheck %s
 
 //--- Test.java
 

--- a/tests/Execution/new-clinit.java
+++ b/tests/Execution/new-clinit.java
@@ -1,0 +1,38 @@
+// RUN: rm -rf %t && split-file %s %t
+// RUN: cd %t && javac %t/Test.java -d %t && javac %t/Other.java -d %t
+// RUN: jllvm %t/Test.class | FileCheck %s
+
+//--- Test.java
+
+class Test
+{
+    public static native void print(String s);
+
+    public static void main(String[] args) throws ClassNotFoundException
+    {
+        // CHECK: Before
+        Test.print("Before");
+
+        // CHECK: Other clinit run
+        new Other();
+
+        // CHECK: After
+        Test.print("After");
+
+        // CHECK-NOT: Other clinit run
+        Other.nothing();
+    }
+}
+
+//--- Other.java
+
+public class Other
+{
+    static {
+        Test.print("Other clinit run");
+    }
+
+    public static void nothing()
+    {
+    }
+}


### PR DESCRIPTION
This PR fixes a bug, where the `new` instruction did not initialize its class object leading to a conformance issue.

Fixes: #297 