### PR TITLE
[JNI] Implement array operations

### DIFF
--- a/src/jllvm/vm/JNIImplementation.cpp
+++ b/src/jllvm/vm/JNIImplementation.cpp
@@ -50,19 +50,93 @@ auto setStaticFieldFunction()
         });
 }
 
+/// Implementation of New*Array for type 'T' corresponding with the given descriptor.
+template <class T, const BaseType& descriptor>
+auto newPrimitiveArrayFunction()
+{
+    return translateJNIInterface(
+        [](VirtualMachine& virtualMachine, std::int32_t length)
+        {
+            ClassObject& classObject = virtualMachine.getClassLoader().forName(ArrayType(descriptor));
+            return virtualMachine.getGC().allocate<Array<T>>(&classObject, length);
+        });
+}
+
+template <class T>
+constexpr auto getPrimitiveArrayElementsLambda = [](VirtualMachine&, GCRootRef<Array<T>> array, jboolean* isCopy)
+{
+    // The GC does not yet have support for object pinning.
+    // Always create a copy to deal with relocations.
+    if (isCopy)
+    {
+        *isCopy = true;
+    }
+    auto* storage = new T[array->size()];
+    llvm::copy(*array, storage);
+    return storage;
+};
+
+/// Implementation of Get*ArrayElements.
+template <class T>
+auto getPrimitiveArrayElementsFunction()
+{
+    return translateJNIInterface(getPrimitiveArrayElementsLambda<T>);
+}
+
+template <class T>
+constexpr auto releasePrimitiveArrayElementsLambda =
+    [](VirtualMachine&, GCRootRef<Array<T>> array, T* elements, jint mode)
+{
+    if (mode != JNI_ABORT)
+    {
+        llvm::copy(llvm::make_range(elements, elements + array->size()), array->begin());
+    }
+    if (mode != JNI_COMMIT)
+    {
+        delete[] elements;
+    }
+};
+
+/// Implementation of Release*ArrayElements.
+template <class T>
+auto releasePrimitiveArrayElementsFunction()
+{
+    return translateJNIInterface(releasePrimitiveArrayElementsLambda<T>);
+}
+
+/// Implementation of Get*ArrayRegion.
+template <class T>
+auto getPrimitiveArrayRegionFunction()
+{
+    return translateJNIInterface([](VirtualMachine&, GCRootRef<Array<T>> array, jsize start, jsize len, T* elements)
+                                 { std::copy_n(array->begin() + start, len, elements); });
+}
+
+/// Implementation of Set*ArrayRegion.
+template <class T>
+auto setPrimitiveArrayRegionFunction()
+{
+    return translateJNIInterface([](VirtualMachine&, GCRootRef<Array<T>> array, jsize start, jsize len,
+                                    const T* elements) { std::copy_n(elements, len, array->begin() + start); });
+}
+
 } // namespace
 
-/// X-Macro used to conveniently implement JNI methods that only differs in part of the name and type.
-#define NAME_AND_TYPES                            \
-    NAME_TYPE(Boolean, jboolean)                  \
-    NAME_TYPE(Object, GCRootRef<ObjectInterface>) \
-    NAME_TYPE(Byte, jbyte)                        \
-    NAME_TYPE(Char, jchar)                        \
-    NAME_TYPE(Short, jshort)                      \
-    NAME_TYPE(Int, jint)                          \
-    NAME_TYPE(Long, jlong)                        \
-    NAME_TYPE(Float, jfloat)                      \
+/// X-Macro used to conveniently implement JNI methods for primitives that only differ in part of the name and type.
+#define NAME_AND_TYPES_PRIMS     \
+    NAME_TYPE(Boolean, jboolean) \
+    NAME_TYPE(Byte, jbyte)       \
+    NAME_TYPE(Char, jchar)       \
+    NAME_TYPE(Short, jshort)     \
+    NAME_TYPE(Int, jint)         \
+    NAME_TYPE(Long, jlong)       \
+    NAME_TYPE(Float, jfloat)     \
     NAME_TYPE(Double, jdouble)
+
+/// X-Macro used to conveniently implement JNI methods that only differs in part of the name and type.
+#define NAME_AND_TYPES   \
+    NAME_AND_TYPES_PRIMS \
+    NAME_TYPE(Object, GCRootRef<ObjectInterface>)
 
 jllvm::VirtualMachine::JNINativeInterfaceUPtr jllvm::VirtualMachine::createJNIEnvironment()
 {
@@ -76,6 +150,8 @@ jllvm::VirtualMachine::JNINativeInterfaceUPtr jllvm::VirtualMachine::createJNIEn
         ClassObject& classObject = virtualMachine.getClassLoader().forName(FieldType::fromMangled(name));
         return llvm::bit_cast<jclass>(virtualMachine.getGC().root(&classObject).release());
     };
+    result->IsSameObject = translateJNIInterface([](VirtualMachine&, GCRootRef<ObjectInterface> lhs,
+                                                    GCRootRef<ObjectInterface> rhs) -> jboolean { return lhs == rhs; });
 
     result->GetStaticFieldID = translateJNIInterface(
         [](VirtualMachine& virtualMachine, GCRootRef<ClassObject> classObject, const char* name,
@@ -93,6 +169,89 @@ jllvm::VirtualMachine::JNINativeInterfaceUPtr jllvm::VirtualMachine::createJNIEn
 #define NAME_TYPE(name, type) result->SetStatic##name##Field = setStaticFieldFunction<type>();
     NAME_AND_TYPES
 #undef NAME_TYPE
+
+    result->GetArrayLength =
+        translateJNIInterface([](VirtualMachine&, GCRootRef<AbstractArray> array) -> jsize { return array->size(); });
+    result->NewObjectArray = translateJNIInterface(
+        [](VirtualMachine& virtualMachine, std::int32_t length, GCRootRef<ClassObject> elementClass,
+           GCRootRef<ObjectInterface> element)
+        {
+            ClassObject& classObject =
+                virtualMachine.getClassLoader().forName(ArrayType(elementClass->getDescriptor()));
+            auto* array = virtualMachine.getGC().allocate<Array<ObjectInterface*>>(&classObject, length);
+            std::fill(array->begin(), array->end(), element);
+            return array;
+        });
+    result->GetObjectArrayElement = translateJNIInterface(
+        [](VirtualMachine&, GCRootRef<Array<ObjectInterface*>> array, std::int32_t index) { return (*array)[index]; });
+    result->SetObjectArrayElement =
+        translateJNIInterface([](VirtualMachine&, GCRootRef<Array<ObjectInterface*>> array, std::int32_t index,
+                                 GCRootRef<ObjectInterface> value) { (*array)[index] = value; });
+
+#define NAME_TYPE(name, type)                                                     \
+    {                                                                             \
+        constexpr static BaseType descriptor = BaseType::name;                    \
+        result->New##name##Array = newPrimitiveArrayFunction<type, descriptor>(); \
+    }
+    NAME_AND_TYPES_PRIMS
+#undef NAME_TYPE
+
+#define NAME_TYPE(name, type) result->Get##name##ArrayElements = getPrimitiveArrayElementsFunction<type>();
+    NAME_AND_TYPES_PRIMS
+#undef NAME_TYPE
+
+#define NAME_TYPE(name, type) result->Release##name##ArrayElements = releasePrimitiveArrayElementsFunction<type>();
+    NAME_AND_TYPES_PRIMS
+#undef NAME_TYPE
+
+#define NAME_TYPE(name, type) result->Get##name##ArrayRegion = getPrimitiveArrayRegionFunction<type>();
+    NAME_AND_TYPES_PRIMS
+#undef NAME_TYPE
+
+#define NAME_TYPE(name, type) result->Set##name##ArrayRegion = setPrimitiveArrayRegionFunction<type>();
+    NAME_AND_TYPES_PRIMS
+#undef NAME_TYPE
+
+    // These are more constrained versions of the '(Get|Release)*ArrayElements' making it more likely for the VM to
+    // return a pointer to the array elements. Performing a copy here by falling back to the normal version is a valid
+    // implementation.
+    result->GetPrimitiveArrayCritical = translateJNIInterface(
+        [](VirtualMachine& virtualMachine, GCRootRef<AbstractArray> array, jboolean* isCopy)
+        {
+            return selectForJVMType(array->getClass()->getComponentType()->getDescriptor(),
+                                    [&](auto primitive) -> void*
+                                    {
+                                        using T = std::remove_cvref_t<decltype(primitive)>;
+                                        if constexpr (std::is_same_v<T, ObjectInterface*>)
+                                        {
+                                            llvm_unreachable("not possible");
+                                        }
+                                        else
+                                        {
+                                            return getPrimitiveArrayElementsLambda<T>(
+                                                virtualMachine, static_cast<GCRootRef<Array<T>>>(array), isCopy);
+                                        }
+                                    });
+        });
+    result->ReleasePrimitiveArrayCritical = translateJNIInterface(
+        [](VirtualMachine& virtualMachine, GCRootRef<AbstractArray> array, void* carray, jint mode)
+        {
+            return selectForJVMType(array->getClass()->getComponentType()->getDescriptor(),
+                                    [&](auto primitive)
+                                    {
+                                        using T = std::remove_cvref_t<decltype(primitive)>;
+                                        if constexpr (std::is_same_v<T, ObjectInterface*>)
+                                        {
+                                            llvm_unreachable("not possible");
+                                        }
+                                        else
+                                        {
+                                            releasePrimitiveArrayElementsLambda<T>(
+                                                virtualMachine, static_cast<GCRootRef<Array<T>>>(array),
+                                                reinterpret_cast<T*>(carray), mode);
+                                        }
+                                    });
+        });
 
     return JNINativeInterfaceUPtr(result, +[](JNINativeInterface_* ptr) { delete ptr; });
 }

--- a/src/jllvm/vm/JNIImplementation.hpp
+++ b/src/jllvm/vm/JNIImplementation.hpp
@@ -99,6 +99,16 @@ struct JNIConvert<T*>
 
 BITCAST(GCRootRef<ClassObject>, jclass);
 BITCAST(GCRootRef<ObjectInterface>, jobject);
+BITCAST(GCRootRef<AbstractArray>, jarray);
+BITCAST(GCRootRef<Array<ObjectInterface*>>, jobjectArray);
+BITCAST(GCRootRef<Array<jboolean>>, jbooleanArray);
+BITCAST(GCRootRef<Array<jbyte>>, jbyteArray);
+BITCAST(GCRootRef<Array<jchar>>, jcharArray);
+BITCAST(GCRootRef<Array<jshort>>, jshortArray);
+BITCAST(GCRootRef<Array<jint>>, jintArray);
+BITCAST(GCRootRef<Array<jlong>>, jlongArray);
+BITCAST(GCRootRef<Array<jfloat>>, jfloatArray);
+BITCAST(GCRootRef<Array<jdouble>>, jdoubleArray);
 BITCAST(Field*, jfieldID);
 
 #undef BITCAST

--- a/unittests/JNITests.cpp
+++ b/unittests/JNITests.cpp
@@ -14,6 +14,7 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
+#include <catch2/matchers/catch_matchers_all.hpp>
 
 #include <llvm/Support/Path.h>
 
@@ -22,9 +23,32 @@
 #include <jni.h>
 
 using namespace jllvm;
+using namespace Catch::Matchers;
 
 namespace
 {
+
+/// Checks that two 'jobject's refer to the same object. JNI defines comparison of two 'jobject's where neither is a
+/// nullptr as undefined. 'jniEnv->IsSameObject' must be used instead in these scenarios.
+struct IsSameObjectMatcher : Catch::Matchers::MatcherGenericBase
+{
+    JNIEnv* jniEnv;
+    jobject rhs;
+
+    IsSameObjectMatcher(JNIEnv* jniEnv, jobject rhs) : jniEnv(jniEnv), rhs(rhs) {}
+
+    bool match(jobject lhs) const
+    {
+        return jniEnv->IsSameObject(lhs, rhs);
+    }
+
+protected:
+    std::string describe() const override
+    {
+        return "refers to the same object as " + Catch::StringMaker<jobject>::convert(rhs);
+    }
+};
+
 class VirtualMachineFixture
 {
 protected:
@@ -44,6 +68,12 @@ public:
               }())),
           jniEnv{virtualMachine.getJNINativeInterface()}
     {
+    }
+
+    /// Returns an instance of 'IsSameObjectMatcher' comparing a 'jobject' with 'rhs'.
+    auto isSameObject(jobject rhs)
+    {
+        return IsSameObjectMatcher(&jniEnv, rhs);
     }
 };
 } // namespace
@@ -74,18 +104,19 @@ struct TemplatedFieldVirtualMachineFixture : public VirtualMachineFixture
 };
 } // namespace
 
+/// X-Macro used to conveniently instantiate a test over multiple JNI primitives.
+#define NAME_AND_DESCS                                                                                               \
+    NAME_DESC(Boolean, 'Z'), NAME_DESC(Byte, 'B'), NAME_DESC(Char, 'C'), NAME_DESC(Short, 'S'), NAME_DESC(Int, 'I'), \
+        NAME_DESC(Long, 'J'), NAME_DESC(Float, 'F'), NAME_DESC(Double, 'D')
+
+#define NAME_DESC(name, desc) (desc, &JNIEnv::GetStatic##name##Field, &JNIEnv::SetStatic##name##Field)
+
 TEMPLATE_TEST_CASE_METHOD_SIG(TemplatedFieldVirtualMachineFixture, "JNI Get-Set static", "[JNI]",
-                              ((char name, auto getter, auto setter), name, getter, setter),
-                              ('Z', &JNIEnv::GetStaticBooleanField, &JNIEnv::SetStaticBooleanField),
-                              ('O', &JNIEnv::GetStaticObjectField, &JNIEnv::SetStaticObjectField),
-                              ('B', &JNIEnv::GetStaticByteField, &JNIEnv::SetStaticByteField),
-                              ('C', &JNIEnv::GetStaticCharField, &JNIEnv::SetStaticCharField),
-                              ('S', &JNIEnv::GetStaticShortField, &JNIEnv::SetStaticShortField),
-                              ('I', &JNIEnv::GetStaticIntField, &JNIEnv::SetStaticIntField),
-                              ('J', &JNIEnv::GetStaticLongField, &JNIEnv::SetStaticLongField),
-                              ('F', &JNIEnv::GetStaticFloatField, &JNIEnv::SetStaticFloatField),
-                              ('D', &JNIEnv::GetStaticDoubleField, &JNIEnv::SetStaticDoubleField))
+                              ((char name, auto getter, auto setter), name, getter, setter), NAME_AND_DESCS,
+                              ('O', &JNIEnv::GetStaticObjectField, &JNIEnv::SetStaticObjectField))
 {
+#undef NAME_DESC
+
     jclass clazz = this->jniEnv.FindClass("TestSimpleJNI");
     std::string signature = {name};
     char fieldName[2] = {name, 0};
@@ -103,4 +134,107 @@ TEMPLATE_TEST_CASE_METHOD_SIG(TemplatedFieldVirtualMachineFixture, "JNI Get-Set 
     (this->jniEnv.*setter)(clazz, field, 0);
 
     CHECK((this->jniEnv.*getter)(clazz, field) == 0);
+}
+
+namespace
+{
+template <auto allocator, auto getter, auto releaser>
+struct TemplatedArrayVirtualMachineFixture : public VirtualMachineFixture
+{
+};
+} // namespace
+
+#define NAME_DESC(name, desc) \
+    (&JNIEnv::New##name##Array, &JNIEnv::Get##name##ArrayElements, &JNIEnv::Release##name##ArrayElements)
+
+TEMPLATE_TEST_CASE_METHOD_SIG(TemplatedArrayVirtualMachineFixture, "JNI New-Get-Release prim arrays", "[JNI]",
+                              ((auto allocator, auto getter, auto releaser), allocator, getter, releaser),
+                              NAME_AND_DESCS)
+{
+#undef NAME_DESC
+    constexpr std::size_t length = 5;
+
+    auto array = (this->jniEnv.*allocator)(length);
+
+    CHECK(this->jniEnv.GetArrayLength(array) == length);
+
+    // isCopy parameter should be callable with a nullptr.
+    auto* elements = (this->jniEnv.*getter)(array, nullptr);
+    // Initially zero init.
+    CHECK_THAT(llvm::make_range(elements, elements + length), NoneTrue());
+
+    // Set to all twos.
+    std::fill_n(elements, length, 2);
+
+    // Only commit the changes.
+    (this->jniEnv.*releaser)(array, elements, JNI_COMMIT);
+
+    // Set to all ones.
+    std::fill_n(elements, length, 1);
+
+    // Free and commit the changes.
+    (this->jniEnv.*releaser)(array, elements, 0);
+
+    // Get the elements again, check that isCopy can be passed without issues.
+    jboolean isCopy;
+    elements = (this->jniEnv.*getter)(array, &isCopy);
+    CHECK_THAT(llvm::make_range(elements, elements + length), AllTrue());
+
+    // Only dealloc elements.
+    (this->jniEnv.*releaser)(array, elements, JNI_ABORT);
+}
+
+#define NAME_DESC(name, desc) \
+    (&JNIEnv::New##name##Array, &JNIEnv::Get##name##ArrayRegion, &JNIEnv::Set##name##ArrayRegion)
+
+TEMPLATE_TEST_CASE_METHOD_SIG(TemplatedArrayVirtualMachineFixture, "JNI Get-Release-Region prim arrays", "[JNI]",
+                              ((auto allocator, auto getter, auto releaser), allocator, getter, releaser),
+                              NAME_AND_DESCS)
+{
+#undef NAME_DESC
+    constexpr std::size_t length = 5;
+    constexpr std::size_t subsetLength = 3;
+
+    auto array = (this->jniEnv.*allocator)(length);
+    // Fetch the element type of the array from the last parameter of the getter which is of type 'T*'.
+    using T = std::remove_pointer_t<typename llvm::function_traits<decltype(getter)>::template arg_t<3>>;
+
+    std::vector<T> subset(subsetLength);
+
+    // Only get some elements.
+    (this->jniEnv.*getter)(array, 1, subset.size(), subset.data());
+
+    // All zero by default.
+    CHECK_THAT(subset, NoneTrue());
+
+    std::fill(subset.begin(), subset.end(), 1);
+
+    // Only fill some elements.
+    (this->jniEnv.*releaser)(array, 1, subset.size(), subset.data());
+
+    subset.resize(length);
+
+    // Fetch all elements to check only that only the desired region was affected.
+    (this->jniEnv.*getter)(array, 0, subset.size(), subset.data());
+
+    CHECK_THAT(subset, Equals(std::vector<T>{0, 1, 1, 1, 0}));
+}
+
+TEST_CASE_METHOD(VirtualMachineFixture, "JNI Object Arrays", "[JNI]")
+{
+    constexpr std::size_t length = 5;
+
+    jclass classObject = jniEnv.FindClass("java/lang/Class");
+    jobjectArray array = jniEnv.NewObjectArray(length, classObject, /*init=*/classObject);
+    CHECK(jniEnv.GetArrayLength(array) == length);
+
+    jclass classObjectArray = jniEnv.FindClass("[Ljava/lang/Class;");
+    for (std::size_t i : llvm::seq<std::size_t>(0, length))
+    {
+        // Initially set to classObject.
+        CHECK_THAT(jniEnv.GetObjectArrayElement(array, i), isSameObject(classObject));
+
+        jniEnv.SetObjectArrayElement(array, i, classObjectArray);
+        CHECK_THAT(jniEnv.GetObjectArrayElement(array, i), isSameObject(classObjectArray));
+    }
 }


### PR DESCRIPTION
This PR implements all operations related to creating and accessing arrays using the JNI. Since there are a lot of methods "generic" over primitive types, X-macros and templated functions were used extensively to remove redundancy.

Due to missing exception handling capabilities, only positive cases have been implemented so far.