### PR TITLE
[native] Implement `isAlive` for some JDK 17 distros

### DIFF
--- a/src/jllvm/vm/native/Lang.hpp
+++ b/src/jllvm/vm/native/Lang.hpp
@@ -375,12 +375,18 @@ public:
         llvm::report_fatal_error("Not yet implemented.");
     }
 
+    bool isAlive()
+    {
+        return state.eetopField(javaThis) != 0;
+    }
+
     constexpr static llvm::StringLiteral className = "java/lang/Thread";
-    constexpr static auto methods = std::make_tuple(
-        &ThreadModel::registerNatives, &ThreadModel::currentThread, &ThreadModel::yield, &ThreadModel::sleep,
-        &ThreadModel::start0, &ThreadModel::holdsLock, &ThreadModel::dumpThreads, &ThreadModel::getThreads,
-        &ThreadModel::setPriority0, &ThreadModel::stop0, &ThreadModel::suspend0, &ThreadModel::resume0,
-        &ThreadModel::interrupt0, &ThreadModel::clearInterruptEvent, &ThreadModel::setNativeName);
+    constexpr static auto methods =
+        std::make_tuple(&ThreadModel::registerNatives, &ThreadModel::currentThread, &ThreadModel::yield,
+                        &ThreadModel::sleep, &ThreadModel::start0, &ThreadModel::holdsLock, &ThreadModel::dumpThreads,
+                        &ThreadModel::getThreads, &ThreadModel::setPriority0, &ThreadModel::stop0,
+                        &ThreadModel::suspend0, &ThreadModel::resume0, &ThreadModel::interrupt0,
+                        &ThreadModel::clearInterruptEvent, &ThreadModel::setNativeName, &ThreadModel::isAlive);
 };
 
 class ReferenceModel : public ModelBase<ModelState, Reference>

--- a/tests/System/thread.java
+++ b/tests/System/thread.java
@@ -15,11 +15,21 @@ class Test
         // CHECK: 1
         print(t.getState() == Thread.State.RUNNABLE);
 
+        // CHECK: 1
+        print(t.isAlive());
+
         Thread.yield();
 
         Thread.sleep(1000);
 
-        new Thread().start();
+        t = new Thread();
+
+        // CHECK: 0
+        print(t.isAlive());
+        t.start();
+
+        // CHECK: 1
+        print(t.isAlive());
 
         var o = new Test();
 


### PR DESCRIPTION
The reference OpenJDK source has `isAlive` as a native method that has to be implemented in native code: https://github.com/openjdk/jdk/blob/dfacda488bfbe2e11e8d607a6d08527710286982/src/java.base/share/classes/java/lang/Thread.java#L1053

Some distributions of the OpenJDK (e.g. Oracle, Amazon corretto) seem to ship their JDK 17s with the preview for virtual threads (https://github.com/openjdk/jdk/commit/9583e3657e43cc1c6f2101a64534564db2a9bd84) which changed the implementation to be completely in Java.

This PR implements `isAlive` to also support OpenJDKs that do not ship the preview (e.g. the builds one gets on Ubuntu or Fedora from their package managers). In the case that `isAlive` is not a `native` method, the implementation is simply ignored making this PR a noop on such distributions.