### PR TITLE
[native] Implement more native methods for `Class`

### DIFF
--- a/src/jllvm/class/ClassFile.hpp
+++ b/src/jllvm/class/ClassFile.hpp
@@ -229,6 +229,21 @@ enum class AccessFlag : std::uint16_t
 
 LLVM_ENABLE_BITMASK_ENUMS_IN_NAMESPACE();
 
+/// Attributes are represented by types which are required to have following structure:
+///     * a static constexpr string called 'identifier' which is the name of the attribute
+///     * a static 'parse(ArrayRef<char>)' method which returns a parsed instance of the attribute class.
+template <class T>
+concept Attribute = requires
+{
+    {
+        T::identifier
+    } -> std::convertible_to<llvm::StringRef>;
+
+    {
+        T::parse(std::declval<llvm::ArrayRef<char>>())
+    } -> std::same_as<T>;
+};
+
 /// Convenience class for accessing the attributes of an entity.
 /// This is essentially a map of attribute names to the attributes themselves.
 ///
@@ -237,7 +252,7 @@ LLVM_ENABLE_BITMASK_ENUMS_IN_NAMESPACE();
 class AttributeMap
 {
     using AttributePointer = std::unique_ptr<void, void (*)(void*)>;
-    mutable llvm::DenseMap<llvm::StringRef, std::pair<llvm::ArrayRef<char>, AttributePointer>> m_map;
+    mutable llvm::DenseMap<llvm::StringRef, std::variant<llvm::ArrayRef<char>, AttributePointer>> m_map;
 
 public:
     AttributeMap() = default;
@@ -249,19 +264,12 @@ public:
 
     void insert(llvm::StringRef name, llvm::ArrayRef<char> bytes)
     {
-        m_map.try_emplace(name, bytes, AttributePointer(nullptr, nullptr));
+        m_map.try_emplace(name, bytes);
     }
 
     /// Looks up an attribute in the attribute map and parses it if present.
-    ///
-    /// Attributes are represented by types which are required to have following structure:
-    ///     * a static constexpr string called 'identifier' which is the name of the attribute
-    ///     * a static 'parse(ArrayRef<char>, const ClassFile&)' method which returns a parsed instance of the attribute
-    ///       class.
-    ///
-    /// 'T' of this method must be such a class. If the attribute is not present within the map a null pointer is
-    /// returned.
-    template <class T>
+    /// If the attribute is not present within the map a null pointer is returned.
+    template <Attribute T>
     T* find() const
     {
         auto result = m_map.find(T::identifier);
@@ -270,12 +278,13 @@ public:
             return nullptr;
         }
 
-        if (!result->second.second)
+        if (auto* bytes = std::get_if<llvm::ArrayRef<char>>(&result->second))
         {
-            result->second.second = std::unique_ptr<void, void (*)(void*)>(
-                new T(T::parse(result->second.first)), +[](void* pointer) { delete reinterpret_cast<T*>(pointer); });
+            result->second = std::unique_ptr<void, void (*)(void*)>(
+                new T(T::parse(*bytes)), +[](void* pointer) { delete reinterpret_cast<T*>(pointer); });
         }
-        return reinterpret_cast<T*>(result->second.second.get());
+
+        return reinterpret_cast<T*>(std::get<AttributePointer>(result->second).get());
     }
 };
 
@@ -367,6 +376,20 @@ struct ConstantValue
     static ConstantValue parse(llvm::ArrayRef<char> bytes)
     {
         return {consume<std::uint16_t>(bytes)};
+    }
+};
+
+/// 'EnclosingMethod' attribute attached to class files if it is a local or an anonymous class.
+struct EnclosingMethod
+{
+    PoolIndex<ClassInfo> class_index{};
+    PoolIndex<NameAndTypeInfo> method_index{};
+
+    constexpr static llvm::StringRef identifier = "EnclosingMethod";
+
+    static EnclosingMethod parse(llvm::ArrayRef<char> bytes)
+    {
+        return {consume<std::uint16_t>(bytes), consume<std::uint16_t>(bytes)};
     }
 };
 

--- a/src/jllvm/object/ClassLoader.cpp
+++ b/src/jllvm/object/ClassLoader.cpp
@@ -217,7 +217,7 @@ jllvm::ClassObject* jllvm::ClassLoader::forNameLoaded(FieldType fieldType)
     ClassObject* curr = result->second;
     for (std::size_t i = 1; i <= arrayTypesCount; i++)
     {
-        curr = ClassObject::createArray(m_classAllocator, m_objectClassObject, curr, m_stringSaver);
+        curr = ClassObject::createArray(m_classAllocator, m_objectClassObject, curr, m_stringSaver, m_arrayBases);
         m_mapping.insert({curr->getDescriptor(), curr});
         m_prepareClassObject(*curr);
     }
@@ -237,8 +237,8 @@ jllvm::ClassObject& jllvm::ClassLoader::forName(FieldType fieldType)
         if (auto arrayTypeDesc = get_if<ArrayType>(&fieldType))
         {
             const ClassObject& componentType = forName(arrayTypeDesc->getComponentType());
-            ClassObject* arrayType =
-                ClassObject::createArray(m_classAllocator, m_objectClassObject, &componentType, m_stringSaver);
+            ClassObject* arrayType = ClassObject::createArray(m_classAllocator, m_objectClassObject, &componentType,
+                                                              m_stringSaver, m_arrayBases);
             m_mapping.insert({arrayType->getDescriptor(), arrayType});
             m_prepareClassObject(*arrayType);
             return *arrayType;
@@ -292,6 +292,9 @@ jllvm::ClassObject& jllvm::ClassLoader::loadBootstrapClasses()
 {
     m_metaClassObject = &forName("Ljava/lang/Class;");
     m_objectClassObject = &forName("Ljava/lang/Object;");
+    m_arrayBases[0] = m_objectClassObject;
+    m_arrayBases[1] = &forName("Ljava/lang/Cloneable;");
+    m_arrayBases[2] = &forName("Ljava/io/Serializable;");
 
     // With the meta class object loaded we can update all so far loaded class objects to be of type 'Class'.
     // This includes 'Class' itself.

--- a/src/jllvm/object/ClassLoader.hpp
+++ b/src/jllvm/object/ClassLoader.hpp
@@ -59,6 +59,7 @@ class ClassLoader
 
     ClassObject* m_metaClassObject = nullptr;
     ClassObject* m_objectClassObject = nullptr;
+    std::array<ClassObject*, 3> m_arrayBases{};
 
 public:
     /// Constructs a class loader with 'classPaths', which are all directories that class files will be searched for.

--- a/src/jllvm/object/ClassObject.hpp
+++ b/src/jllvm/object/ClassObject.hpp
@@ -511,8 +511,10 @@ public:
     /// Function to create a new class object for an array type. The class object is allocated within 'allocator'
     /// using 'componentType' as the component type of the array type.
     /// 'stringSaver' is used to save the array type descriptor created and used as class name.
+    /// Bases are the bases of the array (Object and the interfaces implemented by arrays).
     static ClassObject* createArray(llvm::BumpPtrAllocator& allocator, ClassObject* objectClass,
-                                    const ClassObject* componentType, llvm::StringSaver& stringSaver);
+                                    const ClassObject* componentType, llvm::StringSaver& stringSaver,
+                                    llvm::ArrayRef<ClassObject*> arrayBases);
 
     /// Constructor for creating the class objects for primitive types with a size and name.
     ClassObject(std::uint32_t instanceSize, llvm::StringRef name);
@@ -659,7 +661,7 @@ public:
     /// Returns the direct interfaces implemented by this class.
     llvm::ArrayRef<const ClassObject*> getInterfaces() const
     {
-        return m_bases.drop_front(isClass() ? 1 : 0);
+        return m_bases.drop_front(isClass() || isArray() ? 1 : 0);
     }
 
     /// Returns a range containing all direct and indirect interfaces of this class in an unspecified order.
@@ -708,7 +710,7 @@ public:
     }
 
     /// Returns the super class of this class or null if the class does not have a super class.
-    /// This is notably the case for array types, primitives and java/lang/Object.
+    /// This is notably the case for interfaces, primitives and java/lang/Object.
     const ClassObject* getSuperClass() const
     {
         return (m_bases.empty() || !m_bases.front()->isClass()) ? nullptr : m_bases.front();

--- a/src/jllvm/vm/NativeImplementation.hpp
+++ b/src/jllvm/vm/NativeImplementation.hpp
@@ -82,15 +82,9 @@ struct ModelState
 ///    being modelled
 /// *  'auto methods = std::make_tuple(&ModelClass::aNativeMethod, ...)' which is a tuple that should list ALL
 ///    implementations of 'native' methods that should be registered in the VM.
-template <class StateType = ModelState, class JavaObject = Object>
+template <std::derived_from<ModelState> StateType = ModelState, std::derived_from<ObjectInterface> JavaObject = Object>
 class ModelBase
 {
-    static_assert(std::is_base_of_v<ModelState, StateType>, "State must inherit from ModelState");
-
-    static_assert(
-        std::is_base_of_v<ObjectInterface, JavaObject>,
-        "JavaObject must be a valid Java object representation with an object header and inherits from ObjectInterface");
-
 protected:
     using Base = ModelBase<StateType, JavaObject>;
 

--- a/src/jllvm/vm/VirtualMachine.cpp
+++ b/src/jllvm/vm/VirtualMachine.cpp
@@ -154,9 +154,14 @@ int jllvm::VirtualMachine::executeMain(llvm::StringRef path, llvm::ArrayRef<llvm
     catch (const Throwable& activeException)
     {
         // TODO: Use printStackTrace:()V in the future
-        auto* string =
-            executeStaticMethod<String*>("java/lang/Throwable", "toString", "()Ljava/lang/String;", &activeException);
-        llvm::errs() << string->toUTF8() << '\n';
+
+        // Equivalent to Throwable:toString() (does not yet work for all Throwables).
+        llvm::errs() << activeException.getClass()->getDescriptor().pretty();
+        if (activeException.detailMessage)
+        {
+            llvm::errs() << ": " << activeException.detailMessage->toUTF8();
+        }
+        llvm::errs() << '\n';
 
         return -1;
     }

--- a/src/jllvm/vm/native/Lang.hpp
+++ b/src/jllvm/vm/native/Lang.hpp
@@ -138,31 +138,7 @@ public:
     // getModifiers
     // getSigners
     // setSigners
-
-    Array<>* getEnclosingMethod0()
-    {
-        if (auto* enclosing = javaThis->getClassFile()->getAttributes().find<EnclosingMethod>())
-        {
-            const ClassFile& classFile = *javaThis->getClassFile();
-            ClassLoader& classLoader = virtualMachine.getClassLoader();
-            StringInterner& stringInterner = virtualMachine.getStringInterner();
-            auto* arr = virtualMachine.getGC().allocate<Array<>>(&classLoader.forName("[Ljava/lang/Object;"), 3);
-
-            (*arr)[0] = &classLoader.forName(
-                FieldType::fromMangled(enclosing->class_index.resolve(classFile)->nameIndex.resolve(classFile)->text));
-
-            if (auto methodIndex = enclosing->method_index)
-            {
-                const NameAndTypeInfo* nameAndTypeInfo = methodIndex.resolve(classFile);
-                (*arr)[1] = stringInterner.intern(nameAndTypeInfo->nameIndex.resolve(classFile)->text);
-                (*arr)[2] = stringInterner.intern(nameAndTypeInfo->descriptorIndex.resolve(classFile)->text);
-            }
-
-            return arr;
-        }
-        return nullptr;
-    }
-
+    // getEnclosingMethod0
     // getDeclaringClass0
     // getSimpleBinaryName0
     // getProtectionDomain0
@@ -212,8 +188,8 @@ public:
     constexpr static auto methods = std::make_tuple(
         &ClassModel::registerNatives, &ClassModel::forName0, &ClassModel::isInstance, &ClassModel::isAssignableFrom,
         &ClassModel::isInterface, &ClassModel::isArray, &ClassModel::isPrimitive, &ClassModel::initClassName,
-        &ClassModel::getSuperclass, &ClassModel::getInterfaces0, &ClassModel::getEnclosingMethod0,
-        &ClassModel::getPrimitiveClass, &ClassModel::desiredAssertionStatus0);
+        &ClassModel::getSuperclass, &ClassModel::getInterfaces0, &ClassModel::getPrimitiveClass,
+        &ClassModel::desiredAssertionStatus0);
 };
 
 class ClassLoaderModel : public ModelBase<>

--- a/tests/System/class.java
+++ b/tests/System/class.java
@@ -1,0 +1,75 @@
+// RUN: rm -rf %t
+// RUN: javac %s -d %t
+// RUN: jllvm -Xenable-test-utils %t/Test.class
+
+import java.util.*;
+
+class Test
+{
+    interface I {}
+
+    interface J extends I {}
+
+    interface H extends J {}
+
+    class C implements I {}
+
+    class D implements H {}
+
+    public static native void print(boolean b);
+    public static native void print(String s);
+
+    public static void main(String[] args)
+    {
+        // CHECK: 0
+        print(Object.class.isInstance(null));
+        // CHECK: 1
+        print(Object.class.isInstance(new Test()));
+        // CHECK: 1
+        print(Object.class.isInstance(new int[0]));
+        // CHECK: 1
+        print(Object[].class.isInstance(new int[0][0]));
+        // CHECK: 1
+        print(Cloneable.class.isInstance(new int[0]));
+        // CHECK: 0
+        print(int.class.isInstance(new Test()));
+
+        // CHECK: 1
+        print(Object.class.isAssignableFrom(Test.class));
+        // CHECK: 1
+        print(Object.class.isAssignableFrom(int[].class));
+        // CHECK: 1
+        print(Object[].class.isAssignableFrom(int[][].class));
+        // CHECK: 1
+        print(Cloneable.class.isAssignableFrom(int[].class));
+        // CHECK: 0
+        print(long.class.isAssignableFrom(int.class));
+
+        // CHECK: boolean
+        print(boolean.class.getName());
+        // CHECK: [I
+        print(int[].class.getName());
+        // CHECK: java.lang.String
+        print(String.class.getName());
+
+        // CHECK: java.lang.Object
+        print(Test.class.getSuperclass().getName());
+        // CHECK: 1
+        print(Object.class.getSuperclass() == null);
+        // CHECK: 1
+        print(Runnable.class.getSuperclass() == null);
+        // CHECK: 1
+        print(int.class.getSuperclass() == null);
+
+        // CHECK: []
+        print(Arrays.toString(D.class.getInterfaces()));
+        // CHECK: [interface Test$H]
+        print(Arrays.toString(Test.class.getInterfaces()));
+        // CHECK: [interface Test$J]
+        print(Arrays.toString(H.class.getInterfaces()));
+        // CHECK: []
+        print(Arrays.toString(int.class.getInterfaces()));
+        // CHECK: [interface java.lang.Cloneable, interface java.io.Serializable]
+        print(Arrays.toString(char[].class.getInterfaces()));
+    }
+}

--- a/unittests/GarbageCollectorTests.cpp
+++ b/unittests/GarbageCollectorTests.cpp
@@ -38,7 +38,8 @@ public:
         : metaObject(&metaObject, /*fieldAreaSize=*/0, "MetaObject"),
           objectClass(&metaObject, /*fieldAreaSize=*/0, "Object"),
           emptyTestObject(&metaObject, /*fieldAreaSize=*/0, "TestObject"),
-          arrayOfEmptyTestObject(ClassObject::createArray(m_allocator, &objectClass, &emptyTestObject, m_stringSaver))
+          arrayOfEmptyTestObject(
+              ClassObject::createArray(m_allocator, &objectClass, &emptyTestObject, m_stringSaver, {&objectClass}))
     {
     }
 };


### PR DESCRIPTION
This PR implements the native methods `isInstance`, `isAssignableFrom`, `getSuperclass` and `getInterfaces0`.
It also correct a bug in `getName` for primitive types.