### PR TITLE
[interpreter] Implement subroutine operations

### DIFF
--- a/src/jllvm/compiler/CodeGenerator.cpp
+++ b/src/jllvm/compiler/CodeGenerator.cpp
@@ -321,7 +321,12 @@ bool CodeGenerator::generateInstruction(ByteCodeOp operation)
     };
 
     match(
-        operation, [](...) { llvm_unreachable("NOT YET IMPLEMENTED"); },
+        operation,
+        [](...)
+        {
+            // TODO: Remove this once the jit implements all opcodes.
+            llvm_unreachable("NOT YET IMPLEMENTED");
+        },
         [&](OneOf<AALoad, BALoad, CALoad, DALoad, FALoad, IALoad, LALoad, SALoad>)
         {
             auto* type = match(

--- a/src/jllvm/vm/Interpreter.cpp
+++ b/src/jllvm/vm/Interpreter.cpp
@@ -695,6 +695,11 @@ std::uint64_t jllvm::Interpreter::executeMethod(const Method& method, std::uint1
         ByteCodeOp operation = *curr;
         InstructionResult result = match(
             operation, MultiTypeImpls{m_virtualMachine, context},
+            [&](AConstNull)
+            {
+                context.push<ObjectInterface*>(nullptr);
+                return NextPC{};
+            },
             [&](ANewArray aNewArray)
             {
                 auto count = context.pop<std::int32_t>();
@@ -709,6 +714,16 @@ std::uint64_t jllvm::Interpreter::executeMethod(const Method& method, std::uint1
                 context.push(array);
                 return NextPC{};
             },
+            [&](ArrayLength)
+            {
+                auto* array = context.pop<AbstractArray*>();
+                if (!array)
+                {
+                    m_virtualMachine.throwException("Ljava/lang/NullPointerException;", "()V");
+                }
+                context.push<std::uint32_t>(array->size());
+                return NextPC{};
+            },
             [&](AThrow) -> InstructionResult
             {
                 auto* exception = context.pop<ObjectInterface*>();
@@ -719,21 +734,6 @@ std::uint64_t jllvm::Interpreter::executeMethod(const Method& method, std::uint1
                 // Verifier checks that the exception is an instance of 'Throwable' rather than performing it at
                 // runtime.
                 m_virtualMachine.throwJavaException(static_cast<Throwable*>(exception));
-            },
-            [&](ArrayLength)
-            {
-                auto* array = context.pop<AbstractArray*>();
-                if (!array)
-                {
-                    m_virtualMachine.throwNullPointerException();
-                }
-                context.push<std::uint32_t>(array->size());
-                return NextPC{};
-            },
-            [&](AConstNull)
-            {
-                context.push<ObjectInterface*>(nullptr);
-                return NextPC{};
             },
             [&](BIPush biPush)
             {
@@ -870,6 +870,25 @@ std::uint64_t jllvm::Interpreter::executeMethod(const Method& method, std::uint1
                 context.push<std::int32_t>(-1);
                 return NextPC{};
             },
+            [&](IInc iInc)
+            {
+                context.setLocal(iInc.index,
+                                 static_cast<std::int32_t>(iInc.byte) + context.getLocal<std::uint32_t>(iInc.index));
+                return NextPC{};
+            },
+            [&](InstanceOf instanceOf)
+            {
+                auto* object = context.pop<ObjectInterface*>();
+                if (!object)
+                {
+                    context.push<std::int32_t>(0);
+                    return NextPC{};
+                }
+
+                ClassObject* classObject = getClassObject(classFile, instanceOf.index);
+                context.push<std::int32_t>(object->instanceOf(classObject));
+                return NextPC{};
+            },
             [&](OneOf<InvokeStatic, InvokeSpecial, InvokeInterface, InvokeVirtual> invoke)
             {
                 const RefInfo* refInfo = PoolIndex<RefInfo>{invoke.index}.resolve(classFile);
@@ -954,12 +973,6 @@ std::uint64_t jllvm::Interpreter::executeMethod(const Method& method, std::uint1
 
                 return NextPC{};
             },
-            [&](IInc iInc)
-            {
-                context.setLocal(iInc.index,
-                                 static_cast<std::int32_t>(iInc.byte) + context.getLocal<std::uint32_t>(iInc.index));
-                return NextPC{};
-            },
             [&](IReturn)
             {
                 auto value = context.pop<std::uint32_t>();
@@ -978,18 +991,13 @@ std::uint64_t jllvm::Interpreter::executeMethod(const Method& method, std::uint1
                 }
                 return ReturnValue(value);
             },
-            [&](InstanceOf instanceOf)
+            [&](OneOf<JSR, JSRw> jsr)
             {
-                auto* object = context.pop<ObjectInterface*>();
-                if (!object)
-                {
-                    context.push<std::int32_t>(0);
-                    return NextPC{};
-                }
-
-                ClassObject* classObject = getClassObject(classFile, instanceOf.index);
-                context.push<std::int32_t>(object->instanceOf(classObject));
-                return NextPC{};
+                std::uint16_t retAddress =
+                    jsr.offset + sizeof(OpCodes)
+                    + (holds_alternative<JSRw>(*curr) ? sizeof(std::int32_t) : sizeof(std::int16_t));
+                context.push(reinterpret_cast<ObjectInterface*>(static_cast<std::uintptr_t>(retAddress)));
+                return SetPC{static_cast<std::uint16_t>(jsr.offset + jsr.target)};
             },
             [&](OneOf<LDC, LDCW, LDC2W> ldc)
             {
@@ -1135,6 +1143,12 @@ std::uint64_t jllvm::Interpreter::executeMethod(const Method& method, std::uint1
                 std::memcpy(field->getAddressOfStatic(), &value, descriptor.sizeOf());
                 return NextPC{};
             },
+            [&](Ret ret)
+            {
+                std::uint16_t retAddress =
+                    reinterpret_cast<std::uintptr_t>(context.getLocal<ObjectInterface*>(ret.index));
+                return SetPC{retAddress};
+            },
             [&](Return)
             {
                 // "Noop" return value for void methods.
@@ -1163,7 +1177,7 @@ std::uint64_t jllvm::Interpreter::executeMethod(const Method& method, std::uint1
                 return SetPC{
                     static_cast<std::uint16_t>(tableSwitch.offset + tableSwitch.jumpTable[index - tableSwitch.low])};
             },
-            [&](Wide wide)
+            [&](Wide wide) -> InstructionResult
             {
 #define WIDE_LOAD_CASE(op)                                                            \
     case OpCodes::op:                                                                 \
@@ -1192,8 +1206,9 @@ std::uint64_t jllvm::Interpreter::executeMethod(const Method& method, std::uint1
                     WIDE_STORE_CASE(LStore)
                     case OpCodes::Ret:
                     {
-                        // TODO: implement later
-                        escapeToJIT();
+                        std::uint16_t retAddress =
+                            reinterpret_cast<std::uintptr_t>(context.getLocal<ObjectInterface*>(wide.index));
+                        return SetPC{retAddress};
                     }
                     case OpCodes::IInc:
                     {

--- a/src/jllvm/vm/Interpreter.cpp
+++ b/src/jllvm/vm/Interpreter.cpp
@@ -1002,7 +1002,7 @@ std::uint64_t jllvm::Interpreter::executeMethod(const Method& method, std::uint1
                 std::uint16_t retAddress =
                     jsr.offset + sizeof(OpCodes)
                     + (holds_alternative<JSRw>(*curr) ? sizeof(std::int32_t) : sizeof(std::int16_t));
-                context.pushRaw(retAddress, false);
+                context.pushRaw(retAddress, /*isReference=*/false);
                 return SetPC{static_cast<std::uint16_t>(jsr.offset + jsr.target)};
             },
             [&](OneOf<LDC, LDCW, LDC2W> ldc)
@@ -1151,8 +1151,7 @@ std::uint64_t jllvm::Interpreter::executeMethod(const Method& method, std::uint1
             },
             [&](Ret ret)
             {
-                std::uint16_t retAddress =
-                    reinterpret_cast<std::uintptr_t>(context.getLocal<ObjectInterface*>(ret.index));
+                std::uint16_t retAddress = context.getLocalRaw(ret.index).first;
                 return SetPC{retAddress};
             },
             [&](Return)
@@ -1212,8 +1211,7 @@ std::uint64_t jllvm::Interpreter::executeMethod(const Method& method, std::uint1
                     WIDE_STORE_CASE(LStore)
                     case OpCodes::Ret:
                     {
-                        std::uint16_t retAddress =
-                            reinterpret_cast<std::uintptr_t>(context.getLocal<ObjectInterface*>(wide.index));
+                        std::uint16_t retAddress = context.getLocalRaw(wide.index).first;
                         return SetPC{retAddress};
                     }
                     case OpCodes::IInc:

--- a/src/jllvm/vm/Interpreter.cpp
+++ b/src/jllvm/vm/Interpreter.cpp
@@ -586,7 +586,7 @@ struct MultiTypeImpls
     template <IsStore T>
     NextPC operator()(T store) const
     {
-        using type = InstructionElementType<T>::type;
+        using type = typename InstructionElementType<T>::type;
         context.setLocalAsRaw<type>(store.index, context.popAsRaw<type>());
         return {};
     }
@@ -594,7 +594,7 @@ struct MultiTypeImpls
     template <IsStore0 T>
     NextPC operator()(T) const
     {
-        using type = InstructionElementType<T>::type;
+        using type = typename InstructionElementType<T>::type;
         context.setLocalAsRaw<type>(0, context.popAsRaw<type>());
         return {};
     }
@@ -602,7 +602,7 @@ struct MultiTypeImpls
     template <IsStore1 T>
     NextPC operator()(T) const
     {
-        using type = InstructionElementType<T>::type;
+        using type = typename InstructionElementType<T>::type;
         context.setLocalAsRaw<type>(1, context.popAsRaw<type>());
         return {};
     }
@@ -610,7 +610,7 @@ struct MultiTypeImpls
     template <IsStore2 T>
     NextPC operator()(T) const
     {
-        using type = InstructionElementType<T>::type;
+        using type = typename InstructionElementType<T>::type;
         context.setLocalAsRaw<type>(2, context.popAsRaw<type>());
         return {};
     }
@@ -618,7 +618,7 @@ struct MultiTypeImpls
     template <IsStore3 T>
     NextPC operator()(T) const
     {
-        using type = InstructionElementType<T>::type;
+        using type = typename InstructionElementType<T>::type;
         context.setLocalAsRaw<type>(3, context.popAsRaw<type>());
         return {};
     }

--- a/src/jllvm/vm/Interpreter.cpp
+++ b/src/jllvm/vm/Interpreter.cpp
@@ -889,6 +889,7 @@ std::uint64_t jllvm::Interpreter::executeMethod(const Method& method, std::uint1
                 context.push<std::int32_t>(object->instanceOf(classObject));
                 return NextPC{};
             },
+            // TODO: InvokeDynamic
             [&](OneOf<InvokeStatic, InvokeSpecial, InvokeInterface, InvokeVirtual> invoke)
             {
                 const RefInfo* refInfo = PoolIndex<RefInfo>{invoke.index}.resolve(classFile);
@@ -1225,10 +1226,8 @@ std::uint64_t jllvm::Interpreter::executeMethod(const Method& method, std::uint1
             },
             [&](...) -> InstructionResult
             {
-                // While the interpreter is not fully implemented, we escaped to JIT code that implements the
-                // given bytecode instruction.
-                // TODO: Remove this once interpreter implements all bytecodes.
-                escapeToJIT();
+                // TODO: Remove this once the interpreter implements all opcodes.
+                llvm_unreachable("NOT YET IMPLEMENTED");
             });
 
         if (auto* returnValue = get_if<ReturnValue>(&result))

--- a/src/jllvm/vm/Interpreter.cpp
+++ b/src/jllvm/vm/Interpreter.cpp
@@ -534,35 +534,35 @@ struct MultiTypeImpls
     template <IsLoad T>
     NextPC operator()(T load) const
     {
-        context.push(context.getLocal<typename InstructionElementType<T>::type>(load.index));
+        context.pushAsRaw<typename InstructionElementType<T>::type>(context.getLocalRaw(load.index));
         return {};
     }
 
     template <IsLoad0 T>
     NextPC operator()(T) const
     {
-        context.push(context.getLocal<typename InstructionElementType<T>::type>(0));
+        context.pushAsRaw<typename InstructionElementType<T>::type>(context.getLocalRaw(0));
         return {};
     }
 
     template <IsLoad1 T>
     NextPC operator()(T) const
     {
-        context.push(context.getLocal<typename InstructionElementType<T>::type>(1));
+        context.pushAsRaw<typename InstructionElementType<T>::type>(context.getLocalRaw(1));
         return {};
     }
 
     template <IsLoad2 T>
     NextPC operator()(T) const
     {
-        context.push(context.getLocal<typename InstructionElementType<T>::type>(2));
+        context.pushAsRaw<typename InstructionElementType<T>::type>(context.getLocalRaw(2));
         return {};
     }
 
     template <IsLoad3 T>
     NextPC operator()(T) const
     {
-        context.push(context.getLocal<typename InstructionElementType<T>::type>(3));
+        context.pushAsRaw<typename InstructionElementType<T>::type>(context.getLocalRaw(3));
         return {};
     }
 
@@ -586,35 +586,40 @@ struct MultiTypeImpls
     template <IsStore T>
     NextPC operator()(T store) const
     {
-        context.setLocal(store.index, context.pop<typename InstructionElementType<T>::type>());
+        using type = InstructionElementType<T>::type;
+        context.setLocalAsRaw<type>(store.index, context.popAsRaw<type>());
         return {};
     }
 
     template <IsStore0 T>
     NextPC operator()(T) const
     {
-        context.setLocal(0, context.pop<typename InstructionElementType<T>::type>());
+        using type = InstructionElementType<T>::type;
+        context.setLocalAsRaw<type>(0, context.popAsRaw<type>());
         return {};
     }
 
     template <IsStore1 T>
     NextPC operator()(T) const
     {
-        context.setLocal(1, context.pop<typename InstructionElementType<T>::type>());
+        using type = InstructionElementType<T>::type;
+        context.setLocalAsRaw<type>(1, context.popAsRaw<type>());
         return {};
     }
 
     template <IsStore2 T>
     NextPC operator()(T) const
     {
-        context.setLocal(2, context.pop<typename InstructionElementType<T>::type>());
+        using type = InstructionElementType<T>::type;
+        context.setLocalAsRaw<type>(2, context.popAsRaw<type>());
         return {};
     }
 
     template <IsStore3 T>
     NextPC operator()(T) const
     {
-        context.setLocal(3, context.pop<typename InstructionElementType<T>::type>());
+        using type = InstructionElementType<T>::type;
+        context.setLocalAsRaw<type>(3, context.popAsRaw<type>());
         return {};
     }
 
@@ -719,7 +724,7 @@ std::uint64_t jllvm::Interpreter::executeMethod(const Method& method, std::uint1
                 auto* array = context.pop<AbstractArray*>();
                 if (!array)
                 {
-                    m_virtualMachine.throwException("Ljava/lang/NullPointerException;", "()V");
+                    m_virtualMachine.throwNullPointerException();
                 }
                 context.push<std::uint32_t>(array->size());
                 return NextPC{};
@@ -997,7 +1002,7 @@ std::uint64_t jllvm::Interpreter::executeMethod(const Method& method, std::uint1
                 std::uint16_t retAddress =
                     jsr.offset + sizeof(OpCodes)
                     + (holds_alternative<JSRw>(*curr) ? sizeof(std::int32_t) : sizeof(std::int16_t));
-                context.push(reinterpret_cast<ObjectInterface*>(static_cast<std::uintptr_t>(retAddress)));
+                context.pushRaw(retAddress, false);
                 return SetPC{static_cast<std::uint16_t>(jsr.offset + jsr.target)};
             },
             [&](OneOf<LDC, LDCW, LDC2W> ldc)

--- a/src/jllvm/vm/native/Lang.hpp
+++ b/src/jllvm/vm/native/Lang.hpp
@@ -320,6 +320,11 @@ public:
         state.eetopField(javaThis) = 1;
     }
 
+    bool isAlive()
+    {
+        return state.eetopField(javaThis) != 0;
+    }
+
     static bool holdsLock(GCRootRef<ClassObject>, ObjectInterface*)
     {
         // Returns true if and only if the current thread holds the monitor lock on the specified object.
@@ -375,18 +380,13 @@ public:
         llvm::report_fatal_error("Not yet implemented.");
     }
 
-    bool isAlive()
-    {
-        return state.eetopField(javaThis) != 0;
-    }
-
     constexpr static llvm::StringLiteral className = "java/lang/Thread";
     constexpr static auto methods =
         std::make_tuple(&ThreadModel::registerNatives, &ThreadModel::currentThread, &ThreadModel::yield,
-                        &ThreadModel::sleep, &ThreadModel::start0, &ThreadModel::holdsLock, &ThreadModel::dumpThreads,
-                        &ThreadModel::getThreads, &ThreadModel::setPriority0, &ThreadModel::stop0,
-                        &ThreadModel::suspend0, &ThreadModel::resume0, &ThreadModel::interrupt0,
-                        &ThreadModel::clearInterruptEvent, &ThreadModel::setNativeName, &ThreadModel::isAlive);
+                        &ThreadModel::sleep, &ThreadModel::start0, &ThreadModel::isAlive, &ThreadModel::holdsLock,
+                        &ThreadModel::dumpThreads, &ThreadModel::getThreads, &ThreadModel::setPriority0,
+                        &ThreadModel::stop0, &ThreadModel::suspend0, &ThreadModel::resume0, &ThreadModel::interrupt0,
+                        &ThreadModel::clearInterruptEvent, &ThreadModel::setNativeName);
 };
 
 class ReferenceModel : public ModelBase<ModelState, Reference>


### PR DESCRIPTION
This PR implements the last remaining (although mainly unused) subroutine instructions for the interpreter.
It also refactors the the lambdas in the match, in order to be in alphabetical order.