### PR TITLE
[JNI] Implement static field access

### DIFF
--- a/src/jllvm/vm/JNIImplementation.cpp
+++ b/src/jllvm/vm/JNIImplementation.cpp
@@ -27,7 +27,7 @@ using namespace jllvm;
 
 /// Implementation of 'GetStatic*Field' that should return type 'T'.
 template <class T>
-consteval auto getStaticFieldFunction()
+auto getStaticFieldFunction()
 {
     return translateJNIInterface(
         [](VirtualMachine&, GCRootRef<ClassObject>, Field* field)
@@ -39,7 +39,7 @@ consteval auto getStaticFieldFunction()
 
 /// Implementation of 'SetStatic*Field' that set a value of type 'T'.
 template <class T>
-consteval auto setStaticFieldFunction()
+auto setStaticFieldFunction()
 {
     return translateJNIInterface(
         [](VirtualMachine&, GCRootRef<ClassObject>, Field* field, T value)

--- a/src/jllvm/vm/JNIImplementation.cpp
+++ b/src/jllvm/vm/JNIImplementation.cpp
@@ -25,8 +25,9 @@ namespace
 
 using namespace jllvm;
 
+/// Implementation of 'GetStatic*Field' that should return type 'T'.
 template <class T>
-auto getStaticFieldFunction()
+consteval auto getStaticFieldFunction()
 {
     return translateJNIInterface(
         [](VirtualMachine&, GCRootRef<ClassObject>, Field* field)
@@ -36,8 +37,9 @@ auto getStaticFieldFunction()
         });
 }
 
+/// Implementation of 'SetStatic*Field' that set a value of type 'T'.
 template <class T>
-auto setStaticFieldFunction()
+consteval auto setStaticFieldFunction()
 {
     return translateJNIInterface(
         [](VirtualMachine&, GCRootRef<ClassObject>, Field* field, T value)

--- a/src/jllvm/vm/JNIImplementation.hpp
+++ b/src/jllvm/vm/JNIImplementation.hpp
@@ -135,7 +135,7 @@ struct JNIConvert<const Field*>
 ///
 /// The return value is converted using 'JNIConvert'. There is no symmetry restriction for the return type.
 template <class Lambda>
-consteval auto translateJNIInterface(Lambda) requires std::is_empty_v<Lambda>&& std::is_default_constructible_v<Lambda>
+auto translateJNIInterface(Lambda) requires std::is_empty_v<Lambda>&& std::is_default_constructible_v<Lambda>
 {
     // Initial 0 to discard the implicit 'VirtualMachine&' parameter of 'Lambda'.
     return +[]<std::size_t... idx>(std::index_sequence<0, idx...>)

--- a/src/jllvm/vm/JNIImplementation.hpp
+++ b/src/jllvm/vm/JNIImplementation.hpp
@@ -135,7 +135,7 @@ struct JNIConvert<const Field*>
 ///
 /// The return value is converted using 'JNIConvert'. There is no symmetry restriction for the return type.
 template <class Lambda>
-auto translateJNIInterface(Lambda) requires std::is_empty_v<Lambda>&& std::is_default_constructible_v<Lambda>
+consteval auto translateJNIInterface(Lambda) requires std::is_empty_v<Lambda>&& std::is_default_constructible_v<Lambda>
 {
     // Initial 0 to discard the implicit 'VirtualMachine&' parameter of 'Lambda'.
     return +[]<std::size_t... idx>(std::index_sequence<0, idx...>)

--- a/src/jllvm/vm/JNIImplementation.hpp
+++ b/src/jllvm/vm/JNIImplementation.hpp
@@ -47,20 +47,9 @@ struct JNIConvert
     }
 };
 
-namespace detail
-{
-template <class T>
-struct DelayInstantiation
-{
-    using type = std::decay_t<decltype(JNIConvert<T>{}(std::declval<VirtualMachine&>(), std::declval<T>()))>;
-};
-
-} // namespace detail
-
 /// The type 'T' converts to.
 template <class T>
-using JNIConverted =
-    typename std::conditional_t<std::is_void_v<T>, std::type_identity<void>, detail::DelayInstantiation<T>>::type;
+using JNIConverted = decltype(JNIConvert<T>{}(std::declval<VirtualMachine&>(), std::declval<T>()));
 
 /// Concept satisfied if the JNI conversion of 'T' is symmetric, i.e. the type 'T' converts to, also converts back to
 /// 'T'.

--- a/src/jllvm/vm/JNIImplementation.hpp
+++ b/src/jllvm/vm/JNIImplementation.hpp
@@ -13,7 +13,17 @@
 
 #pragma once
 
+#include <llvm/ADT/STLExtras.h>
+
+#include <jllvm/gc/RootFreeList.hpp>
+#include <jllvm/object/ClassObject.hpp>
+
+#include <cstdint>
+#include <utility>
+
 #include <jni.h>
+
+#include "VirtualMachine.hpp"
 
 namespace jllvm
 {
@@ -22,4 +32,136 @@ class VirtualMachine;
 
 /// Returns the 'VirtualMachine' instance associated with the 'JNIEnv'.
 VirtualMachine& virtualMachineFromJNIEnv(JNIEnv* env);
+
+/// Struct specialised to perform translation between JNI types and JLLVM types.
+/// 'T' is either the JNI or JLLVM type, with the type it converts to being the type returned by the call operator.
+///
+/// Default behaviour just passes through the values.
+template <class T>
+struct JNIConvert
+{
+    /// Call operator that performs the conversion between JNI types and JLLVM types.
+    T operator()(VirtualMachine&, T value)
+    {
+        return value;
+    }
+};
+
+namespace detail
+{
+template <class T>
+struct DelayInstantiation
+{
+    using type = std::decay_t<decltype(JNIConvert<T>{}(std::declval<VirtualMachine&>(), std::declval<T>()))>;
+};
+
+} // namespace detail
+
+/// The type 'T' converts to.
+template <class T>
+using JNIConverted =
+    typename std::conditional_t<std::is_void_v<T>, std::type_identity<void>, detail::DelayInstantiation<T>>::type;
+
+/// Concept satisfied if the JNI conversion of 'T' is symmetric, i.e. the type 'T' converts to, also converts back to
+/// 'T'.
+template <class T>
+concept JNIConversionSymmetric = std::is_same_v<T, JNIConverted<JNIConverted<T>>>;
+
+/// Base class useful to define JNI conversions that are just a bit cast from 'From' to 'To'.
+template <class From, class To>
+struct JNIBitCastConvert
+{
+    To operator()(VirtualMachine&, From value)
+    {
+        static_assert(sizeof(From) == sizeof(To));
+        static_assert(std::is_trivially_copyable_v<From>);
+
+        To to;
+        std::memcpy(&to, &value, sizeof(value));
+        return to;
+    }
+};
+
+/// Conversion of pointer to Java objects to JNI. Performs rooting before then using the conversion of 'GCRootRef'.
+template <std::derived_from<ObjectInterface> T>
+struct JNIConvert<T*>
+{
+    JNIConverted<GCRootRef<T>> operator()(VirtualMachine& virtualMachine, T* value)
+    {
+        if (!value)
+        {
+            // Null values must be null in JNI as well.
+            return nullptr;
+        }
+        return JNIConvert<GCRootRef<T>>{}(virtualMachine, virtualMachine.getGC().root(value).release());
+    }
+};
+
+#define BITCAST(From, To)                                 \
+    template <>                                           \
+    struct JNIConvert<From> : JNIBitCastConvert<From, To> \
+    {                                                     \
+    };                                                    \
+                                                          \
+    template <>                                           \
+    struct JNIConvert<To> : JNIBitCastConvert<To, From>   \
+    {                                                     \
+    }
+
+BITCAST(GCRootRef<ClassObject>, jclass);
+BITCAST(GCRootRef<ObjectInterface>, jobject);
+BITCAST(Field*, jfieldID);
+
+#undef BITCAST
+
+/// Allow returning 'const Field*' as well.
+template <>
+struct JNIConvert<const Field*>
+{
+    decltype(auto) operator()(VirtualMachine& virtualMachine, const Field* value)
+    {
+        return JNIConvert<Field*>{}(virtualMachine, const_cast<Field*>(value));
+    }
+};
+
+/// Converts a capture-less lambda using JLLVM types in its signature to a function pointer with corresponding JNI
+/// types. The lambda is required to take 'VirtualMachine&' as its first parameter. The function pointer returned is
+/// then of type '<ret-converted>(*)(JNIEnv*, <params-converted>)'
+///
+/// The conversion is performed using specializations of 'JNIConvert'. The parameter types are required to be types
+/// that have a symmetric conversion to JNI types. In other words, the 'JNIConvert' specialization from the lambda
+/// parameter types are used to create the JNI function parameters. The 'JNIConvert' from the JNI function parameter
+/// types is then used to convert the JNI types to the JLLVM types.
+///
+/// The return value is converted using 'JNIConvert'. There is no symmetry restriction for the return type.
+template <class Lambda>
+auto translateJNIInterface(Lambda) requires std::is_empty_v<Lambda>&& std::is_default_constructible_v<Lambda>
+{
+    // Initial 0 to discard the implicit 'VirtualMachine&' parameter of 'Lambda'.
+    return +[]<std::size_t... idx>(std::index_sequence<0, idx...>)
+    {
+        static_assert((JNIConversionSymmetric<typename llvm::function_traits<Lambda>::template arg_t<idx>> && ...)
+                      && "Parameter types must have a symmetric conversion");
+
+        return [](JNIEnv* env, JNIConverted<typename llvm::function_traits<Lambda>::template arg_t<idx>>... args)
+        {
+            VirtualMachine& virtualMachine = virtualMachineFromJNIEnv(env);
+            if constexpr (std::is_void_v<typename llvm::function_traits<Lambda>::result_t>)
+            {
+                Lambda{}(virtualMachine,
+                         JNIConvert<JNIConverted<typename llvm::function_traits<Lambda>::template arg_t<idx>>>{}(
+                             virtualMachine, args)...);
+            }
+            else
+            {
+                return JNIConvert<typename llvm::function_traits<Lambda>::result_t>{}(
+                    virtualMachine,
+                    Lambda{}(virtualMachine,
+                             JNIConvert<JNIConverted<typename llvm::function_traits<Lambda>::template arg_t<idx>>>{}(
+                                 virtualMachine, args)...));
+            }
+        };
+    }(std::make_index_sequence<llvm::function_traits<Lambda>::num_args>());
+}
+
 } // namespace jllvm

--- a/unittests/Inputs/TestSimpleJNI.java
+++ b/unittests/Inputs/TestSimpleJNI.java
@@ -1,5 +1,15 @@
 
 public class TestSimpleJNI
 {
+    public static boolean Z = true;
+    public static String O = "test";
+    public static byte B = 5;
+    public static char C = 'c';
+    public static short S = 7;
+    public static int I = 11;
+    public static long J = 13;
+    public static float F = 3.14f;
+    public static double D = 2.717;
 
+    public int instanceI = 0;
 }


### PR DESCRIPTION
This PR implements the basic happy path of the JNI methods used to access static fields.
These consist of `GetStaticFieldID` to fetch a static field and then the various `GetStatic*Field` and `SetStatic*Field` methods used to read or write to static fields.

The most important part of this PR is the infrastructure setup to conveniently implement these functions. Since we need to perform type conversions from JNI to JLLVM types, metaprogramming facilities were implemented that automatically convert between lambdas using JLLVM types to the corresponding JNI types.

The current implementation does not fully implement these methods in the error case as throwing and catching exceptions is not yet implemented for the JNI.

Reopened this PR after accidently merging it in the wrong branch instead of main. See https://github.com/JLLVM/JLLVM/pull/317 for review